### PR TITLE
New "api_client" param for /api/login

### DIFF
--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/fabric8-services/fabric8-auth/token"
 	_ "github.com/lib/pq"
 )
 
@@ -245,12 +246,12 @@ func (s *TestAuthSuite) TestGetProtectedAPITokenOK() {
 func (s *TestAuthSuite) TestReadTokenOK() {
 	b := closer{bytes.NewBufferString("{\"access_token\":\"accToken\", \"expires_in\":3000000, \"refresh_expires_in\":2, \"refresh_token\":\"refToken\"}")}
 	response := http.Response{Body: b}
-	token, err := auth.ReadToken(context.Background(), &response)
+	t, err := token.ReadTokenSet(context.Background(), &response)
 	require.Nil(s.T(), err)
-	assert.Equal(s.T(), "accToken", *token.AccessToken)
-	assert.Equal(s.T(), int64(3000000), *token.ExpiresIn)
-	assert.Equal(s.T(), int64(2), *token.RefreshExpiresIn)
-	assert.Equal(s.T(), "refToken", *token.RefreshToken)
+	assert.Equal(s.T(), "accToken", *t.AccessToken)
+	assert.Equal(s.T(), int64(3000000), *t.ExpiresIn)
+	assert.Equal(s.T(), int64(2), *t.RefreshExpiresIn)
+	assert.Equal(s.T(), "refToken", *t.RefreshToken)
 }
 
 func (s *TestAuthSuite) TestUpdateUserToPolicyOK() {

--- a/controller/login_blackbox_test.go
+++ b/controller/login_blackbox_test.go
@@ -5,8 +5,6 @@ import (
 
 	"context"
 
-	"golang.org/x/oauth2"
-
 	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/app/test"
@@ -66,7 +64,7 @@ func (rest *TestLoginREST) TestLoginOK() {
 	resource.Require(t, resource.UnitTest)
 	svc, ctrl := rest.UnSecuredController()
 
-	test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+	test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil, nil)
 }
 
 func (rest *TestLoginREST) TestOfflineAccessOK() {
@@ -75,16 +73,16 @@ func (rest *TestLoginREST) TestOfflineAccessOK() {
 	svc, ctrl := rest.UnSecuredController()
 
 	offline := "offline_access"
-	resp := test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, &offline)
+	resp := test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil, &offline)
 	assert.Contains(t, resp.Header().Get("Location"), "scope=offline_access")
 
-	resp = test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+	resp = test.LoginLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil, nil)
 	assert.NotContains(t, resp.Header().Get("Location"), "scope=offline_access")
 }
 
 type TestLoginService struct{}
 
-func (t TestLoginService) Perform(ctx *app.LoginLoginContext, oauth *oauth2.Config, config login.LoginServiceConfiguration) error {
+func (t TestLoginService) Perform(ctx *app.LoginLoginContext, config login.OauthConfig, serviceConfig login.LoginServiceConfiguration) error {
 	return ctx.TemporaryRedirect()
 }
 

--- a/design/login.go
+++ b/design/login.go
@@ -20,7 +20,7 @@ var _ = a.Resource("login", func() {
 				a.Enum("offline_access")
 				a.Description("If scope=offline_access then an offline token will be issued instead of a regular refresh token")
 			})
-			a.Param("api_token", d.String, "If not an empty string then return a token for accessing API")
+			a.Param("api_client", d.String, "The name of the api client which is requesting a token")
 		})
 		a.Description("Login user")
 		a.Response(d.Unauthorized, JSONAPIErrors)

--- a/design/login.go
+++ b/design/login.go
@@ -20,6 +20,7 @@ var _ = a.Resource("login", func() {
 				a.Enum("offline_access")
 				a.Description("If scope=offline_access then an offline token will be issued instead of a regular refresh token")
 			})
+			a.Param("api_token", d.String, "If not an empty string then return a token for accessing API")
 		})
 		a.Description("Login user")
 		a.Response(d.Unauthorized, JSONAPIErrors)

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-auth/account"
-	"github.com/fabric8-services/fabric8-auth/auth"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/login"
@@ -19,6 +18,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/test"
 	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
 
