### PR TITLE
sirupsen-case for fabric8-auth

### DIFF
--- a/application/application_db_calls_bench_test.go
+++ b/application/application_db_calls_bench_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/migration"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
-	"github.com/almighty/almighty-core/account"
+	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )

--- a/application/application_db_calls_bench_test.go
+++ b/application/application_db_calls_bench_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/migration"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
-	"github.com/fabric8-services/fabric8-wit/account"
+	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )

--- a/application/application_db_calls_bench_test.go
+++ b/application/application_db_calls_bench_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/migration"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
-	"github.com/fabric8-services/fabric8-auth/account"
+	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/rest"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,10 @@
-hash: d5617480373ee580544dcaa0b3836aec445c98cefbdca0f0ce02b74428592997
-updated: 2017-09-06T14:32:24.658504132-07:00
+hash: abbe98619e040ef910c300bf1e873c2347a2e18efe47b758502fc7c84b1cad15
+updated: 2017-09-29T16:13:02.108418892+02:00
 imports:
 - name: github.com/andygrunwald/go-jira
   version: 9d1f282f93af41553ddb53b0116a8cdb75b4837a
 - name: github.com/armon/go-metrics
   version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
-- name: github.com/asaskevich/govalidator
-  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/axw/gocov
   version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
   subpackages:
@@ -15,8 +13,6 @@ imports:
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
-- name: github.com/fabric8-services/fabric8-wit
-  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/dimfeld/httppath
@@ -26,20 +22,31 @@ imports:
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
-  - cassette
   - recorder
 - name: github.com/elazarl/go-bindata-assetfs
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
   - go-bindata-assetfs
-- name: github.com/fatih/structs
-  version: dc3312cb1a4513a366c4c9e622ad55c32df12ed3
+- name: github.com/fabric8-services/fabric8-wit
+  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
+  subpackages:
+  - account
+  - account/tenant
+  - application/repository
+  - configuration
+  - convert
+  - design
+  - errors
+  - goasupport
+  - gormsupport
+  - log
+  - rest
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/fzipp/gocyclo
   version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 - name: github.com/goadesign/goa
-  version: 58f3177f36f2c50ee6119da92795e48bac6d6243
+  version: 5646a430cdeb66983d5ace3384e0a667c185abc7
   vcs: git
   subpackages:
   - client
@@ -94,6 +101,8 @@ imports:
   version: c1b9cf186e4bcd8e5d566ef43f2ae2dfe22dc34e
 - name: github.com/jinzhu/inflection
   version: 74387dc39a75e970e7a3ae6a3386b5bd2e5c5cff
+- name: github.com/jstemmer/go-junit-report
+  version: 15422cf504f9dc030386499a5c68053a38763e58
 - name: github.com/jteeuwen/go-bindata
   version: bbd0c6e271208dce66d8fda4bc536453cd27fc4a
   subpackages:
@@ -109,13 +118,13 @@ imports:
 - name: github.com/lsegal/gucumber
   version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
 - name: github.com/magiconair/properties
-  version: f917359f079a3759162704eaa8caeec3d01d9f91
+  version: be5ece7dd465ab0765a9682137865547526d1dfb
 - name: github.com/manveru/faker
   version: 717f7cf83fb78669bfab612749c2e8ff63d5be11
 - name: github.com/mattn/go-colorable
   version: d228849504861217f796da67fae4f6e347643f15
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 0360b2af4f38e8d38c7fce2a9f4e702702d73a39
 - name: github.com/microcosm-cc/bluemonday
   version: e79763773ab6222ca1d5a7cbd9d62d83c1f77081
 - name: github.com/mitchellh/mapstructure
@@ -138,8 +147,6 @@ imports:
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/russross/blackfriday
   version: 5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
-- name: github.com/jstemmer/go-junit-report
-  version: 15422cf504f9dc030386499a5c68053a38763e58
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/sergi/go-diff
@@ -174,26 +181,19 @@ imports:
   - assert
   - require
   - suite
-- name: gopkg.in/square/go-jose.v2
-  version: b25e6cab129e4a54675b42ea49d38e9c33ade9e6
-- name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
-  subpackages:
-  - ssh/terminal
-- name: github.com/trivago/tgo
-  version: 4a656addb20609ba4cb4d20219a2f6c27aeb142c
-  subpackages:
-  - tcontainer
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: github.com/zach-klippenstein/goregen
   version: 795b5e3961ea1912fde60af417ad85e86acc0d6a
+- name: golang.org/x/crypto
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  subpackages:
+  - ed25519
+  - ed25519/internal/edwards25519
 - name: golang.org/x/net
   version: b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d
   subpackages:
   - context
-  - html
-  - html/atom
   - websocket
 - name: golang.org/x/oauth2
   version: da3ce8d62a7f77aadfda06cb82bd604d6469c645
@@ -224,6 +224,11 @@ imports:
   - urlfetch
 - name: gopkg.in/asaskevich/govalidator.v4
   version: 7664702784775e51966f0885f5cd27435916517b
+- name: gopkg.in/square/go-jose.v2
+  version: f8f38de21b4dcd69d0413faf231983f5fd6634b1
+  subpackages:
+  - cipher
+  - json
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -28,7 +28,7 @@ imports:
   subpackages:
   - go-bindata-assetfs
 - name: github.com/fabric8-services/fabric8-wit
