### PR TITLE
Support multiple resources when linking accounts

### DIFF
--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -88,6 +88,15 @@ func (rest *TestTokenREST) TestLinkRedirects() {
 	location := response.Header()["Location"]
 	require.Equal(rest.T(), 1, len(location))
 	require.Equal(rest.T(), "providerLocation", location[0])
+
+	// Multiple "for" resources
+	payload = &app.LinkPayload{Token: token, For: "https://github.com/org/repo," + rest.config.GetOpenShiftClientApiUrl(), Redirect: &redirect}
+	response = test.LinkTokenSeeOther(rest.T(), service.Context, service, controller, payload)
+	require.NotNil(rest.T(), response)
+	location = response.Header()["Location"]
+	require.Equal(rest.T(), 1, len(location))
+	require.Equal(rest.T(), "providerLocation", location[0])
+
 }
 
 func (rest *TestTokenREST) TestLinkCallbackRedirects() {

--- a/design/token.go
+++ b/design/token.go
@@ -132,8 +132,8 @@ var _ = a.Resource("token", func() {
 })
 
 var linkPayload = a.Type("LinkPayload", func() {
-	a.Attribute("for", d.String, "Resource we need to link accounts for", func() {
-		a.Example("https://github.com/somecoolrepo")
+	a.Attribute("for", d.String, "Resource we need to link accounts for. Multiple resources should be separated by comma.", func() {
+		a.Example("https://github.com/somecoolrepo,https://api.openshift.com")
 	})
 	a.Attribute("token", d.String, "User's access token")
 	a.Attribute("redirect", d.String, "URL to be redirected to after successful account linking. If not set then will redirect to the referrer instead.")


### PR DESCRIPTION
`for` can now contains a set of resources separated by comma.
For example: `/api/token/link?for=https://github.com,https://api.openshift.com`

Fixes https://github.com/fabric8-services/fabric8-auth/issues/159
