### PR TITLE
Make WIT URL configurable via env var

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,7 +93,7 @@ serviceaccount.privatekeyid: 9MLnViaRkhVj1GT9kpWUkwHIwUD-wZfUxR-3CpkE-Xs
 #notapproved.redirect : https://manage.openshift.com/openshiftio
 
 # ----------------------------
-# Keycloak OAuth2.0 configuration
+# Keycloak configuration
 # ----------------------------
 
 keycloak.client.id : fabric8-online-platform
@@ -105,4 +105,5 @@ keycloak.testuser.secret : testuser
 keycloak.testuser2.name : testuser2
 keycloak.testuser2.secret : testuser2
 
-keycloak.url : https://sso.prod-preview.openshift.io
+#keycloak.url : https://sso.prod-preview.openshift.io
+#wit.url : https://api.prod-preview.openshift.io

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -11,7 +11,7 @@ import (
 
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/resource"
 	"github.com/goadesign/goa"
@@ -203,45 +203,65 @@ func TestGetKeycloakUserInfoEndpointOKrSetByEnvVaribaleOK(t *testing.T) {
 	checkGetKeycloakEndpointSetByEnvVaribaleOK(t, "AUTH_KEYCLOAK_ENDPOINT_ACCOUNT", config.GetKeycloakAccountEndpoint)
 }
 
-func TestGetWITEndpointNotDevModeOK(t *testing.T) {
+func TestGetWITURLNotDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
-	existingWITURL := os.Getenv("AUTH_WIT_DOMAIN_PREFIX")
+	existingWITprefix := os.Getenv("AUTH_WIT_DOMAIN_PREFIX")
 	existingDevMode := os.Getenv("AUTH_DEVELOPER_MODE_ENABLED")
 	defer func() {
 		resetConfiguration(defaultValuesConfigFilePath)
-		os.Setenv("AUTH_WIT_DOMAIN_PREFIX", existingWITURL)
+		os.Setenv("AUTH_WIT_DOMAIN_PREFIX", existingWITprefix)
 		os.Setenv("AUTH_DEVELOPER_MODE_ENABLED", existingDevMode)
 	}()
 
 	os.Setenv("AUTH_DEVELOPER_MODE_ENABLED", "false")
 
 	// Ensure that what we set as env variable is actually what we get
-	computedWITEndpoint, err := config.GetWITEndpoint(reqShort)
+	computedWITURL, err := config.GetWITURL(reqShort)
 	assert.Nil(t, err)
-	assert.Equal(t, "http://api.domain.org", computedWITEndpoint)
+	assert.Equal(t, "http://api.domain.org", computedWITURL)
 
 	os.Setenv("AUTH_WIT_DOMAIN_PREFIX", "myauthsubdomain")
-	computedWITEndpoint, err = config.GetWITEndpoint(reqLong)
+	computedWITURL, err = config.GetWITURL(reqLong)
 	assert.Nil(t, err)
-	assert.Equal(t, "http://myauthsubdomain.service.domain.org", computedWITEndpoint)
+	assert.Equal(t, "http://myauthsubdomain.service.domain.org", computedWITURL)
 }
 
-func TestGetWITEndpointDevModeOK(t *testing.T) {
+func TestGetWITURLDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
-	existingWITURL := os.Getenv("AUTH_WIT_DOMAIN_PREFIX")
+	existingWITprefix := os.Getenv("AUTH_WIT_DOMAIN_PREFIX")
 	existingDevMode := os.Getenv("AUTH_DEVELOPER_MODE_ENABLED")
 	defer func() {
 		resetConfiguration(defaultValuesConfigFilePath)
-		os.Setenv("AUTH_WIT_DOMAIN_PREFIX", existingWITURL)
+		os.Setenv("AUTH_WIT_DOMAIN_PREFIX", existingWITprefix)
 		os.Setenv("AUTH_DEVELOPER_MODE_ENABLED", existingDevMode)
 	}()
 
 	os.Setenv("AUTH_DEVELOPER_MODE_ENABLED", "true")
 
 	// Ensure that what we set as env variable is actually what we get
-	computedWITEndpoint, err := config.GetWITEndpoint(reqShort)
+	computedWITURL, err := config.GetWITURL(reqShort)
 	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost:8080", computedWITEndpoint)
+	assert.Equal(t, "http://localhost:8080", computedWITURL)
+}
+
+func TestGetWITURLSetViaEnvVarOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	existingWITURL := os.Getenv("AUTH_WIT_URL")
+	defer func() {
+		resetConfiguration(defaultValuesConfigFilePath)
+		if existingWITURL != "" {
+			os.Setenv("AUTH_WIT_URL", existingWITURL)
+		} else {
+			os.Unsetenv("AUTH_WIT_URL")
+		}
+	}()
+
+	os.Setenv("AUTH_WIT_URL", "https://new.wit.url")
+
+	// Ensure that what we set as env variable is actually what we get
+	computedWITURL, err := config.GetWITURL(reqShort)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://new.wit.url", computedWITURL)
 }
 
 func checkGetKeycloakEndpointOK(t *testing.T, expectedEndpoint string, getEndpoint func(req *goa.RequestData) (string, error)) {

--- a/controller/login.go
+++ b/controller/login.go
@@ -33,7 +33,7 @@ type LoginConfiguration interface {
 	GetValidRedirectURLs(*goa.RequestData) (string, error)
 	GetHeaderMaxLength() int64
 	GetNotApprovedRedirect() string
-	GetWITEndpoint(*goa.RequestData) (string, error)
+	GetWITURL(*goa.RequestData) (string, error)
 }
 
 // LoginController implements the login resource.

--- a/controller/users.go
+++ b/controller/users.go
@@ -37,7 +37,7 @@ type UsersControllerConfiguration interface {
 	GetCacheControlUsers() string
 	GetCacheControlUser() string
 	GetKeycloakAccountEndpoint(*goa.RequestData) (string, error)
-	GetWITEndpoint(*goa.RequestData) (string, error)
+	GetWITURL(*goa.RequestData) (string, error)
 }
 
 // NewUsersController creates a users controller.
@@ -388,11 +388,11 @@ func (c *UsersController) updateWITUser(ctx *app.UpdateUsersContext, request *go
 			Type: ctx.Payload.Data.Type,
 		},
 	}
