### PR TITLE
Don't fetch profileURL from WIT

### DIFF
--- a/remoteservice/wit.go
+++ b/remoteservice/wit.go
@@ -160,8 +160,7 @@ func (r *RemoteWITServiceCaller) GetWITUser(ctx context.Context, req *goa.Reques
 		}
 
 		identity = &account.Identity{
-			ProfileURL: witServiceUser.Data.Attributes.URL,
-			UserID:     account.NullUUID{UUID: user.ID, Valid: true},
+			UserID: account.NullUUID{UUID: user.ID, Valid: true},
 		}
 
 		if witServiceUser.Data.Attributes.IdentityID != nil {


### PR DESCRIPTION
When creating a new identity in Auth which already exists in WIT we should not set profileURL for such identity in Auth. ProfileURL is returned as an empty string in User's result payload which causes `failed to create user/identity pq: duplicate key value violates unique constraint \"uix_identity_profileurl\"` error in Auth DB. The profileURL should be null. Not an empty string.
We could check if profileURL is an empty sting and insert a null instead but profileURL is not currently used anyway (it's supposed to be used in remote, like GitHub, identities). So, let's just ignore this field in that temporal code. 
