### PR TITLE
add a make target for fast redeployment of a dev build on mini*

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM fabric8/fabric8-auth:v6a56c54
+
+COPY fabric8-auth-linux /usr/local/auth/bin/auth
+RUN echo chmod +x /usr/local/auth/bin/auth

--- a/Makefile
+++ b/Makefile
@@ -308,3 +308,17 @@ endif
 .PHONY: clean
 ## Runs all clean-* targets.
 clean: $(CLEAN_TARGETS)
+
+
+bin/docker: Dockerfile.dev
+	mkdir -p bin/docker
+	cp Dockerfile.dev bin/docker/Dockerfile
+
+bin/docker/fabric8-auth-linux: bin/docker $(SOURCES)
+	GO15VENDOREXPERIMENT=1 GOARCH=amd64 GOOS=linux go build -o bin/docker/fabric8-auth-linux
+
+fast-docker: bin/docker/fabric8-auth-linux
+	docker build -t fabric8/fabric8-auth:dev bin/docker
+
+kube-redeploy: fast-docker
+	kubectl delete pod -l service=auth

--- a/README.adoc
+++ b/README.adoc
@@ -364,3 +364,29 @@ Generate a token for future use.
 ----
 
 You should get Token in response, save this token in your favourite editor as you need to use this token for POST API calls
+
+
+== Rapid development on Minikube / Minishift
+
+If you run fabric8 in minikube or minishift then you can get rapid feedback of your code via the following:
+
+on openshift:
+ * oc edit dc auth
+on kubernetes:
+ * kubectl edit deploy auth
+
+* replace the `fabric8/auth:xxxx` image with `fabric8/auth:dev` and save
+
+Now when developing you can:
+
+* use the `kube-redeploy` make target whenever you want to create a new docker image and redeploy
+```
+make kube-redeploy
+```
+if the docker build fails you may need to type this first to point your local shell at the docker daemon inside minishift/minikube:
+```
+eval $(minishift docker-env)
+or
+eval $(minikube docker-env)
+
+```

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -221,14 +221,16 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
-			"resource": resource,
-			"err":      err.Error(),
+			"auth_endpoint": authzEndpoint,
+			"resource":      resource,
+			"err":           err.Error(),
 		}, "unable to create a Keycloak resource")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create a Keycloak resource"))
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
 		log.Error(ctx, map[string]interface{}{
+			"auth_endpoint":   authzEndpoint,
 			"resource":        resource,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),


### PR DESCRIPTION
lets add fast way to rebuild a local docker image and use it inside
    minikube / minishift