### PR TITLE
Delete account links from Keycloak

### DIFF
--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -202,37 +202,54 @@ func (rest *TestTokenStorageREST) TestDeleteExternalTokenIdentityNotPresent() {
 }
 
 func (rest *TestTokenStorageREST) TestDeleteExternalTokenGithubOK() {
-	rest.deleteExternalToken("https://github.com/a/b")
+	rest.deleteExternalTokenOK("https://github.com/a/b")
 }
 
 func (rest *TestTokenStorageREST) TestDeleteExternalTokenOSOOK() {
-	rest.deleteExternalToken("https://api.starter-us-east-2.openshift.com")
+	rest.deleteExternalTokenOK("https://api.starter-us-east-2.openshift.com")
 }
 
-func (rest *TestTokenStorageREST) deleteExternalToken(forResource string) {
+func (rest *TestTokenStorageREST) deleteExternalTokenOK(forResource string) {
+	rest.deleteExternalToken(forResource, 1, "unlinked")
+	rest.deleteExternalToken(forResource, 1, "positive")
+	rest.deleteExternalToken(forResource, 1, "internalError")
+	rest.deleteExternalToken(forResource, 3, "unlinked")
+	rest.deleteExternalToken(forResource, 3, "positive")
+	rest.deleteExternalToken(forResource, 3, "internalError")
+}
+
+func (rest *TestTokenStorageREST) deleteExternalToken(forResource string, numberOfTokens int, scenario string) {
 	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
 	require.Nil(rest.T(), err)
+	rest.mockKeycloakExternalTokenServiceClient.scenario = scenario
 	service, controller := rest.SecuredControllerWithIdentity(identity)
-
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.example.org"},
 	}
 	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), r, forResource)
 	require.Nil(rest.T(), err)
 
-	expectedToken := provider.ExternalToken{
-		ProviderID: providerConfig.ID(),
-		Scope:      providerConfig.Scopes(),
-		IdentityID: identity.ID,
-		Token:      "1234-from-db",
-	}
 	// OK is returned even if there is nothing to delete
 	test.DeleteTokenOK(rest.T(), service.Context, service, controller, forResource)
 
-	err = rest.externalTokenRepository.Create(context.Background(), &expectedToken)
+	for i := 0; i < numberOfTokens; i++ {
+		expectedToken := provider.ExternalToken{
+			ProviderID: providerConfig.ID(),
+			Scope:      providerConfig.Scopes(),
+			IdentityID: identity.ID,
+			Token:      "1234-from-db",
+		}
+		err = rest.externalTokenRepository.Create(context.Background(), &expectedToken)
+		require.Nil(rest.T(), err)
+	}
+	tokens, err := rest.db.ExternalTokens().LoadByProviderIDAndIdentityID(service.Context, providerConfig.ID(), identity.ID)
 	require.Nil(rest.T(), err)
+	require.Equal(rest.T(), numberOfTokens, len(tokens))
 
 	test.DeleteTokenOK(rest.T(), service.Context, service, controller, forResource)
+	tokens, err = rest.db.ExternalTokens().LoadByProviderIDAndIdentityID(service.Context, providerConfig.ID(), identity.ID)
+	require.Nil(rest.T(), err)
+	require.Empty(rest.T(), tokens)
 }
 
 type mockKeycloakExternalTokenServiceClient struct {
@@ -255,6 +272,16 @@ func (client mockKeycloakExternalTokenServiceClient) Get(ctx context.Context, ac
 		return nil, errs.NewInternalError(ctx, errors.New("Internal Server Error"))
 	}
 	return nil, errs.NewUnauthorizedError("user not linked")
+}
+
+func (client mockKeycloakExternalTokenServiceClient) Delete(ctx context.Context, keycloakExternalTokenURL string) error {
+	if client.scenario == "positive" {
+		return nil
+	}
+	if client.scenario == "internalError" {
+		return errs.NewInternalError(ctx, errors.New("Internal Server Error"))
+	}
+	return errs.NewUnauthorizedError("user not linked")
 }
 
 func positiveKCResponseGithub() *keycloak.KeycloakExternalTokenResponse {

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 	providerFactory := link.NewOauthProviderFactory(configuration)
 	linkService := link.NewLinkServiceWithFactory(configuration, appDB, providerFactory)
 	//providerFactory := link.NewOauthProviderFactory(configuration, appDB)
-	keycloakExternalTokenService := keycloak.NewKeycloakTokenServiceClient()
+	keycloakExternalTokenService := keycloak.NewKeycloakTokenServiceClient(configuration)
 	// Mount "token" controller
 	tokenCtrl := controller.NewTokenController(service, appDB, loginService, linkService, providerFactory, tokenManager, &keycloakExternalTokenService, configuration)
 	app.MountTokenController(service, tokenCtrl)

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func main() {
 	providerFactory := link.NewOauthProviderFactory(config)
 	linkService := link.NewLinkServiceWithFactory(config, appDB, providerFactory)
 	//providerFactory := link.NewOauthProviderFactory(configuration, appDB)
-	keycloakExternalTokenService := keycloak.NewKeycloakTokenServiceClient(configuration)
+	keycloakExternalTokenService := keycloak.NewKeycloakTokenServiceClient(config)
 	// Mount "token" controller
 	tokenCtrl := controller.NewTokenController(service, appDB, loginService, linkService, providerFactory, tokenManager, &keycloakExternalTokenService, config)
 	app.MountTokenController(service, tokenCtrl)


### PR DESCRIPTION
We should delete the Account links from Keycloak when deleting them via Auth API.

Extracted from https://github.com/fabric8-services/fabric8-auth/pull/155
