### PR TITLE
Get rid of configuration dependency in logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -8,8 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/fabric8-services/fabric8-auth/configuration"
-
 	"github.com/goadesign/goa"
 	log "github.com/sirupsen/logrus"
 )
@@ -307,12 +305,9 @@ func extractCallerDetails() (file string, line int, pkg string, function string,
 // in tests and as default static initialization of the log. If the ENV variable
 // is not set then the log level is Info.
 func getDefaultLogLevel() log.Level {
-	config, err := configuration.GetConfigurationData()
-	if err != nil {
-		log.Errorf("error getting configuration data")
-	}
+	envVar := os.Getenv("AUTH_LOG_LEVEL")
 
-	logLevel, err := log.ParseLevel(config.GetLogLevel())
+	logLevel, err := log.ParseLevel(envVar)
 	if err != nil {
 		log.Warnf("unable to parse log level configuration error: %q", err)
 		return log.InfoLevel // reset to INFO


### PR DESCRIPTION
Configuration package includes confbindata.go generated my `make`. So, we can't re-use any code which depends on configuration package in our downstream repos (WIT, tenant, etc). confbindata.go is not available there.
Currently WIT uses design and token packages from Auth. So removing log->configuraton dependency will fix the WIT->Auth/token dependency.