### PR TITLE
Add constraint for allowed user search query string

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -81,7 +81,6 @@ const (
 	varCacheControlCollaborators            = "cachecontrol.collaborators"
 	varCacheControlUser                     = "cachecontrol.user"
 	varUsersListLimit                       = "users.listlimit"
-	varMinimumUsersSearchQuerySize          = "users.search.min"
 	defaultConfigFile                       = "config.yaml"
 	varValidRedirectURLs                    = "redirect.valid"
 	varLogLevel                             = "log.level"
@@ -400,9 +399,6 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Max number of users returned when searching users
 	c.v.SetDefault(varUsersListLimit, 50)
 
-	// Min length of search query string
-	c.v.SetDefault(varMinimumUsersSearchQuerySize, 3)
-
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlUsers, "max-age=2")
 	c.v.SetDefault(varCacheControlCollaborators, "max-age=2")
@@ -515,11 +511,6 @@ func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
 // GetMaxUsersListLimit returns the max number of users returned when searching users
 func (c *ConfigurationData) GetMaxUsersListLimit() int {
 	return c.v.GetInt(varUsersListLimit)
-}
-
-// GetMinimumUserSearchQuerySize returns the minimum size of the search query
-func (c *ConfigurationData) GetMinimumUserSearchQuerySize() int {
-	return c.v.GetInt(varMinimumUsersSearchQuerySize)
 }
 
 // GetCacheControlUsers returns the value to set in the "Cache-Control" HTTP response header

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -81,6 +81,7 @@ const (
 	varCacheControlCollaborators            = "cachecontrol.collaborators"
 	varCacheControlUser                     = "cachecontrol.user"
 	varUsersListLimit                       = "users.listlimit"
+	varMinimumUsersSearchQuerySize          = "users.search.min"
 	defaultConfigFile                       = "config.yaml"
 	varValidRedirectURLs                    = "redirect.valid"
 	varLogLevel                             = "log.level"
@@ -399,6 +400,9 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Max number of users returned when searching users
 	c.v.SetDefault(varUsersListLimit, 50)
 
+	// Min length of search query string
+	c.v.SetDefault(varMinimumUsersSearchQuerySize, 3)
+
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlUsers, "max-age=2")
 	c.v.SetDefault(varCacheControlCollaborators, "max-age=2")
@@ -511,6 +515,11 @@ func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
 // GetMaxUsersListLimit returns the max number of users returned when searching users
 func (c *ConfigurationData) GetMaxUsersListLimit() int {
 	return c.v.GetInt(varUsersListLimit)
+}
+
+// GetMinimumUserSearchQuerySize returns the minimum size of the search query
+func (c *ConfigurationData) GetMinimumUserSearchQuerySize() int {
+	return c.v.GetInt(varMinimumUsersSearchQuerySize)
 }
 
 // GetCacheControlUsers returns the value to set in the "Cache-Control" HTTP response header

--- a/controller/search.go
+++ b/controller/search.go
@@ -15,6 +15,7 @@ import (
 type searchConfiguration interface {
 	GetHTTPAddress() string
 	GetMaxUsersListLimit() int
+	GetMinimumUserSearchQuerySize() int
 }
 
 // SearchController implements the search resource.
@@ -33,8 +34,8 @@ func NewSearchController(service *goa.Service, db application.DB, configuration 
 func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 
 	q := ctx.Q
-	if q == "" {
-		return ctx.BadRequest(goa.ErrBadRequest(fmt.Errorf("empty search query not allowed")))
+	if len(q) < c.configuration.GetMinimumUserSearchQuerySize() {
+		return ctx.BadRequest(goa.ErrBadRequest(fmt.Errorf("search query should be longer")))
 	}
 
 	var result []account.Identity

--- a/controller/search.go
+++ b/controller/search.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/fabric8-services/fabric8-auth/app"
@@ -34,7 +35,7 @@ func NewSearchController(service *goa.Service, db application.DB, configuration 
 func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 
 	q := ctx.Q
-	if len(q) < c.configuration.GetMinimumUserSearchQuerySize() {
+	if len(q) == 0 {
 		return ctx.BadRequest(goa.ErrBadRequest(fmt.Errorf("search query should be longer")))
 	}
 
@@ -45,6 +46,8 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 	exceeded := false
 	offset, limit := computePagingLimits(ctx.PageOffset, ctx.PageLimit)
 
+	r, err := regexp.Compile(`\w`) // check for A-Z a-z 0-9
+
 	searchLimit := limit
 	// Don't return more users than allowed by configuration
 	if offset >= c.configuration.GetMaxUsersListLimit() {
@@ -53,15 +56,17 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 		searchLimit = c.configuration.GetMaxUsersListLimit() - offset
 	}
 
-	err = application.Transactional(c.db, func(appl application.Application) error {
-		result, count, err = appl.Identities().Search(ctx, q, offset, searchLimit)
-		return err
-	})
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"err": err,
-		}, "unable to run search query on users.")
-		return jsonapi.JSONErrorResponse(ctx, err)
+	if r.MatchString(q) {
+		err = application.Transactional(c.db, func(appl application.Application) error {
+			result, count, err = appl.Identities().Search(ctx, q, offset, searchLimit)
+			return err
+		})
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err": err,
+			}, "unable to run search query on users.")
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
 	}
 
 	if exceeded {
@@ -110,4 +115,5 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 	setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+q)
 
 	return ctx.OK(&response)
+
 }

