### PR TITLE
Disable KC AuthZ tests

### DIFF
--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -39,6 +39,9 @@ func init() {
 }
 
 func TestAuth(t *testing.T) {
+	if configuration.IsKeycloakTestsDisabled() {
+		t.Skip("Skipping Keycloak AuthZ tests")
+	}
 	resource.Require(t, resource.Remote)
 	suite.Run(t, new(TestAuthSuite))
 }

--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestPolicy(t *testing.T) {
+	if configuration.IsKeycloakTestsDisabled() {
+		t.Skip("Skipping Keycloak AuthZ tests")
+	}
 	resource.Require(t, resource.Remote)
 	suite.Run(t, new(TestPolicySuite))
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -89,6 +89,8 @@ const (
 	varWITURL                               = "wit.url"
 
 	varTenantServiceURL = "tenant.serviceurl"
+
+	varKeycloakTestsDisabled = "keycloak.tests.disabled"
 )
 
 type serviceAccountConfig struct {
@@ -343,6 +345,9 @@ func (c *ConfigurationData) setConfigDefaults() {
 
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)
+
+	// Keycloak Tests are disabled by default
+	c.v.SetDefault(varKeycloakTestsDisabled, true)
 }
 
 // GetPostgresHost returns the postgres host as set via default, config file, or environment variable
@@ -533,6 +538,10 @@ func (c *ConfigurationData) GetKeycloakRealm() string {
 		return devModeKeycloakRealm
 	}
 	return defaultKeycloakRealm
+}
+
+func (c *ConfigurationData) IsKeycloakTestsDisabled() bool {
+	return c.v.GetBool(varKeycloakTestsDisabled)
 }
 
 // GetKeycloakTestUserName returns the keycloak test user name used to obtain a test token (as set via config file or environment variable)


### PR DESCRIPTION
Keycloak test are very unstable. It seems to be a problem with our Keycloak. This PR introducing a new env var to control Keycloak tests. By default we disable AuthZ tests which call remote Keycloak.
As a long term solution we are working on moving our AuthZ functionality to Auth service instead of relaying unstable Keycloak.
