### PR TITLE
Move remoteservices/wit.go to wit/wit.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ swagger/
 tool/cli/
 migration/sqlbindata.go
 migration/sqlbindata_test.go
-wit/
+wit/witservice
 
 # Ignore artifacts directory
 bin/

--- a/controller/users.go
+++ b/controller/users.go
@@ -13,8 +13,8 @@ import (
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/login"
-	"github.com/fabric8-services/fabric8-auth/remoteservice"
 	"github.com/fabric8-services/fabric8-auth/rest"
+	"github.com/fabric8-services/fabric8-auth/wit"
 
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
@@ -29,7 +29,7 @@ type UsersController struct {
 	db                 application.DB
 	config             UsersControllerConfiguration
 	userProfileService login.UserProfileService
-	RemoteWITService   remoteservice.RemoteWITService
+	RemoteWITService   wit.RemoteWITService
 }
 
 // UsersControllerConfiguration the Configuration for the UsersController
@@ -47,7 +47,7 @@ func NewUsersController(service *goa.Service, db application.DB, config UsersCon
 		db:                 db,
 		config:             config,
 		userProfileService: userProfileService,
-		RemoteWITService:   &remoteservice.RemoteWITServiceCaller{},
+		RemoteWITService:   &wit.RemoteWITServiceCaller{},
 	}
 }
 

--- a/login/service.go
+++ b/login/service.go
@@ -22,9 +22,9 @@ import (
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/login/tokencontext"
-	"github.com/fabric8-services/fabric8-auth/remoteservice"
 	"github.com/fabric8-services/fabric8-auth/rest"
 	"github.com/fabric8-services/fabric8-auth/token"
+	"github.com/fabric8-services/fabric8-auth/wit"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
@@ -49,7 +49,7 @@ func NewKeycloakOAuthProvider(identities account.IdentityRepository, users accou
 		Users:            users,
 		TokenManager:     tokenManager,
 		db:               db,
-		remoteWITService: &remoteservice.RemoteWITServiceCaller{},
+		remoteWITService: &wit.RemoteWITServiceCaller{},
 	}
 }
 
@@ -59,7 +59,7 @@ type KeycloakOAuthProvider struct {
 	Users            account.UserRepository
 	TokenManager     token.Manager
 	db               application.DB
-	remoteWITService remoteservice.RemoteWITService
+	remoteWITService wit.RemoteWITService
 }
 
 // KeycloakOAuthService represents keycloak OAuth service interface

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -1,4 +1,4 @@
-package remoteservice
+package wit
 
 import (
 	"context"


### PR DESCRIPTION
IMO it makes sense to keep all wit related code in the wit package instead of spreading it between remoteservices and wit/witservices