--- a/controller/search.go
+++ b/controller/search.go
@@ -16,7 +16,6 @@ import (
 type searchConfiguration interface {
 	GetHTTPAddress() string
 	GetMaxUsersListLimit() int
-	GetMinimumUserSearchQuerySize() int
 }
 
 // SearchController implements the search resource.

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -58,6 +58,9 @@ func (s *TestSearchUserSearch) TestUsersSearchOK() {
 	defer s.cleanTestData(idents)
 
 	tests := []okScenarioUserSearchTest{
+		{"Without A-Z ,a-z or 0-9", userSearchTestArgs{s.offset(0), s.limit(10), "."}, userSearchTestExpects{s.totalCount(0)}},
+		{"Without A-Z ,a-z or 0-9", userSearchTestArgs{s.offset(0), s.limit(10), ".@"}, userSearchTestExpects{s.totalCount(0)}},
+		{"Without A-Z ,a-z or 0-9", userSearchTestArgs{s.offset(0), s.limit(10), "a@"}, userSearchTestExpects{s.totalCountAtLeast(1)}},
 		{"With lowercase fullname query", userSearchTestArgs{s.offset(0), s.limit(10), "x_test_ab"}, userSearchTestExpects{s.totalCountAtLeast(3)}},
 		{"With uppercase fullname query", userSearchTestArgs{s.offset(0), s.limit(10), "X_TEST_AB"}, userSearchTestExpects{s.totalCountAtLeast(3)}},
 		{"With uppercase email query", userSearchTestArgs{s.offset(0), s.limit(10), "EMAIL_X_TEST_AB"}, userSearchTestExpects{s.totalCountAtLeast(1)}},
@@ -90,10 +93,6 @@ func (s *TestSearchUserSearch) TestUsersSearchBadRequest() {
 		userSearchTestArgs userSearchTestArgs
 	}{
 		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), ""}},
-		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "."}},
-		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "1"}},
-		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "m"}},
-		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "@."}},
 	}
 
 	for _, tt := range tests {

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -90,10 +90,10 @@ func (s *TestSearchUserSearch) TestUsersSearchBadRequest() {
 		userSearchTestArgs userSearchTestArgs
 	}{
 		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), ""}},
-		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "."}},
-		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "1"}},
-		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "m"}},
-		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "@."}},
+		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "."}},
+		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "1"}},
+		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "m"}},
+		{"with query size less than the allowed minimum", userSearchTestArgs{s.offset(0), s.limit(10), "@."}},
 	}
 
 	for _, tt := range tests {

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -90,6 +90,10 @@ func (s *TestSearchUserSearch) TestUsersSearchBadRequest() {
 		userSearchTestArgs userSearchTestArgs
 	}{
 		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), ""}},
+		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "."}},
+		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "1"}},
+		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "m"}},
+		{"with empty query", userSearchTestArgs{s.offset(0), s.limit(10), "@."}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When user is searched using the API:
this change will ensure that the search string contains at least 1 character in the set A-Z,a-z,0-9
`https://auth.openshift.io/api/search/users?q=@.`  not allowed.
`https://auth.openshift.io/api/search/users?q=bose@` allowed.