+	"github.com/fabric8-services/fabric8-auth/token"
 	"github.com/goadesign/goa"
 	_ "github.com/lib/pq"
 	errs "github.com/pkg/errors"
@@ -111,9 +111,9 @@ func (s *ProfileBlackBoxTest) generateAccessToken() (*string, error) {
 		return nil, errors.NewInternalError(context.Background(), errs.Wrap(err, "error when obtaining token"))
 	}
 
-	token, err := auth.ReadToken(context.Background(), res)
+	t, err := token.ReadTokenSet(context.Background(), res)
 	require.Nil(s.T(), err)
-	return token.AccessToken, err
+	return t.AccessToken, err
 }
 
 func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -547,7 +547,7 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 
 func (s *serviceBlackBoxTest) TestValidOAuthAuthorizationCode() {
 	rw, authorizeCtx := s.loginCallback(make(map[string]string))
-	s.checkLoginCallback(s.dummyOauth, rw, authorizeCtx)
+	s.checkLoginCallback(s.dummyOauth, rw, authorizeCtx, "token_json")
 }
 
 func (s *serviceBlackBoxTest) TestUnapprovedUserLoginUnauthorized() {
@@ -585,7 +585,7 @@ func (s *serviceBlackBoxTest) TestAPIClientForApprovedUsersReturnOK() {
 		accessToken: accessToken,
 	}
 
-	s.checkLoginCallback(dummyOauth, rw, authorizeCtx)
+	s.checkLoginCallback(dummyOauth, rw, authorizeCtx, "api_token")
 }
 
 func (s *serviceBlackBoxTest) TestAPIClientForUnapprovedUsersReturnOK() {
@@ -603,7 +603,7 @@ func (s *serviceBlackBoxTest) TestAPIClientForUnapprovedUsersReturnOK() {
 		accessToken: accessToken,
 	}
 
-	s.checkLoginCallback(dummyOauth, rw, authorizeCtx)
+	s.checkLoginCallback(dummyOauth, rw, authorizeCtx, "api_token")
 }
 
 func (s *serviceBlackBoxTest) loginCallback(extraParams map[string]string) (*httptest.ResponseRecorder, *app.LoginLoginContext) {
@@ -665,7 +665,7 @@ func (s *serviceBlackBoxTest) loginCallback(extraParams map[string]string) (*htt
 	return rw, authorizeCtx
 }
 
-func (s *serviceBlackBoxTest) checkLoginCallback(dummyOauth *dummyOauth2Config, rw *httptest.ResponseRecorder, authorizeCtx *app.LoginLoginContext) {
+func (s *serviceBlackBoxTest) checkLoginCallback(dummyOauth *dummyOauth2Config, rw *httptest.ResponseRecorder, authorizeCtx *app.LoginLoginContext, tokenParam string) {
 
 	err := s.loginService.Perform(authorizeCtx, dummyOauth, s.configuration)
 	require.Nil(s.T(), err)
@@ -679,7 +679,7 @@ func (s *serviceBlackBoxTest) checkLoginCallback(dummyOauth *dummyOauth2Config, 
 	assert.Equal(s.T(), 307, rw.Code) // redirect to the original redirect page
 
 	assert.NotNil(s.T(), allQueryParameters)
-	tokenJson := allQueryParameters["token_json"]
+	tokenJson := allQueryParameters[tokenParam]
 	require.NotNil(s.T(), tokenJson)
 	require.True(s.T(), len(tokenJson) > 0)
 

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -571,9 +571,9 @@ func (s *serviceBlackBoxTest) TestUnapprovedUserLoginUnauthorized() {
 	assert.Equal(s.T(), 0, len(rw.HeaderMap["Location"]))
 }
 
-func (s *serviceBlackBoxTest) TestAPITokenForApprovedUsersReturnOK() {
+func (s *serviceBlackBoxTest) TestAPIClientForApprovedUsersReturnOK() {
 	extra := make(map[string]string)
-	extra["api_token"] = "vscode"
+	extra["api_client"] = "vscode"
 	rw, authorizeCtx := s.loginCallback(extra)
 
 	claims := make(map[string]interface{})
@@ -588,9 +588,9 @@ func (s *serviceBlackBoxTest) TestAPITokenForApprovedUsersReturnOK() {
 	s.checkLoginCallback(dummyOauth, rw, authorizeCtx)
 }
 
-func (s *serviceBlackBoxTest) TestAPITokenForUnapprovedUsersReturnOK() {
+func (s *serviceBlackBoxTest) TestAPIClientForUnapprovedUsersReturnOK() {
 	extra := make(map[string]string)
-	extra["api_token"] = "vscode"
+	extra["api_client"] = "vscode"
 	rw, authorizeCtx := s.loginCallback(extra)
 
 	claims := make(map[string]interface{})

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -1,18 +1,15 @@
 package login_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
-	"context"
-
-	"golang.org/x/oauth2"
-
-	"github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/fabric8-services/fabric8-auth/app"
 	config "github.com/fabric8-services/fabric8-auth/configuration"
@@ -24,6 +21,9 @@ import (
 	"github.com/fabric8-services/fabric8-auth/migration"
 	"github.com/fabric8-services/fabric8-auth/resource"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
+	"github.com/fabric8-services/fabric8-auth/token"
+
+	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/goadesign/goa/uuid"
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	netcontext "golang.org/x/net/context"
+	"golang.org/x/oauth2"
 )
 
 type serviceBlackBoxTest struct {
@@ -39,6 +41,7 @@ type serviceBlackBoxTest struct {
 	ctx           context.Context
 	loginService  KeycloakOAuthService
 	oauth         *oauth2.Config
+	dummyOauth    *dummyOauth2Config
 	configuration *config.ConfigurationData
 }
 
@@ -80,6 +83,23 @@ func (s *serviceBlackBoxTest) SetupSuite() {
 			AuthURL:  authEndpoint,
 			TokenURL: tokenEndpoint,
 		},
+	}
+	claims := make(map[string]interface{})
+	accessToken, err := testtoken.GenerateTokenWithClaims(claims)
+	if err != nil {
+		panic(err)
+	}
+	s.dummyOauth = &dummyOauth2Config{
+		Config: oauth2.Config{
+			ClientID:     s.configuration.GetKeycloakClientID(),
+			ClientSecret: s.configuration.GetKeycloakSecret(),
+			Scopes:       []string{"user:email"},
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  authEndpoint,
+				TokenURL: tokenEndpoint,
+			},
+		},
+		accessToken: accessToken,
 	}
 
 	userRepository := account.NewUserRepository(s.DB)
@@ -523,4 +543,172 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 	assert.NotEmpty(s.T(), returnedErrorReason)
 	assert.NotContains(s.T(), locationString, refererKeycloakUrl)
 	assert.Contains(s.T(), locationString, refererUrl)
+}
+
+func (s *serviceBlackBoxTest) TestValidOAuthAuthorizationCode() {
+	rw, authorizeCtx := s.loginCallback(make(map[string]string))
+	s.checkLoginCallback(s.dummyOauth, rw, authorizeCtx)
+}
+
+func (s *serviceBlackBoxTest) TestUnapprovedUserLoginUnauthorized() {
+	extra := make(map[string]string)
+	rw, authorizeCtx := s.loginCallback(extra)
+
+	claims := make(map[string]interface{})
+	claims["approved"] = nil
+	accessToken, err := testtoken.GenerateTokenWithClaims(claims)
+	require.Nil(s.T(), err)
+
+	dummyOauth := &dummyOauth2Config{
+		Config:      oauth2.Config{},
+		accessToken: accessToken,
+	}
+
+	err = s.loginService.Perform(authorizeCtx, dummyOauth, s.configuration)
+	require.NotNil(s.T(), err)
+	assert.Equal(s.T(), 401, rw.Code)
+
+	assert.Equal(s.T(), 0, len(rw.HeaderMap["Location"]))
+}
+
+func (s *serviceBlackBoxTest) TestAPITokenForApprovedUsersReturnOK() {
+	extra := make(map[string]string)
+	extra["api_token"] = "vscode"
+	rw, authorizeCtx := s.loginCallback(extra)
+
+	claims := make(map[string]interface{})
+	accessToken, err := testtoken.GenerateTokenWithClaims(claims)
+	require.Nil(s.T(), err)
+
+	dummyOauth := &dummyOauth2Config{
+		Config:      oauth2.Config{},
+		accessToken: accessToken,
+	}
+
+	s.checkLoginCallback(dummyOauth, rw, authorizeCtx)
+}
+
+func (s *serviceBlackBoxTest) TestAPITokenForUnapprovedUsersReturnOK() {
+	extra := make(map[string]string)
+	extra["api_token"] = "vscode"
+	rw, authorizeCtx := s.loginCallback(extra)
+
+	claims := make(map[string]interface{})
+	claims["approved"] = nil
+	accessToken, err := testtoken.GenerateTokenWithClaims(claims)
+	require.Nil(s.T(), err)
+
+	dummyOauth := &dummyOauth2Config{
+		Config:      oauth2.Config{},
+		accessToken: accessToken,
+	}
+
+	s.checkLoginCallback(dummyOauth, rw, authorizeCtx)
+}
+
+func (s *serviceBlackBoxTest) loginCallback(extraParams map[string]string) (*httptest.ResponseRecorder, *app.LoginLoginContext) {
+	// Setup request context
+	rw := httptest.NewRecorder()
+	u := &url.URL{
+		Path: fmt.Sprintf("/api/login"),
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	require.Nil(s.T(), err)
+
+	prms := url.Values{}
+	originalRedirect := "https://openshift.io/somepath"
+	prms.Add("redirect", originalRedirect)
+	for key, value := range extraParams {
+		prms.Add(key, value)
+	}
+
+	ctx := context.Background()
+	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
+	authorizeCtx, err := app.NewLoginLoginContext(goaCtx, req, goa.New("LoginService"))
+	require.Nil(s.T(), err)
+
+	err = s.loginService.Perform(authorizeCtx, s.dummyOauth, s.configuration)
+	require.Nil(s.T(), err)
+
+	assert.Equal(s.T(), 307, rw.Code) // redirect to keycloak login page.
+
+	locationString := rw.HeaderMap["Location"][0]
+	locationUrl, err := url.Parse(locationString)
+	require.Nil(s.T(), err)
+
+	allQueryParameters := locationUrl.Query()
+
+	assert.NotNil(s.T(), allQueryParameters)
+	assert.NotNil(s.T(), allQueryParameters["state"][0])
+
+	returnedState := allQueryParameters["state"][0]
+
+	prms = url.Values{
+		"state": {returnedState},
+		"code":  {"SOME_OAUTH2.0_CODE"},
+	}
+	ctx = context.Background()
+	rw = httptest.NewRecorder()
+
+	req, err = http.NewRequest("GET", u.String(), nil)
+	require.Nil(s.T(), err)
+
+	// The OAuth code is sent as a query parameter by calling /api/login?code=_SOME_CODE_&state=_SOME_STATE_
+	// The request originates from Keycloak after a valid authorization by the end user.
+	refererKeycloakUrl := "https://keycloak-url.example.org/path-of-login"
+	req.Header.Add("referer", refererKeycloakUrl)
+
+	goaCtx = goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
+	authorizeCtx, err = app.NewLoginLoginContext(goaCtx, req, goa.New("LoginService"))
+	require.Nil(s.T(), err)
+
+	return rw, authorizeCtx
+}
+
+func (s *serviceBlackBoxTest) checkLoginCallback(dummyOauth *dummyOauth2Config, rw *httptest.ResponseRecorder, authorizeCtx *app.LoginLoginContext) {
+
+	err := s.loginService.Perform(authorizeCtx, dummyOauth, s.configuration)
+	require.Nil(s.T(), err)
+
+	locationString := rw.HeaderMap["Location"][0]
+	locationUrl, err := url.Parse(locationString)
+	require.Nil(s.T(), err)
+
+	allQueryParameters := locationUrl.Query()
+
+	assert.Equal(s.T(), 307, rw.Code) // redirect to the original redirect page
+
+	assert.NotNil(s.T(), allQueryParameters)
+	tokenJson := allQueryParameters["token_json"]
+	require.NotNil(s.T(), tokenJson)
+	require.True(s.T(), len(tokenJson) > 0)
+
+	tokenSet, err := token.ReadTokenSetFromJson(context.Background(), tokenJson[0])
+	require.Nil(s.T(), err)
+	assert.Equal(s.T(), dummyOauth.accessToken, *tokenSet.AccessToken)
+	assert.Equal(s.T(), "someRefreshToken", *tokenSet.RefreshToken)
+
+	assert.NotContains(s.T(), locationString, "https://keycloak-url.example.org/path-of-login")
+	assert.Contains(s.T(), locationString, "https://openshift.io/somepath")
+}
+
+type dummyOauth2Config struct {
+	oauth2.Config
+	accessToken string
+}
+
+func (c *dummyOauth2Config) Exchange(ctx netcontext.Context, code string) (*oauth2.Token, error) {
+	var thirtyDays int64
+	thirtyDays = 60 * 60 * 24 * 30
+	token := &oauth2.Token{
+		TokenType:    "Bearer",
+		AccessToken:  c.accessToken,
+		RefreshToken: "someRefreshToken",
+		Expiry:       time.Unix(time.Now().Unix()+thirtyDays, 0),
+	}
+	extra := make(map[string]interface{})
+	extra["expires_in"] = time.Now().Unix() + thirtyDays
+	extra["refresh_expires_in"] = time.Now().Unix() + thirtyDays
+	token = token.WithExtra(extra)
+	return token, nil
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/account"
@@ -147,7 +146,6 @@ func (s *TestTokenSuite) TestLocateInvalidUUIDInTokenInContext() {
 }
 
 func (s *TestTokenSuite) TestEncodeTokenOK() {
-	referrerURL, _ := url.Parse("https://example.domain.com")
 	accessToken := "accessToken%@!/\\&?"
 	refreshToken := "refreshToken%@!/\\&?"
 	tokenType := "tokenType%@!/\\&?"
@@ -164,14 +162,9 @@ func (s *TestTokenSuite) TestEncodeTokenOK() {
 		"expires_in":         expiresIn,
 		"refresh_expires_in": refreshExpiresIn,
 	}
-	err := token.EncodeToken(context.Background(), referrerURL, outhToken.WithExtra(extra))
+	tokenJson, err := token.TokenToJson(context.Background(), outhToken.WithExtra(extra))
 	assert.Nil(s.T(), err)
-	encoded := referrerURL.String()
-
-	referrerURL, _ = url.Parse(encoded)
-	values := referrerURL.Query()
-	tJSON := values["token_json"]
-	b := []byte(tJSON[0])
+	b := []byte(tokenJson)
 	tokenData := &token.TokenSet{}
 	err = json.Unmarshal(b, tokenData)
 	assert.Nil(s.T(), err)

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,10 +3,10 @@ package token_test
 import (
 	"context"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"testing"
-
-	"golang.org/x/oauth2"
 
 	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/fabric8-services/fabric8-auth/configuration"
@@ -14,15 +14,13 @@ import (
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 	"github.com/fabric8-services/fabric8-auth/token"
 
-	"encoding/json"
 	"github.com/dgrijalva/jwt-go"
-	"github.com/fabric8-services/fabric8-auth/auth"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"net/url"
+	"golang.org/x/oauth2"
 )
 
 func TestToken(t *testing.T) {
@@ -174,7 +172,7 @@ func (s *TestTokenSuite) TestEncodeTokenOK() {
 	values := referrerURL.Query()
 	tJSON := values["token_json"]
 	b := []byte(tJSON[0])
-	tokenData := &auth.Token{}
+	tokenData := &token.TokenSet{}
 	err = json.Unmarshal(b, tokenData)
 	assert.Nil(s.T(), err)
 


### PR DESCRIPTION
- Added new `/api/login?api_client=<anystring>` param to issue a set of tokens to be used for api calls even if user is not approved yet.
- If `api_client` is present and not an empty string then the token json will be encoded in `api_token` param instead of `token_json`
- If user is not approved then we do not create a new user/identity in the Auth DB.
- Added tests to cover login flow.

It's based on https://github.com/fabric8-services/fabric8-auth/pull/124 (so, contains the same commit) which can be merged separately.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/125
Fixes https://github.com/fabric8-services/fabric8-auth/issues/34
Related to https://github.com/fabric8-services/fabric8-auth/issues/46