### PR TITLE
Enabling updates to accept empty strings for User's profile for optional fields

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -211,7 +211,7 @@ func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) erro
 		}, "unable to update the identity")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Updates(model).Error
+	err = m.db.Save(obj).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"identity_id": model.ID,

--- a/account/identity.go
+++ b/account/identity.go
@@ -202,16 +202,7 @@ func (m *GormIdentityRepository) Lookup(ctx context.Context, username, profileUR
 func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity", "save"}, time.Now())
 
-	_, err := m.Load(ctx, model.ID)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"identity_id": model.ID,
-			"ctx":         ctx,
-			"err":         err,
-		}, "unable to update the identity")
-		return errs.WithStack(err)
-	}
-	err = m.db.Save(model).Error
+	err := m.db.Save(model).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"identity_id": model.ID,

--- a/account/identity.go
+++ b/account/identity.go
@@ -202,7 +202,7 @@ func (m *GormIdentityRepository) Lookup(ctx context.Context, username, profileUR
 func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity", "save"}, time.Now())
 
-	obj, err := m.Load(ctx, model.ID)
+	_, err := m.Load(ctx, model.ID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"identity_id": model.ID,
@@ -211,7 +211,7 @@ func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) erro
 		}, "unable to update the identity")
 		return errs.WithStack(err)
 	}
-	err = m.db.Save(obj).Error
+	err = m.db.Save(model).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"identity_id": model.ID,

--- a/account/user.go
+++ b/account/user.go
@@ -123,15 +123,7 @@ func (m *GormUserRepository) Create(ctx context.Context, u *User) error {
 func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "save"}, time.Now())
 
-	_, err := m.Load(ctx, model.ID)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"user_id": model.ID,
-			"err":     err,
-		}, "unable to update user")
-		return errs.WithStack(err)
-	}
-	err = m.db.Save(model).Error
+	err := m.db.Save(model).Error
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/account/user.go
+++ b/account/user.go
@@ -131,7 +131,7 @@ func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 		}, "unable to update user")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Updates(model).Error
+	err = m.db.Save(obj).Error
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/account/user.go
+++ b/account/user.go
@@ -123,7 +123,7 @@ func (m *GormUserRepository) Create(ctx context.Context, u *User) error {
 func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "save"}, time.Now())
 
-	obj, err := m.Load(ctx, model.ID)
+	_, err := m.Load(ctx, model.ID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"user_id": model.ID,
@@ -131,7 +131,7 @@ func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 		}, "unable to update user")
 		return errs.WithStack(err)
 	}
-	err = m.db.Save(obj).Error
+	err = m.db.Save(model).Error
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -145,7 +145,7 @@ func (s *userBlackBoxTest) TestUpdateUserWithoutClusterFails() {
 	require.NotEmpty(t, user.Cluster)
 	user.Cluster = ""
 	err = s.repo.Save(s.Ctx, user)
-	require.Nil(t, err)
+	require.NotNil(t, err)
 	u, err := s.repo.Load(s.Ctx, user.ID)
 	require.Nil(t, err)
 	require.NotEmpty(t, u.Cluster)

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -156,6 +156,21 @@ func (s *userBlackBoxTest) TestUpdateUserWithoutClusterFails() {
 	require.Nil(t, err)
 }
 
+func (s *userBlackBoxTest) TestUpdateToEmptyString() {
+	t := s.T()
+	resource.Require(t, resource.Database)
+	user := createAndLoadUser(s)
+
+	err := s.repo.Save(s.Ctx, user)
+	require.Nil(t, err)
+	user.Bio = ""
+	err = s.repo.Save(s.Ctx, user)
+	require.Nil(t, err)
+	u, err := s.repo.Load(s.Ctx, user.ID)
+	require.Nil(t, err)
+	require.Empty(t, u.Bio)
+}
+
 func createAndLoadUser(s *userBlackBoxTest) *account.User {
 	user := &account.User{
 		ID:       uuid.NewV4(),


### PR DESCRIPTION
Made changes such that gorm can update fields with blank values as well
It was treating them as not-changed before

Fixes(#186)