### PR TITLE
Clean up space authorization code

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/goadesign/goa"
-	goalogrus "github.com/goadesign/goa/logging/logrus"
+	"github.com/goadesign/goa/logging/logrus"
 	"github.com/goadesign/goa/middleware"
 	"github.com/goadesign/goa/middleware/gzip"
 	"github.com/goadesign/goa/middleware/security/jwt"
@@ -145,7 +145,7 @@ func main() {
 	}
 	app.UseJWTMiddleware(service, jwt.New(tokenManager.PublicKeys(), nil, app.NewJWTSecurity()))
 	service.Use(login.InjectTokenManager(tokenManager))
-	spaceAuthzService := authz.NewAuthzService(configuration, appDB)
+	spaceAuthzService := authz.NewAuthzService(configuration)
 	service.Use(authz.InjectAuthzService(spaceAuthzService))
 
 	// Mount "login" controller

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -4,23 +4,16 @@ package authz
 import (
 	"context"
 	"net/http"
-	"time"
 
-	"github.com/fabric8-services/fabric8-auth/application"
 	"github.com/fabric8-services/fabric8-auth/auth"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/log"
-	tokencontext "github.com/fabric8-services/fabric8-auth/login/tokencontext"
-	"github.com/fabric8-services/fabric8-auth/space"
-	"github.com/fabric8-services/fabric8-auth/token"
+	"github.com/fabric8-services/fabric8-auth/login/tokencontext"
 	errs "github.com/pkg/errors"
-
-	contx "context"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-	uuid "github.com/satori/go.uuid"
 )
 
 // AuthzService represents a space authorization service
@@ -59,12 +52,11 @@ func (m *KeycloakAuthzServiceManager) EntitlementEndpoint() string {
 // KeycloakAuthzService implements AuthzService interface
 type KeycloakAuthzService struct {
 	config AuthzConfiguration
-	db     application.DB
 }
 
 // NewAuthzService constructs a new KeycloakAuthzService
-func NewAuthzService(config AuthzConfiguration, db application.DB) *KeycloakAuthzService {
-	return &KeycloakAuthzService{config: config, db: db}
+func NewAuthzService(config AuthzConfiguration) *KeycloakAuthzService {
+	return &KeycloakAuthzService{config: config}
 }
 
 // Configuration returns authz service configuration
@@ -78,57 +70,7 @@ func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 	if jwttoken == nil {
 		return false, errors.NewUnauthorizedError("missing token")
 	}
-	tm := tokencontext.ReadTokenManagerFromContext(ctx)
-	if tm == nil {
-		log.Error(ctx, map[string]interface{}{
-			"token": tm,
-		}, "missing token manager")
-		return false, errors.NewInternalError(ctx, errs.New("missing token manager"))
-	}
-	tokenWithClaims, err := tm.(token.Manager).ParseToken(ctx, jwttoken.Raw)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"space_id": spaceID,
-			"err":      err,
-		}, "unable to parse the rpt token")
-		return false, errors.NewInternalError(ctx, errs.Wrap(err, "unable to parse the rpt token"))
-	}
 
-	if tokenWithClaims.Authorization == nil {
-		// No authorization in the token. This is not a RPT token. This is an access token.
-		// We need to obtain an PRT token.
-		log.Warn(ctx, map[string]interface{}{
-			"space_id": spaceID,
-		}, "no authorization found in the token; this is an access token (not a RPT token)")
-		return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
-	}
-
-	// Check if the token was issued before the space resouces changed the last time.
-	// If so, we need to re-fetch the rpt token for that space/resource and check permissions.
-	outdated, err := s.isTokenOutdated(ctx, *tokenWithClaims, entitlementEndpoint, spaceID)
-	if err != nil {
-		return false, err
-	}
-	if outdated {
-		return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
-	}
-
-	permissions := tokenWithClaims.Authorization.Permissions
-	if permissions == nil {
-		// if the RPT doesn't contain the resource info, it could be probably
-		// because the entitlement was never fetched in the first place. Hence we consider
-		// the token to be 'outdated' and hence re-fetch the entitlements from keycloak.
-		return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
-	}
-	for _, permission := range permissions {
-		name := permission.ResourceSetName
-		if name != nil && spaceID == *name {
-			return true, nil
-		}
-	}
-	// if the RPT doesn't contain the resource info, it could be probably
-	// because the entitlement was never fetched in the first place. Hence we consider
-	// the token to be 'outdated' and hence re-fetch the entitlements from keycloak.
 	return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
 }
 