-	WITEndpoint, err := c.config.GetWITEndpoint(ctx.RequestData)
+	witURL, err := c.config.GetWITURL(ctx.RequestData)
 	if err != nil {
 		return err
 	}
-	return c.RemoteWITService.UpdateWITUser(ctx, request, updateUserPayload, WITEndpoint, identityID)
+	return c.RemoteWITService.UpdateWITUser(ctx, request, updateUserPayload, witURL, identityID)
 }
 
 func isEmailValid(email string) bool {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -951,15 +951,15 @@ func (s *TestUsersSuite) generateUsersTag(allUsers app.UserArray) string {
 
 type dummyRemoteWITService struct{}
 
-func (r *dummyRemoteWITService) UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUsersPayload, WITEndpoint string, identityID string) error {
+func (r *dummyRemoteWITService) UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUsersPayload, witURL string, identityID string) error {
 	return nil
 }
 
-func (r *dummyRemoteWITService) GetWITUser(ctx context.Context, req *goa.RequestData, WITEndpointUserProfile string, accessToken *string) (*account.User, *account.Identity, error) {
+func (r *dummyRemoteWITService) GetWITUser(ctx context.Context, req *goa.RequestData, witURL string, accessToken *string) (*account.User, *account.Identity, error) {
 	return nil, nil, nil
 }
 
-func (r *dummyRemoteWITService) CreateWITUser(ctx context.Context, req *goa.RequestData, user *account.User, identity *account.Identity, WITEndpoint string, identityID string) error {
+func (r *dummyRemoteWITService) CreateWITUser(ctx context.Context, req *goa.RequestData, user *account.User, identity *account.Identity, witURL string, identityID string) error {
 	return nil
 }
 


### PR DESCRIPTION
WIT URL can now be set via env var. I also renamed WITEndpoint to WIT URL to avoid confusion because it represents the base WIT URL. Not the final endpoint.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/113