### PR TITLE
Support offline token generation

### DIFF
--- a/controller/login.go
+++ b/controller/login.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/rest"
 
+	"fmt"
+
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
@@ -91,6 +93,9 @@ func (c *LoginController) Login(ctx *app.LoginLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
 
+	if ctx.Scope != nil {
+		authEndpoint = fmt.Sprintf("%s?scope=%s", authEndpoint, *ctx.Scope) // Offline token
+	}
 	oauth := &oauth2.Config{
 		ClientID:     c.Configuration.GetKeycloakClientID(),
 		ClientSecret: c.Configuration.GetKeycloakSecret(),

--- a/controller/login_blackbox_test.go
+++ b/controller/login_blackbox_test.go
@@ -22,6 +22,7 @@ import (
 	almtoken "github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -76,7 +77,20 @@ func (rest *TestLoginREST) TestLoginOK() {
 	resource.Require(t, resource.UnitTest)
 	svc, ctrl := rest.UnSecuredController()
 
-	test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil)
+	test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+}
+
+func (rest *TestLoginREST) TestOfflineAccessOK() {
+	t := rest.T()
+	resource.Require(t, resource.UnitTest)
+	svc, ctrl := rest.UnSecuredController()
+
+	offline := "offline_access"
+	resp := test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, &offline)
+	assert.Contains(t, resp.Header().Get("Location"), "scope=offline_access")
+
+	resp = test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+	assert.NotContains(t, resp.Header().Get("Location"), "scope=offline_access")
 }
 
 type TestLoginService struct{}

--- a/design/login.go
+++ b/design/login.go
@@ -16,7 +16,10 @@ var _ = a.Resource("login", func() {
 		a.Params(func() {
 			a.Param("link", d.Boolean, "If true then link all available Identity Providers to the user account after successful login")
 			a.Param("redirect", d.String, "URL to be redirected to after successful login. If not set then will redirect to the referrer instead.")
-
+			a.Param("scope", d.String, func() {
+				a.Enum("offline_access")
+				a.Description("If scope=offline_access then an offline token will be issued instead of a regular refresh token")
+			})
 		})
 		a.Description("Login user")
 		a.Response(d.Unauthorized, JSONAPIErrors)


### PR DESCRIPTION
If `scope=offline_access` param is added to the authentication request then the offline token will be issued instead of a regular refresh token.

Example: `auth.openshift.io/api/login?scope=offline_access`

Related to https://github.com/fabric8-services/fabric8-auth/issues/69