### PR TITLE
Move TokenToJson to service level

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -19,17 +19,16 @@ import (
 	"time"
 
 	"bytes"
+	"io"
+	"strconv"
+	"strings"
+
 	"github.com/dgrijalva/jwt-go"
-	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
-	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2"
-	"io"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -468,44 +467,6 @@ func NumberToInt(number interface{}) (int64, error) {
 		return 0, err
 	}
 	return result, nil
-}
-
-// TokenToJson marshals an oauth2 token to a json string
-func TokenToJson(ctx context.Context, outhToken *oauth2.Token) (string, error) {
-	str := outhToken.Extra("expires_in")
-	var expiresIn interface{}
-	var refreshExpiresIn interface{}
-	var err error
-	expiresIn, err = NumberToInt(str)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"expires_in": str,
-			"err":        err,
-		}, "unable to parse expires_in claim")
-		return "", errs.WithStack(err)
-	}
-	str = outhToken.Extra("refresh_expires_in")
-	refreshExpiresIn, err = NumberToInt(str)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"refresh_expires_in": str,
-			"err":                err,
-		}, "unable to parse expires_in claim")
-		return "", errs.WithStack(err)
-	}
-	tokenData := &app.TokenData{
-		AccessToken:      &outhToken.AccessToken,
-		RefreshToken:     &outhToken.RefreshToken,
-		TokenType:        &outhToken.TokenType,
-		ExpiresIn:        &expiresIn,
-		RefreshExpiresIn: &refreshExpiresIn,
-	}
-	b, err := json.Marshal(tokenData)
-	if err != nil {
-		return "", errs.WithStack(err)
-	}
-
-	return string(b), nil
 }
 
 // TokenSet represents a set of Access and Refresh tokens

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,7 +3,6 @@ package token_test
 import (
 	"context"
 	"crypto/rsa"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -144,38 +143,6 @@ func (s *TestTokenSuite) TestLocateInvalidUUIDInTokenInContext() {
 	_, err := s.tokenManager.Locate(ctx)
 	require.NotNil(s.T(), err)
 }
-
-func (s *TestTokenSuite) TestEncodeTokenOK() {
-	accessToken := "accessToken%@!/\\&?"
-	refreshToken := "refreshToken%@!/\\&?"
-	tokenType := "tokenType%@!/\\&?"
-	expiresIn := 1800
-	var refreshExpiresIn float64
-	refreshExpiresIn = 2.59e6
-
-	outhToken := &oauth2.Token{
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
-		TokenType:    tokenType,
-	}
-	extra := map[string]interface{}{
-		"expires_in":         expiresIn,
-		"refresh_expires_in": refreshExpiresIn,
-	}
-	tokenJson, err := token.TokenToJson(context.Background(), outhToken.WithExtra(extra))
-	assert.Nil(s.T(), err)
-	b := []byte(tokenJson)
-	tokenData := &token.TokenSet{}
-	err = json.Unmarshal(b, tokenData)
-	assert.Nil(s.T(), err)
-
-	assert.Equal(s.T(), accessToken, *tokenData.AccessToken)
-	assert.Equal(s.T(), refreshToken, *tokenData.RefreshToken)
-	assert.Equal(s.T(), tokenType, *tokenData.TokenType)
-	assert.Equal(s.T(), int64(expiresIn), *tokenData.ExpiresIn)
-	assert.Equal(s.T(), int64(refreshExpiresIn), *tokenData.RefreshExpiresIn)
-}
-
 func (s *TestTokenSuite) TestInt32ToInt64OK() {
 	var i32 int32
 	i32 = 60


### PR DESCRIPTION
Avoid lower level package dependency on external generated
REST API.

Related to fabric8-services/fabric8-wit#1395