### PR TITLE
Update existing Keycloak users when registering new users

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -234,7 +234,7 @@ func (c *TokenController) Retrieve(ctx *app.RetrieveTokenContext) error {
 	}
 
 	osConfig, ok := providerConfig.(*link.OpenShiftIdentityProvider)
-	if ok && token.IsSpecificServiceAccount(ctx, []string{"fabric8-oso-proxy", "fabric8-tenant"}) {
+	if ok && token.IsSpecificServiceAccount(ctx, "fabric8-oso-proxy", "fabric8-tenant") {
 		// This is a request from OSO proxy or tenant service to obtain a cluster wide token
 		clusterToken := app.ExternalToken{
 			Scope:       "<unknown>",

--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -132,7 +132,7 @@ func (rest *TestTokenREST) checkServiceAccountCredentials(name string, id string
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 	ctx := goajwt.WithJWT(context.Background(), jwtToken)
 	assert.True(rest.T(), token.IsServiceAccount(ctx))
-	assert.True(rest.T(), token.IsSpecificServiceAccount(ctx, []string{name}))
+	assert.True(rest.T(), token.IsSpecificServiceAccount(ctx, name))
 }
 
 func validateToken(t *testing.T, token *app.AuthToken, controler *TokenController) {

--- a/controller/users.go
+++ b/controller/users.go
@@ -123,7 +123,7 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 			"err":      err,
 			"username": ctx.Payload.Data.Attributes.Username,
 		}, "failed to create user in keycloak")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	log.Info(ctx, map[string]interface{}{
 		"keycloak_user_id": *keycloakUserID,

--- a/controller/users.go
+++ b/controller/users.go
@@ -90,10 +90,18 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 // Create creates a user when requested using a service account token
 func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 
-	isSvcAccount := token.IsSpecificServiceAccount(ctx, []string{"online-registration"})
+	isSvcAccount := token.IsSpecificServiceAccount(ctx, "online-registration")
 	if !isSvcAccount {
 		log.Error(ctx, nil, "The account is not an authorized service account allowed to create a new user")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("account not authorized to create users."))
+	}
+
+	userExists, err := c.userExistsInDB(ctx, ctx.Payload.Data.Attributes.Email, ctx.Payload.Data.Attributes.Username)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+	}
+	if userExists {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewVersionConflictError("user with such email or username already exists"))
 	}
 
 	tokenEndpoint, err := c.config.GetKeycloakEndpointToken(ctx.RequestData)
@@ -454,7 +462,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			if !isValid {
 				return errors.NewBadParameterError("email", *updatedEmail).Expected("valid email")
 			}
-			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
+			isUnique, err := isEmailUnique(ctx, appl, *updatedEmail, *user)
 			if err != nil {
 				return errs.Wrap(err, fmt.Sprintf("error updating identitity with id %s and user with id %s", identity.ID, identity.UserID.UUID))
 			}
@@ -476,7 +484,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			if identity.RegistrationCompleted {
 				return errors.NewForbiddenError(fmt.Sprintf("username cannot be updated more than once for identity id %s ", *id))
 			}
-			isUnique, err := isUsernameUnique(appl, *updatedUserName, *identity)
+			isUnique, err := isUsernameUnique(ctx, appl, *updatedUserName, *identity)
 			if err != nil {
 				return errs.Wrap(err, fmt.Sprintf("error updating identitity with id %s and user with id %s", identity.ID, identity.UserID.UUID))
 			}
@@ -671,10 +679,10 @@ func isUsernameValid(username string) bool {
 	return false
 }
 
-func isUsernameUnique(appl application.Application, username string, identity account.Identity) (bool, error) {
+func isUsernameUnique(ctx context.Context, appl application.Application, username string, identity account.Identity) (bool, error) {
 	usersWithSameUserName, err := appl.Identities().Query(account.IdentityFilterByUsername(username), account.IdentityFilterByProviderType(account.KeycloakIDP))
 	if err != nil {
-		log.Error(nil, map[string]interface{}{
+		log.Error(ctx, map[string]interface{}{
 			"user_name": username,
 			"err":       err,
 		}, "error fetching users with username filter")
@@ -688,13 +696,13 @@ func isUsernameUnique(appl application.Application, username string, identity ac
 	return true, nil
 }
 
-func isEmailUnique(appl application.Application, email string, user account.User) (bool, error) {
+func isEmailUnique(ctx context.Context, appl application.Application, email string, user account.User) (bool, error) {
 	usersWithSameEmail, err := appl.Users().Query(account.UserFilterByEmail(email))
 	if err != nil {
-		log.Error(nil, map[string]interface{}{
+		log.Error(ctx, map[string]interface{}{
 			"email": email,
 			"err":   err,
-		}, "error fetching identities with email filter")
+		}, "error fetching users with email filter")
 		return false, err
 	}
 	for _, u := range usersWithSameEmail {
@@ -703,6 +711,43 @@ func isEmailUnique(appl application.Application, email string, user account.User
 		}
 	}
 	return true, nil
+}
+
+func (c *UsersController) userExistsInDB(ctx context.Context, email string, username string) (bool, error) {
+	var exists bool
+	err := application.Transactional(c.db, func(appl application.Application) error {
+		users, err := appl.Users().Query(account.UserFilterByEmail(email))
+		if err != nil {
+			return err
+		}
+		if len(users) > 0 {
+			// User with the same email exists
+			exists = true
+			return nil
+		}
+		identities, err := appl.Identities().Query(account.IdentityFilterByUsername(username), account.IdentityFilterByProviderType(account.KeycloakIDP))
+		if err != nil {
+			return err
+		}
+		for _, identity := range identities {
+			if identity.UserID.Valid {
+				// A Keycloak Identity which is assigned to a user exists
+				exists = true
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"email":    email,
+			"username": username,
+			"err":      err,
+		}, "unable to check if user exists")
+	}
+	return exists, err
 }
 
 // List runs the list action.

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -1006,9 +1006,9 @@ func (d *dummyUserProfileService) Get(ctx context.Context, accessToken string, k
 	return d.dummyGetResponse, nil
 }
 
-func (d *dummyUserProfileService) Create(ctx context.Context, keycloakUserProfile *login.KeytcloakUserRequest, accessToken string, keycloakProfileURL string) (*string, error) {
+func (d *dummyUserProfileService) CreateOrUpdate(ctx context.Context, keycloakUserProfile *login.KeytcloakUserRequest, accessToken string, keycloakProfileURL string) (*string, bool, error) {
 	url := "https://someurl/pathinkeycloakurl/" + uuid.NewV4().String()
-	return &url, nil
+	return &url, true, nil
 }
 
 func (d *dummyUserProfileService) SetDummyGetResponse(dummyGetResponse *login.KeycloakUserProfileResponse) {

--- a/design/account.go
+++ b/design/account.go
@@ -143,7 +143,7 @@ var _ = a.Resource("users", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
-
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
 	a.Action("update", func() {

--- a/login/profile.go
+++ b/login/profile.go
@@ -159,7 +159,7 @@ func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.C
 			return nil, false, errors.NewUnauthorizedError(bodyString)
 		}
 
-		return nil, true, errors.NewInternalError(ctx, errs.Errorf("received a non-200 response %s while creating keycloak user :  %s", resp.Status, keycloakAdminUserAPIURL))
+		return nil, false, errors.NewInternalError(ctx, errs.Errorf("received a non-200 response %s while creating keycloak user :  %s", resp.Status, keycloakAdminUserAPIURL))
 	}
 
 	createdUserURL, err := resp.Location()
@@ -183,7 +183,7 @@ func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.C
 		"user_url":          createdUserURLString,
 	}, "Successfully created Keycloak user")
 
-	return &createdUserURLString, false, nil
+	return &createdUserURLString, true, nil
 }
 
 func (userProfileClient *KeycloakUserProfileClient) updateAsAdmin(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, error) {

--- a/login/profile.go
+++ b/login/profile.go
@@ -230,6 +230,11 @@ func (userProfileClient *KeycloakUserProfileClient) updateAsAdmin(ctx context.Co
 			"keycloak_user_profile_url": keycloakAdminUserAPIURL,
 			"email":                     *keycloakUserRequest.Email,
 		}, "Unable to update Keycloak user")
+
+		// new username, but existing email can cause this.
+		if resp.StatusCode == 409 {
+			return nil, errors.NewVersionConflictError(fmt.Sprintf("user with the same email %s already exists", *keycloakUserRequest.Email))
+		}
 		return nil, errs.Errorf("received a non-2xx response %s while creating keycloak user:  %s", resp.Status, keycloakAdminUserAPIURL)
 	}
 	log.Info(ctx, map[string]interface{}{

--- a/login/profile.go
+++ b/login/profile.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/fabric8-services/fabric8-auth/errors"
@@ -83,7 +84,7 @@ func NewKeycloakUserProfile(firstName *string, lastName *string, email *string, 
 type UserProfileService interface {
 	Update(ctx context.Context, conkeycloakUserProfile *KeycloakUserProfile, accessToken string, keycloakProfileURL string) error
 	Get(ctx context.Context, accessToken string, keycloakProfileURL string) (*KeycloakUserProfileResponse, error)
-	Create(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, error)
+	CreateOrUpdate(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, bool, error)
 }
 
 // KeycloakUserProfileClient describes the interface between platform and Keycloak User profile service.
@@ -98,16 +99,18 @@ func NewKeycloakUserProfileClient() *KeycloakUserProfileClient {
 	}
 }
 
-// Create creates the user in Keycloak using the admin REST API
-func (userProfileClient *KeycloakUserProfileClient) Create(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, error) {
+// CreateOrUpdate creates the user in Keycloak using the admin REST API
+// If the user already exists then the user will be updated
+// Returns true if a new user has been created and false if the existing user has been updated
+func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, bool, error) {
 	body, err := json.Marshal(keycloakUserRequest)
 	if err != nil {
-		return nil, errors.NewInternalError(ctx, err)
+		return nil, false, errors.NewInternalError(ctx, err)
 	}
 
 	req, err := http.NewRequest("POST", keycloakAdminUserAPIURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, errors.NewInternalError(ctx, err)
+		return nil, false, errors.NewInternalError(ctx, err)
 	}
 	req.Header.Add("Authorization", "Bearer "+protectedAccessToken)
 	req.Header.Add("Content-Type", "application/json")
@@ -119,13 +122,30 @@ func (userProfileClient *KeycloakUserProfileClient) Create(ctx context.Context, 
 			"keycloak_user_profile_url": keycloakAdminUserAPIURL,
 			"err": err,
 		}, "Unable to create Keycloak user")
-		return nil, errors.NewInternalError(ctx, err)
+		return nil, false, errors.NewInternalError(ctx, err)
 	} else if resp != nil {
 		defer resp.Body.Close()
 	}
 
 	bodyString := rest.ReadBody(resp.Body)
 	if resp.StatusCode != 201 {
+		if resp.StatusCode == 409 {
+			// User exists. Update the user.
+			log.Info(ctx, map[string]interface{}{
+				"response_status":           resp.Status,
+				"response_body":             bodyString,
+				"keycloak_user_profile_url": keycloakAdminUserAPIURL,
+			}, "User already exists in Keycloak. Will try to update")
+			createdUserURLString, err := userProfileClient.updateAsAdmin(ctx, keycloakUserRequest, protectedAccessToken, keycloakAdminUserAPIURL)
+			if err != nil {
+				return nil, false, err
+			}
+			log.Info(ctx, map[string]interface{}{
+				"keycloak_user_url": keycloakAdminUserAPIURL,
+				"user_url":          createdUserURLString,
+			}, "Successfully updated Keycloak user user")
+			return createdUserURLString, false, nil
+		}
 
 		log.Error(ctx, map[string]interface{}{
 			"response_status":           resp.Status,
@@ -136,23 +156,11 @@ func (userProfileClient *KeycloakUserProfileClient) Create(ctx context.Context, 
 		// Observed this error code when trying to create user
 		// with a token belonging to a different realm.
 		if resp.StatusCode == 403 {
-			return nil, errors.NewUnauthorizedError(bodyString)
+			return nil, false, errors.NewUnauthorizedError(bodyString)
 		}
 
-		// Observed this error code when trying to create user with an existing username.
-		if resp.StatusCode == 409 {
-			// This isn't version conflict really,
-			// but helps us generate the final response code.
-			return nil, errors.NewVersionConflictError(fmt.Sprintf("user with username %s / email %s already exists", *keycloakUserRequest.Username, *keycloakUserRequest.Email))
-		}
-
-		return nil, errors.NewInternalError(ctx, errs.Errorf("received a non-200 response %s while creating keycloak user :  %s", resp.Status, keycloakAdminUserAPIURL))
+		return nil, true, errors.NewInternalError(ctx, errs.Errorf("received a non-200 response %s while creating keycloak user :  %s", resp.Status, keycloakAdminUserAPIURL))
 	}
-	log.Info(ctx, map[string]interface{}{
-		"response_status":           resp.Status,
-		"response_body":             bodyString,
-		"keycloak_user_profile_url": keycloakAdminUserAPIURL,
-	}, "Successfully create Keycloak user")
 
 	createdUserURL, err := resp.Location()
 	if err != nil {
@@ -160,22 +168,138 @@ func (userProfileClient *KeycloakUserProfileClient) Create(ctx context.Context, 
 			"keycloak_user_url": keycloakAdminUserAPIURL,
 			"err":               err,
 		}, "Unable to create Keycloak user")
-		return nil, errors.NewInternalError(ctx, err)
+		return nil, false, errors.NewInternalError(ctx, err)
 	}
 	if createdUserURL == nil {
 		log.Error(ctx, map[string]interface{}{
 			"keycloak_user_url": keycloakAdminUserAPIURL,
 		}, "Unable to create Keycloak user")
-		return nil, errors.NewInternalError(ctx, errs.Errorf("user creation in keycloak might have failed."))
+		return nil, false, errors.NewInternalError(ctx, errs.Errorf("user creation in keycloak might have failed."))
 	}
 
 	createdUserURLString := createdUserURL.String()
 	log.Info(ctx, map[string]interface{}{
 		"keycloak_user_url": keycloakAdminUserAPIURL,
 		"user_url":          createdUserURLString,
-	}, "Successfully created Keycloak user user")
+	}, "Successfully created Keycloak user")
 
-	return &createdUserURLString, nil
+	return &createdUserURLString, false, nil
+}
+
+func (userProfileClient *KeycloakUserProfileClient) updateAsAdmin(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, error) {
+	user, err := userProfileClient.loadUser(ctx, *keycloakUserRequest.Email, protectedAccessToken, keycloakAdminUserAPIURL)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		log.Error(ctx, map[string]interface{}{
+			"keycloak_user_profile_url": keycloakAdminUserAPIURL,
+			"email":                     *keycloakUserRequest.Email,
+		}, "Unable to update Keycloak user because user not found")
+		return nil, errs.New("unable to update Keycloak user because user not found")
+	}
+	body, err := json.Marshal(keycloakUserRequest)
+	if err != nil {
+		return nil, errors.NewInternalError(ctx, err)
+	}
+	userURL := keycloakAdminUserAPIURL + "/" + *user.ID
+	req, err := http.NewRequest("PUT", userURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+protectedAccessToken)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := userProfileClient.client.Do(req)
+
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"keycloak_user_profile_url": keycloakAdminUserAPIURL,
+			"email":                     *keycloakUserRequest.Email,
+			"err":                       err,
+		}, "Unable to update Keycloak user")
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyString := rest.ReadBody(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Error(ctx, map[string]interface{}{
+			"response_status":           resp.Status,
+			"response_body":             bodyString,
+			"keycloak_user_profile_url": keycloakAdminUserAPIURL,
+			"email":                     *keycloakUserRequest.Email,
+		}, "Unable to update Keycloak user")
+		return nil, errs.Errorf("received a non-2xx response %s while creating keycloak user:  %s", resp.Status, keycloakAdminUserAPIURL)
+	}
+	log.Info(ctx, map[string]interface{}{
+		"response_status":           resp.Status,
+		"response_body":             bodyString,
+		"keycloak_user_profile_url": keycloakAdminUserAPIURL,
+		"email":                     *keycloakUserRequest.Email,
+	}, "Successfully updated Keycloak user")
+
+	return &userURL, nil
+}
+
+// loadUser search for a user by email. Return nil if no user found.
+func (userProfileClient *KeycloakUserProfileClient) loadUser(ctx context.Context, email string, protectedAccessToken string, keycloakAdminUserAPIURL string) (*KeycloakUserProfile, error) {
+	validEmail, err := rest.ValidateEmail(email)
+	if err != nil {
+		return nil, err
+	}
+	if !validEmail {
+		log.Error(ctx, map[string]interface{}{
+			"email": email,
+		}, "invalid email")
+		return nil, errs.New("invalid email: " + email)
+	}
+	kcURL, err := rest.AddParam(keycloakAdminUserAPIURL, "email", email)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("GET", kcURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+protectedAccessToken)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := userProfileClient.client.Do(req)
+
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"url": kcURL,
+			"err": err,
+		}, "Unable to load Keycloak user")
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		bodyString := string(body)
+		log.Error(ctx, map[string]interface{}{
+			"response_status": resp.Status,
+			"response_body":   bodyString,
+			"url":             kcURL,
+		}, "Unable to load Keycloak user")
+
+		return nil, errors.NewInternalError(ctx, errs.Errorf("received a non-200 response %s while loading keycloak user :  %s", resp.Status, kcURL))
+	}
+
+	var users []KeycloakUserProfile
+	err = json.Unmarshal(body, &users)
+	if err != nil {
+		return nil, err
+	}
+	if len(users) > 0 {
+		return &users[0], nil
+	}
+	return nil, nil
 }
 
 // Update updates the user profile information in Keycloak

--- a/login/profile_user_blackbox_test.go
+++ b/login/profile_user_blackbox_test.go
@@ -128,6 +128,41 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakAddUser() {
 	err = s.idpLinkService.Create(context.Background(), &linkRequest, s.protectedAccessToken, linkURL)
 	require.Nil(s.T(), err)
 
+	userURL = s.updateExistingUser(&testKeycloakUserData)
+}
+
+func (s *ProfileUserBlackBoxTest) TestKeycloakUpdateExistingUser() {
+	// UPDATE the user profile
+
+	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
+	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
+	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.NewV4().String()
+	testURL := "updatedURLNew" + uuid.NewV4().String()
+	testImageURL := "updatedBio" + uuid.NewV4().String()
+	testUserName := "sbosetestusercreate" + uuid.NewV4().String()
+	testEnabled := true
+	testEmailVerified := true
+
+	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{
+		login.ImageURLAttributeName: []string{testImageURL},
+		login.BioAttributeName:      []string{testBio},
+		login.URLAttributeName:      []string{testURL},
+	}
+
+	testKeycloakUserData := login.KeytcloakUserRequest{
+		Username:      &testUserName,
+		Enabled:       &testEnabled,
+		EmailVerified: &testEmailVerified,
+		FirstName:     &testFirstName,
+		LastName:      &testLastName,
+		Email:         &testEmail,
+		Attributes:    testKeycloakUserProfileAttributes,
+	}
+
+	s.createUser(&testKeycloakUserData)
+	s.updateExistingUser(&testKeycloakUserData)
+
 }
 
 func (s *ProfileUserBlackBoxTest) createUser(userProfile *login.KeytcloakUserRequest) *string {
@@ -135,5 +170,13 @@ func (s *ProfileUserBlackBoxTest) createUser(userProfile *login.KeytcloakUserReq
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), url)
 	require.True(s.T(), created)
+	return url
+}
+
+func (s *ProfileUserBlackBoxTest) updateExistingUser(userProfile *login.KeytcloakUserRequest) *string {
+	url, created, err := s.profileService.CreateOrUpdate(context.Background(), userProfile, s.protectedAccessToken, s.userAPIFOrAdminURL)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), url)
+	require.False(s.T(), created)
 	return url
 }

