### PR TITLE
Rename auth Service Account to 'fabric8-auth'

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -406,7 +406,7 @@ func (mgm *tokenManager) initServiceAccountToken(req *goa.RequestData) (string, 
 	mgm.serviceAccountLock.Lock()
 	defer mgm.serviceAccountLock.Unlock()
 
-	tokenStr, err := mgm.GenerateServiceAccountToken(req, AuthServiceAccountID, "auth")
+	tokenStr, err := mgm.GenerateServiceAccountToken(req, AuthServiceAccountID, "fabric8-auth")
 	if err != nil {
 		return "", errors.WithStack(err)
 	}

--- a/token/token_remote_test.go
+++ b/token/token_remote_test.go
@@ -95,7 +95,7 @@ func (s *TokenWhiteBoxTest) TestAuthServiceAccount() {
 
 	claims := token.Claims.(jwt.MapClaims)
 	require.Equal(s.T(), AuthServiceAccountID, claims["sub"])
-	require.Equal(s.T(), "auth", claims["service_accountname"])
+	require.Equal(s.T(), "fabric8-auth", claims["service_accountname"])
 	require.Equal(s.T(), []interface{}{"uma_protection"}, claims["scopes"])
 	jti, ok := claims["jti"].(string)
 	require.True(s.T(), ok)

--- a/token/token_whitebox_test.go
+++ b/token/token_whitebox_test.go
@@ -67,7 +67,7 @@ func (s *TestWhiteboxTokenSuite) TestAuthServiceAccountGeneratedOK() {
 	tokenString, err := s.tokenManager.AuthServiceAccountToken(r)
 	require.Nil(s.T(), err)
 
-	s.checkServiceAccountToken(tokenString, AuthServiceAccountID, "auth")
+	s.checkServiceAccountToken(tokenString, AuthServiceAccountID, "fabric8-auth")
 }
 
 func (s *TestWhiteboxTokenSuite) TestServiceAccountGeneratedOK() {


### PR DESCRIPTION
For consistency sake.
We are using github repo name as service account names.

Already updated in WIT - https://github.com/fabric8-services/fabric8-wit/pull/1758 (in prod)