@@ -144,30 +86,10 @@ func (s *KeycloakAuthzService) checkEntitlementForSpace(ctx context.Context, tok
 	return ent != nil, nil
 }
 
-func (s *KeycloakAuthzService) isTokenOutdated(ctx context.Context, token token.TokenClaims, entitlementEndpoint string, spaceID string) (bool, error) {
-	spaceUUID, err := uuid.FromString(spaceID)
-	if err != nil {
-		return false, errors.NewInternalError(ctx, err)
-	}
-	var spaceResource *space.Resource
-	err = application.Transactional(s.db, func(appl application.Application) error {
-		spaceResource, err = appl.SpaceResources().LoadBySpace(ctx, &spaceUUID)
-		return err
-	})
-	if err != nil {
-		return false, err
-	}
-	if token.IssuedAt == 0 {
-		return false, errors.NewInternalError(ctx, errs.New("iat claim is not found in the token"))
-	}
-	tokenIssued := time.Unix(token.IssuedAt, 0)
-	return tokenIssued.Before(spaceResource.UpdatedAt), nil
-}
-
 // InjectAuthzService is a middleware responsible for setting up AuthzService in the context for every request.
 func InjectAuthzService(service AuthzService) goa.Middleware {
 	return func(h goa.Handler) goa.Handler {
-		return func(ctx contx.Context, rw http.ResponseWriter, req *http.Request) error {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 			config := service.Configuration()
 			var endpoint string
 			if config != nil {

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -3,25 +3,21 @@ package authz_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
-	"time"
 
-	"github.com/fabric8-services/fabric8-auth/account"
-	"github.com/fabric8-services/fabric8-auth/application"
-	"github.com/fabric8-services/fabric8-auth/auth"
-	config "github.com/fabric8-services/fabric8-auth/configuration"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/fabric8-services/fabric8-auth/configuration"
+	"github.com/fabric8-services/fabric8-auth/controller"
+	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/resource"
-	"github.com/fabric8-services/fabric8-auth/space"
 	"github.com/fabric8-services/fabric8-auth/space/authz"
-	testsupport "github.com/fabric8-services/fabric8-auth/test"
-	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
-	"github.com/fabric8-services/fabric8-auth/token"
-	"github.com/goadesign/goa"
-
-	uuid "github.com/satori/go.uuid"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testSpaceID = "a2c706fa-7421-452c-8a34-91016e5a4eab"
 )
 
 var (
@@ -29,132 +25,79 @@ var (
 )
 
 func TestAuthz(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+	resource.Require(t, resource.Remote)
 	suite.Run(t, new(TestAuthzSuite))
 }
 
 type TestAuthzSuite struct {
 	suite.Suite
-	authzService  *authz.KeycloakAuthzService
-	configuration *config.ConfigurationData
+	authzService        *authz.KeycloakAuthzService
+	config              *configuration.ConfigurationData
+	entitlementEndpoint string
+	test1Token          string
+	test2Token          string
 }
 
 func (s *TestAuthzSuite) SetupSuite() {
 	var err error
+	s.config, err = configuration.GetConfigurationData()
 	if err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+		panic(fmt.Errorf("failed to setup the configuration: %s", err.Error()))
 	}
-	var resource *space.Resource
-	s.authzService = authz.NewAuthzService(nil, &db{app{resource: resource}})
-	s.configuration, err = config.GetConfigurationData()
+	s.authzService = authz.NewAuthzService(s.config)
+	s.entitlementEndpoint, err = s.config.GetKeycloakEndpointEntitlement(nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to get endpoint from configuration: %s", err.Error()))
+	}
+	tokenEndpoint, err := s.config.GetKeycloakEndpointToken(nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to get endpoint from configuration: %s", err.Error()))
+	}
+
+	token, err := controller.GenerateUserToken(context.Background(), tokenEndpoint, s.config, s.config.GetKeycloakTestUserName(), s.config.GetKeycloakTestUserSecret())
+	if err != nil {
+		panic(fmt.Errorf("failed to generate token: %s", err.Error()))
+	}
+	if token.Token.AccessToken == nil {
+		panic("failed to generate token")
+	}
+
+	s.test1Token = *token.Token.AccessToken
+
+	token, err = controller.GenerateUserToken(context.Background(), tokenEndpoint, s.config, s.config.GetKeycloakTestUser2Name(), s.config.GetKeycloakTestUser2Secret())
+	if err != nil {
+		panic(fmt.Errorf("failed to generate token: %s", err.Error()))
+	}
+	if token.Token.AccessToken == nil {
+		panic("failed to generate token")
+	}
+
+	s.test2Token = *token.Token.AccessToken
 }
 
 func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
 	ctx := context.Background()
-	spaceID := ""
-	_, err := s.authzService.Authorize(ctx, "", spaceID)
+	_, err := s.authzService.Authorize(ctx, s.entitlementEndpoint, testSpaceID)
 	require.NotNil(s.T(), err)
+	require.IsType(s.T(), errors.UnauthorizedError{}, err)
 }
 
 func (s *TestAuthzSuite) TestUserAmongSpaceCollaboratorsOK() {
-	spaceID := uuid.NewV4().String()
-	authzPayload := token.AuthorizationPayload{Permissions: []token.Permissions{{ResourceSetName: &spaceID}}}
-	ok := s.checkPermissions(authzPayload, spaceID)
+	ok := s.checkPermissions(s.test1Token, testSpaceID)
 	require.True(s.T(), ok)
 }
 
 func (s *TestAuthzSuite) TestUserIsNotAmongSpaceCollaboratorsFails() {
-	spaceID1 := uuid.NewV4().String()
-	spaceID2 := uuid.NewV4().String()
-	authzPayload := token.AuthorizationPayload{Permissions: []token.Permissions{{ResourceSetName: &spaceID1}}}
-	ok := s.checkPermissions(authzPayload, spaceID2)
+	ok := s.checkPermissions(s.test2Token, testSpaceID)
 	require.False(s.T(), ok)
 }
 
-func (s *TestAuthzSuite) checkPermissions(authzPayload token.AuthorizationPayload, spaceID string) bool {
-	resource := &space.Resource{}
-	authzService := authz.NewAuthzService(nil, &db{app{resource: resource}})
-	testIdentity := testsupport.TestIdentity
-	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", testtoken.PrivateKey(), testIdentity, authzPayload)
-	resource.UpdatedAt = time.Now()
-
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
-	entitlementEndpoint, err := s.configuration.GetKeycloakEndpointEntitlement(r)
-	require.Nil(s.T(), err)
-	ok, err := authzService.Authorize(svc.Context, entitlementEndpoint, spaceID)
+func (s *TestAuthzSuite) checkPermissions(token string, spaceID string) bool {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Raw = token
+	ctx := goajwt.WithJWT(context.Background(), tk)
+	authzService := authz.NewAuthzService(s.config)
+	ok, err := authzService.Authorize(ctx, s.entitlementEndpoint, spaceID)
 	require.Nil(s.T(), err)
 	return ok
-}
-
-type app struct {
-	resource *space.Resource
-}
-
-type db struct {
-	app
-}
-
-type trx struct {
-	app
-}
-
-type resourceRepo struct {
-	resource *space.Resource
-}
-
-func (t *trx) Commit() error {
-	return nil
-}
-
-func (t *trx) Rollback() error {
-	return nil
-}
-
-func (d *db) BeginTransaction() (application.Transaction, error) {
-	return &trx{}, nil
-}
-
-func (a *app) Identities() account.IdentityRepository {
-	return nil
-}
-
-func (a *app) SpaceResources() space.ResourceRepository {
-	return &resourceRepo{a.resource}
-}
-
-func (a *app) Users() account.UserRepository {
-	return nil
-}
-
-func (a *app) OauthStates() auth.OauthStateReferenceRepository {
-	return nil
-}
-
-func (r *resourceRepo) Create(ctx context.Context, s *space.Resource) (*space.Resource, error) {
-	return nil, nil
-}
-
-func (r *resourceRepo) Save(ctx context.Context, s *space.Resource) (*space.Resource, error) {
-	return nil, nil
-}
-
-func (r *resourceRepo) Load(ctx context.Context, ID uuid.UUID) (*space.Resource, error) {
-	return nil, nil
-}
-
-func (r *resourceRepo) Delete(ctx context.Context, ID uuid.UUID) error {
-	return nil
-}
-
-func (r *resourceRepo) CheckExists(ctx context.Context, ID string) error {
-	return nil
-}
-
-func (r *resourceRepo) LoadBySpace(ctx context.Context, spaceID *uuid.UUID) (*space.Resource, error) {
-	resource := &space.Resource{}
-	past := time.Now().Unix() - 1000
-	resource.UpdatedAt = time.Unix(past, 0)
-	return resource, nil
 }


### PR DESCRIPTION
We do not use RPT tokens to authorize a user in spaces anymore. So, this PR removes code that checkes if the access token is an RPT token otherwise calls Keycloak to check entitlement. We should just call Keycloak to obtain an entitlement.

Part of https://github.com/fabric8-services/fabric8-auth/issues/65