--- a/login/profile_user_blackbox_test.go
+++ b/login/profile_user_blackbox_test.go
@@ -131,8 +131,9 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakAddUser() {
 }
 
 func (s *ProfileUserBlackBoxTest) createUser(userProfile *login.KeytcloakUserRequest) *string {
-	url, err := s.profileService.Create(context.Background(), userProfile, s.protectedAccessToken, s.userAPIFOrAdminURL)
+	url, created, err := s.profileService.CreateOrUpdate(context.Background(), userProfile, s.protectedAccessToken, s.userAPIFOrAdminURL)
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), url)
+	require.True(s.T(), created)
 	return url
 }

--- a/login/profile_user_whitebox_test.go
+++ b/login/profile_user_whitebox_test.go
@@ -1,0 +1,121 @@
+package login
+
+import (
+	"context"
+	"github.com/fabric8-services/fabric8-auth/auth"
+	"net/http"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/login/link"
+	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+
+	"github.com/goadesign/goa"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProfileUserWhiteboxTest struct {
+	testsuite.RemoteTestSuite
+	profileService       KeycloakUserProfileClient
+	loginService         *KeycloakOAuthProvider
+	idpLinkService       link.KeycloakIDPService
+	protectedAccessToken string
+	userAPIFOrAdminURL   string
+	tokenEndpoint        string
+}
+
+func TestRunProfileUserWhiteboxTest(t *testing.T) {
+	suite.Run(t, &ProfileUserWhiteboxTest{RemoteTestSuite: testsuite.NewRemoteTestSuite()})
+}
+
+// SetupSuite overrides the RemoteTestSuite's function but calls it before doing anything else
+// The SetupSuite method will run before the tests in the suite are run.
+func (s *ProfileUserWhiteboxTest) SetupSuite() {
+	s.RemoteTestSuite.SetupSuite()
+	if s.Config.IsKeycloakTestsDisabled() {
+		s.T().Skip("Skipping Keycloak tests")
+	}
+	var err error
+	keycloakUserProfileService := NewKeycloakUserProfileClient()
+	s.profileService = *keycloakUserProfileService
+
+	s.idpLinkService = link.NewKeycloakIDPServiceClient()
+
+	r := &goa.RequestData{
+		Request: &http.Request{Host: "api.example.org"},
+	}
+
+	s.tokenEndpoint, err = s.Config.GetKeycloakEndpointToken(r)
+	assert.Nil(s.T(), err)
+
+	// http://sso.prod-preview.openshift.io/auth/admin/realms/fabric8/users"
+	s.userAPIFOrAdminURL, err = s.Config.GetKeycloakEndpointUsers(r)
+	assert.Nil(s.T(), err)
+
+	token, err := s.generateProtectedAccessToken()
+	assert.Nil(s.T(), err)
+	require.NotNil(s.T(), token)
+	s.protectedAccessToken = *token
+}
+
+func (s *ProfileUserWhiteboxTest) generateProtectedAccessToken() (*string, error) {
+	clientID := s.Config.GetKeycloakClientID()
+	clientSecret := s.Config.GetKeycloakSecret()
+	token, err := auth.GetProtectedAPIToken(context.Background(), s.tokenEndpoint, clientID, clientSecret)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), token)
+
+	return &token, err
+}
+
+func (s *ProfileUserWhiteboxTest) TestPATGenerated() {
+	assert.NotEmpty(s.T(), s.protectedAccessToken)
+}
+
+func (s *ProfileUserWhiteboxTest) TestKeycloakLoadUser() {
+
+	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
+	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
+	testEmail := "updatedemail" + uuid.NewV4().String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.NewV4().String()
+	testURL := "updatedURLNew" + uuid.NewV4().String()
+	testImageURL := "updatedBio" + uuid.NewV4().String()
+	testUserName := "sbosetestusercreate" + uuid.NewV4().String()
+	testEnabled := true
+	testEmailVerified := true
+
+	testKeycloakUserProfileAttributes := &KeycloakUserProfileAttributes{
+		ImageURLAttributeName: []string{testImageURL},
+		BioAttributeName:      []string{testBio},
+		URLAttributeName:      []string{testURL},
+	}
+
+	testKeycloakUserData := KeytcloakUserRequest{
+		Username:      &testUserName,
+		Enabled:       &testEnabled,
+		EmailVerified: &testEmailVerified,
+		FirstName:     &testFirstName,
+		LastName:      &testLastName,
+		Email:         &testEmail,
+		Attributes:    testKeycloakUserProfileAttributes,
+	}
+
+	s.createUser(&testKeycloakUserData)
+
+	retrievedUserProfile, err := s.profileService.loadUser(context.Background(), testUserName, s.protectedAccessToken, s.userAPIFOrAdminURL)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), retrievedUserProfile)
+	require.Equal(s.T(), testEmail, *retrievedUserProfile.Email)
+	require.Equal(s.T(), testUserName, *retrievedUserProfile.Username)
+
+}
+
+func (s *ProfileUserWhiteboxTest) createUser(userProfile *KeytcloakUserRequest) *string {
+	url, created, err := s.profileService.CreateOrUpdate(context.Background(), userProfile, s.protectedAccessToken, s.userAPIFOrAdminURL)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), url)
+	require.True(s.T(), created)
+	return url
+}

