### PR TITLE
chore: fixed typo in error message

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -363,7 +363,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
 		}, "unable to obtain token")
-		return nil, errors.NewInternalError(ctx, errs.Errorf("unable to obtain toke. Response status: %s. Responce body: %s", res.Status, rest.ReadBody(res.Body)))
+		return nil, errors.NewInternalError(ctx, errs.Errorf("unable to obtain token. Response status: %s. Responce body: %s", res.Status, rest.ReadBody(res.Body)))
 	}
 	t, err := token.ReadTokenSet(ctx, res)
 	if err != nil {


### PR DESCRIPTION
"Toke" typo in error message when not able to obtain token.

> toke (təʊk); informal; _noun_
> a pull on a cigarette or pipe, typically one containing cannabis.

Also the biggest gecko in the world 

![image](https://user-images.githubusercontent.com/719616/32415322-6f208a70-c238-11e7-815c-908d09db4c87.png)


