### PR TITLE
For new user, add provider type as well

### DIFF
--- a/login/service.go
+++ b/login/service.go
@@ -789,7 +789,12 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 
 	} else {
 		identity = &identities[0]
-		if user.ID == uuid.Nil {
+
+		// we had done a
+		// keycloak.Identities.Query(account.IdentityFilterByID(keycloakIdentityID), account.IdentityWithUser())
+		// so, identity.user should have been populated.
+
+		if identity.User.ID == uuid.Nil {
 			log.Error(ctx, map[string]interface{}{
 				"identity_id": keycloakIdentityID,
 			}, "Found Keycloak identity is not linked to any User")

--- a/remoteservice/wit.go
+++ b/remoteservice/wit.go
@@ -75,14 +75,15 @@ func (r *RemoteWITServiceCaller) CreateWITUser(ctx context.Context, req *goa.Req
 	createUserPayload := &witservice.CreateUserAsServiceAccountUsersPayload{
 		Data: &witservice.CreateUserData{
 			Attributes: &witservice.CreateIdentityDataAttributes{
-				Bio:      &user.Bio,
-				Company:  &user.Company,
-				Email:    user.Email,
-				FullName: &user.FullName,
-				ImageURL: &user.ImageURL,
-				URL:      &user.URL,
-				Username: identity.Username,
-				UserID:   identity.User.ID.String(),
+				Bio:          &user.Bio,
+				Company:      &user.Company,
+				Email:        user.Email,
+				FullName:     &user.FullName,
+				ImageURL:     &user.ImageURL,
+				URL:          &user.URL,
+				Username:     identity.Username,
+				UserID:       identity.User.ID.String(),
+				ProviderType: identity.ProviderType,
 			},
 			Type: "identities",
 		},


### PR DESCRIPTION
Noticed this when 
`http://localhost:8080/api/users?filter[email]=sbose78@gmail.com` kept failing in WIT because the user was created from AUTH without the ProviderType field.

And our DAO code always does a `where provider_type = 'kc'` while fetching data from the db.