--- a/rest/url.go
+++ b/rest/url.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/fabric8-services/fabric8-auth/errors"
 
-	"github.com/goadesign/goa"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+
+	"github.com/goadesign/goa"
 )
 
 // AbsoluteURL prefixes a relative URL with absolute address
@@ -46,4 +49,32 @@ func ReadBody(body io.ReadCloser) string {
 func CloseResponse(response *http.Response) {
 	ioutil.ReadAll(response.Body)
 	response.Body.Close()
+}
+
+// ValidateEmail return true if the string is a valid email address
+// This is a very simple validation. It just checks if there is @ and dot in the address
+func ValidateEmail(email string) (bool, error) {
+	// .+@.+\..+
+	return regexp.MatchString(".+@.+\\..+", email)
+}
+
+// AddParam adds a parameter to URL
+func AddParam(urlString string, paramName string, paramValue string) (string, error) {
+	return AddParams(urlString, map[string]string{paramName: paramValue})
+}
+
+// AddParams adds parameters to URL
+func AddParams(urlString string, params map[string]string) (string, error) {
+	parsedURL, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	parameters := url.Values{}
+	for k, v := range params {
+		parameters.Add(k, v)
+	}
+	parsedURL.RawQuery = parameters.Encode()
+
+	return parsedURL.String(), nil
 }

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"net/http"
+	"net/url"
 
 	"github.com/fabric8-services/fabric8-auth/resource"
 	"github.com/goadesign/goa"
@@ -95,9 +96,20 @@ func TestAddParamsSuccess(t *testing.T) {
 		"param2": "b",
 		"param3": "https://www.redhat.com",
 	}
-	generatedURL, err := AddParams("https://openshift.io", testMap)
+	testHost := "openshift.io"
+	generatedURLString, err := AddParams("https://"+testHost, testMap)
 	require.NoError(t, err)
-	assert.Equal(t, "https://openshift.io?param1=a&param2=b&param3=https%3A%2F%2Fwww.redhat.com", generatedURL)
+
+	generateURL, err := url.Parse(generatedURLString)
+	require.NoError(t, err)
+
+	assert.Equal(t, testHost, generateURL.Host)
+	assert.Equal(t, "https", generateURL.Scheme)
+
+	m, _ := url.ParseQuery(generateURL.RawQuery)
+	for k, v := range testMap {
+		assert.Equal(t, v, m[k][0])
+	}
 }
 
 func TestAddParamSuccess(t *testing.T) {

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -67,3 +67,44 @@ func TestReplaceDomainPrefixInTooShortHostFails(t *testing.T) {
 	_, err := ReplaceDomainPrefix("org", "sso")
 	assert.NotNil(t, err)
 }
+
+func TestValidateEmailSuccess(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	isValid, err := ValidateEmail("a@a.com")
+	require.NoError(t, err)
+	require.True(t, isValid)
+}
+
+func TestValidateEmailFail(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	isValid, err := ValidateEmail("a.a@com")
+	require.NoError(t, err)
+	require.False(t, isValid)
+}
+
+func TestAddParamsSuccess(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	testMap := map[string]string{
+		"param1": "a",
+		"param2": "b",
+		"param3": "https://www.redhat.com",
+	}
+	generatedURL, err := AddParams("https://openshift.io", testMap)
+	require.NoError(t, err)
+	assert.Equal(t, "https://openshift.io?param1=a&param2=b&param3=https%3A%2F%2Fwww.redhat.com", generatedURL)
+}
+
+func TestAddParamSuccess(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	generatedURL, err := AddParam("https://openshift.io", "param1", "a")
+	require.NoError(t, err)
+	assert.Equal(t, "https://openshift.io?param1=a", generatedURL)
+}

--- a/token/token.go
+++ b/token/token.go
@@ -441,7 +441,7 @@ func (mgm *tokenManager) GenerateUnsignedServiceAccountToken(req *goa.RequestDat
 
 // IsSpecificServiceAccount checks if the request is done by a service account listed in the names param
 // based on the JWT Token provided in context
-func IsSpecificServiceAccount(ctx context.Context, names []string) bool {
+func IsSpecificServiceAccount(ctx context.Context, names ...string) bool {
 	accountName, ok := extractServiceAccountName(ctx)
 	if !ok {
 		return false

--- a/token/token_whitebox_test.go
+++ b/token/token_whitebox_test.go
@@ -83,7 +83,7 @@ func (s *TestWhiteboxTokenSuite) TestServiceAccountGeneratedOK() {
 
 func (s *TestWhiteboxTokenSuite) TestNotAServiceAccountFails() {
 	ctx := createInvalidSAContext()
-	assert.False(s.T(), IsSpecificServiceAccount(ctx, []string{"someName"}))
+	assert.False(s.T(), IsSpecificServiceAccount(ctx, "someName"))
 }
 
 func (s *TestWhiteboxTokenSuite) TestIsServiceAccountFails() {
@@ -120,11 +120,11 @@ func (s *TestWhiteboxTokenSuite) checkServiceAccountToken(rawToken string, saID 
 	require.Equal(s.T(), "http://example.com", claims["iss"])
 
 	ctx := goajwt.WithJWT(context.Background(), token)
-	assert.True(s.T(), IsSpecificServiceAccount(ctx, []string{saName}))
-	assert.True(s.T(), IsSpecificServiceAccount(ctx, []string{saName + "wrongName", saName}))
-	assert.True(s.T(), IsSpecificServiceAccount(ctx, []string{saName, saName + "wrongName"}))
-	assert.False(s.T(), IsSpecificServiceAccount(ctx, []string{saName + "wrongName"}))
-	assert.False(s.T(), IsSpecificServiceAccount(ctx, []string{saName + "wrongName", saName + "wrongName"}))
+	assert.True(s.T(), IsSpecificServiceAccount(ctx, saName))
+	assert.True(s.T(), IsSpecificServiceAccount(ctx, saName+"wrongName", saName))
+	assert.True(s.T(), IsSpecificServiceAccount(ctx, saName, saName+"wrongName"))
+	assert.False(s.T(), IsSpecificServiceAccount(ctx, saName+"wrongName"))
+	assert.False(s.T(), IsSpecificServiceAccount(ctx, saName+"wrongName", saName+"wrongName"))
 }
 
 func createInvalidSAContext() context.Context {


### PR DESCRIPTION
If during creating a new user by the registration app the user already exists in Keycloak then we should update the user in Keycloak.
If user already exists in the Auth DB then return 409 Conflict.

- [x] Tests

Fixes https://github.com/fabric8-services/fabric8-auth/issues/230