### PR TITLE
Use *.openshift.io as valid redirect URL by default

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -3,7 +3,6 @@ package configuration
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -579,30 +578,16 @@ func (c *ConfigurationData) IsLogJSON() bool {
 }
 
 // GetValidRedirectURLs returns the RegEx of valid redirect URLs for auth requests
-// If the AUTH_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
-// In prod mode the default regex will be returned
-func (c *ConfigurationData) GetValidRedirectURLs(req *goa.RequestData) (string, error) {
+// If AUTH_REDIRECT_VALID is not set then in Dev Mode all redirects allowed - *
+// Otherwise only *.openshift.io URLs are considered valid
+func (c *ConfigurationData) GetValidRedirectURLs() string {
 	if c.v.IsSet(varValidRedirectURLs) {
-		return c.v.GetString(varValidRedirectURLs), nil
+		return c.v.GetString(varValidRedirectURLs)
 	}
 	if c.IsPostgresDeveloperModeEnabled() {
-		return devModeValidRedirectURLs, nil
+		return devModeValidRedirectURLs
 	}
-	return c.checkLocalhostRedirectException(req)
-}
-
-func (c *ConfigurationData) checkLocalhostRedirectException(req *goa.RequestData) (string, error) {
-	if req.Request == nil || req.Request.URL == nil {
-		return DefaultValidRedirectURLs, nil
-	}
-	matched, err := regexp.MatchString(localhostRedirectException, req.Request.URL.String())
-	if err != nil {
-		return "", err
-	}
-	if matched {
-		return localhostRedirectURLs, nil
-	}
-	return DefaultValidRedirectURLs, nil
+	return DefaultValidRedirectURLs
 }
 
 const (
@@ -665,12 +650,8 @@ OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
 	// DefaultValidRedirectURLs is a regex to be used to whitelist redirect URL for auth
 	// If the AUTH_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
 	// In prod mode the following regex will be used by default:
-	DefaultValidRedirectURLs = "^(https|http)://([^/]+[.])?(?i:openshift[.]io)(/.*)?$" // *.openshift.io/*
+	DefaultValidRedirectURLs = "^(https|http)://([^/?#]+[.])?(?i:openshift[.]io)((/|:).*)?$" // *.openshift.io/*
 	devModeValidRedirectURLs = ".*"
-	// Allow redirects to localhost when running in prod-preveiw
-	localhostRedirectURLs      = "(" + DefaultValidRedirectURLs + "|^(https|http)://([^/]+[.])?(localhost|127[.]0[.]0[.]1)(:\\d+)?(/.*)?$)" // *.openshift.io/* or localhost/* or 127.0.0.1/*
-	localhostRedirectException = "^(https|http)://([^/]+[.])?(?i:prod-preview[.]openshift[.]io)(:\\d+)?(/.*)?$"                             // *.prod-preview.openshift.io/*
-
 )
 
 // ActualToken is actual OAuth access token of github

--- a/controller/link.go
+++ b/controller/link.go
@@ -34,10 +34,7 @@ func (c *LinkController) Link(ctx *app.LinkLinkContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.Configuration.GetKeycloakClientID()
-	whitelist, err := c.Configuration.GetValidRedirectURLs(ctx.RequestData)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
-	}
+	whitelist := c.Configuration.GetValidRedirectURLs()
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
 	return c.Auth.Link(ctx, brokerEndpoint, clientID, whitelist)
@@ -53,10 +50,7 @@ func (c *LinkController) Session(ctx *app.SessionLinkContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.Configuration.GetKeycloakClientID()
-	whitelist, err := c.Configuration.GetValidRedirectURLs(ctx.RequestData)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
-	}
+	whitelist := c.Configuration.GetValidRedirectURLs()
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
 	return c.Auth.LinkSession(ctx, brokerEndpoint, clientID, whitelist)

--- a/controller/login.go
+++ b/controller/login.go
@@ -30,7 +30,7 @@ type LoginConfiguration interface {
 	GetKeycloakTestUserSecret() string
 	GetKeycloakTestUser2Name() string
 	GetKeycloakTestUser2Secret() string
-	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetValidRedirectURLs() string
 	GetHeaderMaxLength() int64
 	GetNotApprovedRedirect() string
 	GetWITURL(*goa.RequestData) (string, error)

--- a/controller/logout.go
+++ b/controller/logout.go
@@ -12,7 +12,7 @@ import (
 
 type logoutConfiguration interface {
 	GetKeycloakEndpointLogout(*goa.RequestData) (string, error)
-	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetValidRedirectURLs() string
 }
 
 // LogoutController implements the logout resource.
@@ -36,10 +36,7 @@ func (c *LogoutController) Logout(ctx *app.LogoutLogoutContext) error {
 		}, "Unable to get Keycloak logout endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak logout endpoint URL")))
 	}
-	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
-	}
+	whitelist := c.configuration.GetValidRedirectURLs()
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
 	return c.logoutService.Logout(ctx, logoutEndpoint, whitelist)

--- a/login/service.go
+++ b/login/service.go
@@ -39,7 +39,7 @@ import (
 type LoginServiceConfiguration interface {
 	GetKeycloakAccountEndpoint(req *goa.RequestData) (string, error)
 	GetKeycloakEndpointBroker(*goa.RequestData) (string, error)
-	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetValidRedirectURLs() string
 	GetNotApprovedRedirect() string
 	GetWITURL(*goa.RequestData) (string, error)
 }
@@ -105,10 +105,7 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.LoginLoginContext, confi
 		}, "unable to get Keycloak account endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, autherrors.NewInternalError(ctx, err))
 	}
-	validRedirectURL, err := serviceConfig.GetValidRedirectURLs(ctx.RequestData)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, autherrors.NewInternalError(ctx, err))
-	}
+	validRedirectURL := serviceConfig.GetValidRedirectURLs()
 
 	witURL, err := serviceConfig.GetWITURL(ctx.RequestData)
 	if err != nil {

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -126,15 +126,6 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 	assert.NotEqual(s.T(), rw.Header().Get("Location"), "")
 }
 
-func (s *serviceBlackBoxTest) getValidRedirectURLs() string {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.com"},
-	}
-	whitelist, err := s.configuration.GetValidRedirectURLs(r)
-	require.Nil(s.T(), err)
-	return whitelist
-}
-
 func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirectsToRedirectParam() {
 	rw := httptest.NewRecorder()
 	redirect := "https://url.example.org/pathredirect"
@@ -316,7 +307,7 @@ func keycloakLinkRedirect(s *serviceBlackBoxTest, provider string, redirect stri
 	require.Nil(s.T(), err)
 	clientID := s.configuration.GetKeycloakClientID()
 
-	err = s.loginService.Link(linkCtx, brokerEndpoint, clientID, s.getValidRedirectURLs())
+	err = s.loginService.Link(linkCtx, brokerEndpoint, clientID, s.configuration.GetValidRedirectURLs())
 	require.Nil(s.T(), err)
 
 	assert.Equal(s.T(), 307, rw.Code)


### PR DESCRIPTION
Use *.openshift.io as valid redirect URL by default even if the corresponding env var is not set.