-  version: 97f0b184866f7f6cdf89d4fcc3c06c04d5837755
+  version: 296f01addee8a560c9bb43fb291cf93ccd35ee8e
   subpackages:
   - account
   - account/tenant

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b0ac946fc96bea77464c8d56044f479f7d0265d346b4a62133ce5d0e5d8102a2
-updated: 2017-09-29T17:07:14.477697973+02:00
+hash: abbe98619e040ef910c300bf1e873c2347a2e18efe47b758502fc7c84b1cad15
+updated: 2017-09-29T16:13:02.108418892+02:00
 imports:
 - name: github.com/andygrunwald/go-jira
   version: 9d1f282f93af41553ddb53b0116a8cdb75b4837a
@@ -27,6 +27,20 @@ imports:
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
   - go-bindata-assetfs
+- name: github.com/fabric8-services/fabric8-wit
+  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
+  subpackages:
+  - account
+  - account/tenant
+  - application/repository
+  - configuration
+  - convert
+  - design
+  - errors
+  - goasupport
+  - gormsupport
+  - log
+  - rest
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/fzipp/gocyclo

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: abbe98619e040ef910c300bf1e873c2347a2e18efe47b758502fc7c84b1cad15
-updated: 2017-09-29T16:13:02.108418892+02:00
+hash: 905eff0b6e3bd1dc48bb151f625c989c3468088728df1a357f58d00f7231305e
+updated: 2017-09-29T17:41:30.504994916+02:00
 imports:
 - name: github.com/andygrunwald/go-jira
   version: 9d1f282f93af41553ddb53b0116a8cdb75b4837a
 - name: github.com/armon/go-metrics
-  version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
+  version: 0a12dc6f6b9da6da644031a1b9b5a85478c5ee27
 - name: github.com/axw/gocov
   version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
   subpackages:
@@ -28,7 +28,7 @@ imports:
   subpackages:
   - go-bindata-assetfs
 - name: github.com/fabric8-services/fabric8-wit
-  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
+  version: 97f0b184866f7f6cdf89d4fcc3c06c04d5837755
   subpackages:
   - account
   - account/tenant
@@ -82,6 +82,12 @@ imports:
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
   - query
+- name: github.com/hashicorp/go-immutable-radix
+  version: 8aac2701530899b64bdea735a1de8da899815220
+- name: github.com/hashicorp/golang-lru
+  version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/hcl
   version: 37ab263305aaeb501a60eb16863e808d426e37f2
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: abbe98619e040ef910c300bf1e873c2347a2e18efe47b758502fc7c84b1cad15
-updated: 2017-09-29T16:13:02.108418892+02:00
+hash: b0ac946fc96bea77464c8d56044f479f7d0265d346b4a62133ce5d0e5d8102a2
+updated: 2017-09-29T17:07:14.477697973+02:00
 imports:
 - name: github.com/andygrunwald/go-jira
   version: 9d1f282f93af41553ddb53b0116a8cdb75b4837a
@@ -27,20 +27,6 @@ imports:
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
   - go-bindata-assetfs
-- name: github.com/fabric8-services/fabric8-wit
-  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
-  subpackages:
-  - account
-  - account/tenant
-  - application/repository
-  - configuration
-  - convert
-  - design
-  - errors
-  - goasupport
-  - gormsupport
-  - log
-  - rest
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/fzipp/gocyclo

--- a/glide.lock
+++ b/glide.lock
@@ -148,7 +148,7 @@ imports:
   - diffmatchpatch
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/sourcegraph/annotate
   version: f4cad6c6324d3f584e1743d8b3e0e017a5f3a636

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: ^1.2.0
+  version: ^1.3.0
   vcs: git
   subpackages:
   - client
@@ -97,7 +97,7 @@ import:
   subpackages:
   - golint
 - package: github.com/fzipp/gocyclo
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/sourcegraph/syntaxhighlight
 - package: github.com/jstemmer/go-junit-report
 - package: github.com/sourcegraph/annotate

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,9 @@ package: github.com/fabric8-services/fabric8-auth
 homepage: https://github.com/fabric8-services/fabric8-auth
 license: Apache-2.0
 import:
+- package: github.com/fabric8-services/fabric8-wit
+  subpackages:
+   - design
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ license: Apache-2.0
 import:
 - package: github.com/fabric8-services/fabric8-wit
   subpackages:
-   - design
+  - design
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
@@ -106,3 +106,4 @@ import:
   - diffmatchpatch
 - package: gopkg.in/square/go-jose.v2
   version: ^2.1.2
+- package: github.com/armon/go-metrics

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,9 +2,6 @@ package: github.com/fabric8-services/fabric8-auth
 homepage: https://github.com/fabric8-services/fabric8-auth
 license: Apache-2.0
 import:
-- package: github.com/fabric8-services/fabric8-wit
-  subpackages:
-   - design
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa

--- a/log/log.go
+++ b/log/log.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/configuration"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/goadesign/goa"
+	log "github.com/sirupsen/logrus"
 )
 
 const defaultPackageName = "github.com/fabric8-services/fabric8-auth/"

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	logrus "github.com/Sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Switched from github.com/Sirupsen/logrus to github.com/sirupsen/logrus

This commit will probably not build because not all packages that this
project depends on have adopted the lowercase version of the package. We
have to merge this commit anyway, I think.

Also updated GOA to 1.3.0

See also fabric8-services/fabric8-wit#1395