### PR TITLE
Allow to overwrite valid redirect URL in prod and staging env

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -213,8 +213,8 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 		msg := "TLS verification disabled"
 		c.appendDefaultConfigErrorMessage(&msg)
 	}
-	if c.GetValidRedirectURLs() != DefaultValidRedirectURLs {
-		msg := "default valid redirect URLs are NOT used"
+	if c.GetValidRedirectURLs() == ".*" {
+		msg := "no restrictions for valid redirect URLs"
 		c.appendDefaultConfigErrorMessage(&msg)
 	}
 	if c.defaultConfigurationError != nil {

--- a/controller/status_test.go
+++ b/controller/status_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	expectedDefaultConfDevModeErrorMessage  = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; developer Mode is enabled; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used; default valid redirect URLs are NOT used"
+	expectedDefaultConfDevModeErrorMessage  = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; developer Mode is enabled; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used; no restrictions for valid redirect URLs"
 	expectedDefaultConfProdModeErrorMessage = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used"
 )
 


### PR DESCRIPTION
Currently the deployment fails in preview because we have the valid redirect URL there is different from the default one and prod.