### PR TITLE
Added fix to a troubleshooting problem and changed the command to generate tokens

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -371,7 +371,7 @@ NOTE: The CLI needs the API Server which was started on executing `make dev`  to
 
 Generate a token for future use.
 ----
-./bin/auth-cli generate login -H localhost:8089 --pp
+./bin/auth-cli generate token -H localhost:8089 --pp
 ----
 
 You should get Token in response, save this token in your favourite editor as you need to use this token for POST API calls

--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,17 @@ type `make` in a freshly clone repository of this project.
 $ cd $GOPATH/src/github.com/fabric8-services/fabric8-auth
 $ make
 ----
+If you are getting the following error
+----
+[ERROR]	Failed to set references: Unable to update checked out version (Skip to cleanup)
+make: *** [vendor] Error 1
+----
+Try out this
+----
+$ glide cache-clear
+$ make clean deps
+$ make build
+----
 
 ==== Special make targets
 


### PR DESCRIPTION
1.

The command that was shown earlier would end up in an error
```
$ ./bin/auth-cli generate login -H localhost:8089 --help
Generate a set of Tokens for different Auth levels. NOT FOR PRODUCTION. Only available if server is running in dev mode

Usage:
  auth-cli generate [command]

Available Commands:
  token       

Global Flags:
      --dump               Dump HTTP request and response.
      --format string      Format used to create auth header or query from key (default "Bearer %s")
  -H, --host string        API hostname (default "openshift.io")
      --key string         API key used for authentication
  -s, --scheme string      Set the requests scheme
  -t, --timeout duration   Set the request timeout (default 20s)

Use "auth-cli generate [command] --help" for more information about a command.
```
2.
fix for
```
[ERROR]	Failed to set references: Unable to update checked out version (Skip to cleanup)
make: *** [vendor] Error 1
```
