### PR TITLE
Fix minor typos in token.go and authz.go

### DIFF
--- a/auth/authz.go
+++ b/auth/authz.go
@@ -206,7 +206,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
 		}, "unable to create a Keycloak resource")
-		return "", errors.NewInternalError(ctx, errs.Errorf("unable to create a Keycloak resource. Response status: "+res.Status+". Responce body: "+rest.ReadBody(res.Body)))
+		return "", errors.NewInternalError(ctx, errs.Errorf("unable to create a Keycloak resource. Response status: "+res.Status+". Response body: "+rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
 

--- a/controller/token.go
+++ b/controller/token.go
@@ -363,7 +363,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
 		}, "unable to obtain token")
-		return nil, errors.NewInternalError(ctx, errs.Errorf("unable to obtain toke. Response status: %s. Responce body: %s", res.Status, rest.ReadBody(res.Body)))
+		return nil, errors.NewInternalError(ctx, errs.Errorf("unable to obtain token. Response status: %s. Response body: %s", res.Status, rest.ReadBody(res.Body)))
 	}
 	t, err := token.ReadTokenSet(ctx, res)
 	if err != nil {


### PR DESCRIPTION
* Please describe what your change is about.
Fix incorrect spellings in `token.go` and `authz.go`. 
`responce` => `response` and `toke` => `token`