### PR TITLE
External token provider ID index should be case sensitive

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"database/sql"
 	"net/http"
 	"net/url"
@@ -10,8 +11,6 @@ import (
 	"text/template"
 
 	"github.com/fabric8-services/fabric8-auth/log"
-
-	"context"
 
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/client"
@@ -123,6 +122,9 @@ func GetMigrations() Migrations {
 
 	// Version 6
 	m = append(m, steps{ExecuteSQLFile("006-external-provider.sql")})
+
+	// Version 7
+	m = append(m, steps{ExecuteSQLFile("007-external-provider-id-index.sql")})
 
 	// Version N
 	//

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -98,6 +98,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration01", testMigration01)
 	t.Run("TestMigration02", testMigration02)
 	t.Run("TestMigration04", testMigration04)
+	t.Run("TestMigration07", testMigration07)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName); err != nil {
@@ -139,6 +140,12 @@ func testMigration04(t *testing.T) {
 	migrateToVersion(sqlDB, migrations[:(5)], (5))
 
 	assert.NotNil(t, runSQLscript(sqlDB, "004-insert-duplicate-space-resource.sql"))
+}
+
+func testMigration07(t *testing.T) {
+	migrateToVersion(sqlDB, migrations[:(8)], (8))
+
+	assert.True(t, dialect.HasIndex("external_provider_tokens", "idx_provider_id"))
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/007-external-provider-id-index.sql
+++ b/migration/sql-files/007-external-provider-id-index.sql
@@ -1,0 +1,4 @@
+-- drop existing index
+DROP INDEX idx_provider_id;
+-- recreate case sensitive index idx_provider_id
+CREATE INDEX idx_provider_id ON external_provider_tokens (provider_id);


### PR DESCRIPTION
It doesn't make any sense to convert provider ID to low case because we use UUID as provider IDs