### PR TITLE
Allow email privacy to be configured

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -25,7 +25,7 @@ type User struct {
 	gormsupport.Lifecycle
 	ID                 uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
 	Email              string    `sql:"unique_index"`
-	EmailHidden        bool
+	EmailPrivate       bool
 	FullName           string             // The fullname of the User
 	ImageURL           string             // The image URL for the User
 	Bio                string             // The bio of the User

--- a/account/user.go
+++ b/account/user.go
@@ -23,8 +23,9 @@ import (
 // User describes a User account. A few identities can be assosiated with one user account
 type User struct {
 	gormsupport.Lifecycle
-	ID                 uuid.UUID          `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
-	Email              string             `sql:"unique_index"`                                            // This is the unique email field
+	ID                 uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	Email              string    `sql:"unique_index"`
+	EmailHidden        bool
 	FullName           string             // The fullname of the User
 	ImageURL           string             // The image URL for the User
 	Bio                string             // The bio of the User

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -102,7 +102,7 @@ func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error 
 	return ctx.ConditionalEntities(resultUsers, c.config.GetCacheControlCollaborators, func() error {
 		data := make([]*app.UserData, len(page))
 		for i := range resultUsers {
-			appUser := ConvertToAppUser(ctx.RequestData, &resultUsers[i], &resultIdentities[i])
+			appUser := ConvertToAppUser(ctx.RequestData, &resultUsers[i], &resultIdentities[i], false)
 			data[i] = appUser.Data
 		}
 		response := app.UserList{

--- a/controller/search.go
+++ b/controller/search.go
@@ -81,22 +81,29 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 		ident := result[i]
 		id := ident.ID.String()
 		userID := ident.User.ID.String()
+
+		email := ident.User.Email
+		if ident.User.EmailPrivate {
+			email = ""
+		}
+
 		users = append(users, &app.UserData{
 			// FIXME : should be "users" in the long term
 			Type: "identities",
 			ID:   &id,
 			Attributes: &app.UserDataAttributes{
-				CreatedAt:  &ident.User.CreatedAt,
-				UpdatedAt:  &ident.User.UpdatedAt,
-				Username:   &ident.Username,
-				FullName:   &ident.User.FullName,
-				ImageURL:   &ident.User.ImageURL,
-				Bio:        &ident.User.Bio,
-				URL:        &ident.User.URL,
-				UserID:     &userID,
-				IdentityID: &id,
-				Email:      &ident.User.Email,
-				Company:    &ident.User.Company,
+				CreatedAt:    &ident.User.CreatedAt,
+				UpdatedAt:    &ident.User.UpdatedAt,
+				Username:     &ident.Username,
+				FullName:     &ident.User.FullName,
+				ImageURL:     &ident.User.ImageURL,
+				Bio:          &ident.User.Bio,
+				URL:          &ident.User.URL,
+				UserID:       &userID,
+				IdentityID:   &id,
+				Email:        &email,
+				EmailPrivate: &ident.User.EmailPrivate,
+				Company:      &ident.User.Company,
 			},
 		})
 	}

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -151,7 +151,7 @@ func (s *TestSearchUserSearch) TestEmailPrivateSearchOK() {
 		Cluster:      "default Cluster",
 	}
 
-	_, err := testsupport.CreateTestUser(s.DB, user)
+	_, err := testsupport.CreateTestUser(s.DB, &user)
 	require.Nil(s.T(), err)
 
 	offset := "0"
@@ -172,7 +172,7 @@ func (s *TestSearchUserSearch) TestEmailNotPrivateSearchOK() {
 		Email:        uuid.NewV4().String(),
 		Cluster:      "default Cluster",
 	}
-	_, err := testsupport.CreateTestUser(s.DB, user)
+	_, err := testsupport.CreateTestUser(s.DB, &user)
 	require.Nil(s.T(), err)
 
 	offset := "0"

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/gormapplication"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/fabric8-services/fabric8-auth/resource"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
@@ -142,26 +143,16 @@ func (s *TestSearchUserSearch) createTestData() []account.Identity {
 
 func (s *TestSearchUserSearch) TestEmailPrivateSearchOK() {
 	randomName := uuid.NewV4().String()
-	application.Transactional(s.Application, func(app application.Application) error {
-		user := account.User{
-			EmailPrivate: true,
-			FullName:     randomName,
-			ImageURL:     "http://example.org/" + randomName + ".png",
-			Email:        uuid.NewV4().String(),
-			Cluster:      "default Cluster",
-		}
-		err := app.Users().Create(context.Background(), &user)
-		require.Nil(s.T(), err)
+	user := account.User{
+		EmailPrivate: true,
+		FullName:     randomName,
+		ImageURL:     "http://example.org/" + randomName + ".png",
+		Email:        uuid.NewV4().String(),
+		Cluster:      "default Cluster",
+	}
 
-		ident := account.Identity{
-			User:         user,
-			Username:     uuid.NewV4().String(),
-			ProviderType: "kc",
-		}
-		err = app.Identities().Create(context.Background(), &ident)
-		require.Nil(s.T(), err)
-		return err
-	})
+	_, err := testsupport.CreateTestUser(s.DB, user)
+	require.Nil(s.T(), err)
 
 	offset := "0"
 	pageLimit := 1
@@ -174,26 +165,15 @@ func (s *TestSearchUserSearch) TestEmailPrivateSearchOK() {
 
 func (s *TestSearchUserSearch) TestEmailNotPrivateSearchOK() {
 	randomName := uuid.NewV4().String()
-	application.Transactional(s.Application, func(app application.Application) error {
-		user := account.User{
-			EmailPrivate: false,
-			FullName:     randomName,
-			ImageURL:     "http://example.org/" + randomName + ".png",
-			Email:        uuid.NewV4().String(),
-			Cluster:      "default Cluster",
-		}
-		err := app.Users().Create(context.Background(), &user)
-		require.Nil(s.T(), err)
-
-		ident := account.Identity{
-			User:         user,
-			Username:     uuid.NewV4().String(),
-			ProviderType: "kc",
-		}
-		err = app.Identities().Create(context.Background(), &ident)
-		require.Nil(s.T(), err)
-		return err
-	})
+	user := account.User{
+		EmailPrivate: false,
+		FullName:     randomName,
+		ImageURL:     "http://example.org/" + randomName + ".png",
+		Email:        uuid.NewV4().String(),
+		Cluster:      "default Cluster",
+	}
+	_, err := testsupport.CreateTestUser(s.DB, user)
+	require.Nil(s.T(), err)
 
 	offset := "0"
 	pageLimit := 1

--- a/controller/user.go
+++ b/controller/user.go
@@ -70,7 +70,7 @@ func (c *UserController) Show(ctx *app.ShowUserContext) error {
 					c.InitTenant(ctx)
 				}(ctx)
 			}
-			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity))
+			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, true))
 		})
 	})
 }

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -136,7 +136,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedNotModifiedUsingIfNoneMatchHeader
 func (rest *TestUserREST) TestPrivateEmailVisibleIfNotPrivate() {
 	ctx, userCtrl, usr, _ := rest.initTestCurrentAuthorized()
 	usr.EmailPrivate = false
-	_, err := testsupport.CreateTestUser(rest.DB, usr)
+	_, err := testsupport.CreateTestUser(rest.DB, &usr)
 	require.NoError(rest.T(), err)
 	_, returnedUser := test.ShowUserOK(rest.T(), ctx, nil, userCtrl, nil, nil)
 	require.NotNil(rest.T(), returnedUser)
@@ -146,7 +146,7 @@ func (rest *TestUserREST) TestPrivateEmailVisibleIfNotPrivate() {
 func (rest *TestUserREST) TestPrivateEmailVisibleIfPrivate() {
 	ctx, userCtrl, usr, _ := rest.initTestCurrentAuthorized()
 	usr.EmailPrivate = true
-	_, err := testsupport.CreateTestUser(rest.DB, usr)
+	_, err := testsupport.CreateTestUser(rest.DB, &usr)
 	require.NoError(rest.T(), err)
 	_, returnedUser := test.ShowUserOK(rest.T(), ctx, nil, userCtrl, nil, nil)
 	require.NotNil(rest.T(), returnedUser)

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -2,7 +2,6 @@ package controller_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -13,11 +12,12 @@ import (
 	"github.com/fabric8-services/fabric8-auth/application"
 	"github.com/fabric8-services/fabric8-auth/auth"
 	res "github.com/fabric8-services/fabric8-auth/authorization/resource"
-	"github.com/fabric8-services/fabric8-auth/configuration"
 	. "github.com/fabric8-services/fabric8-auth/controller"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/fabric8-services/fabric8-auth/resource"
 	"github.com/fabric8-services/fabric8-auth/space"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 	"github.com/fabric8-services/fabric8-auth/token/provider"
 
@@ -33,25 +33,21 @@ import (
 )
 
 type TestUserREST struct {
-	suite.Suite
-	config configuration.ConfigurationData
+	gormtestsupport.DBTestSuite
 }
 
 func TestRunUserREST(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+	resource.Require(t, resource.Database)
 	suite.Run(t, &TestUserREST{})
 }
 
 func (rest *TestUserREST) SetupSuite() {
-	config, err := configuration.GetConfigurationData()
-	if err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
-	rest.config = *config
+	rest.DBTestSuite.SetupSuite()
+
 }
 
 func (rest *TestUserREST) newUserController(identity *account.Identity, user *account.User) *UserController {
-	return NewUserController(goa.New("wit-test"), newGormTestBase(identity, user), testtoken.TokenManager, &rest.config)
+	return NewUserController(goa.New("wit-test"), newGormTestBase(identity, user), testtoken.TokenManager, rest.Configuration)
 }
 
 func (rest *TestUserREST) TestCurrentAuthorizedMissingUUID() {
@@ -137,6 +133,27 @@ func (rest *TestUserREST) TestCurrentAuthorizedNotModifiedUsingIfNoneMatchHeader
 	rest.assertResponseHeaders(res, usr)
 }
 
+func (rest *TestUserREST) TestPrivateEmailVisibleIfNotPrivate() {
+	ctx, userCtrl, usr, _ := rest.initTestCurrentAuthorized()
+	usr.EmailPrivate = false
+	_, err := testsupport.CreateTestUser(rest.DB, usr)
+	require.NoError(rest.T(), err)
+	_, returnedUser := test.ShowUserOK(rest.T(), ctx, nil, userCtrl, nil, nil)
+	require.NotNil(rest.T(), returnedUser)
+	require.Equal(rest.T(), usr.Email, *returnedUser.Data.Attributes.Email)
+}
+
+func (rest *TestUserREST) TestPrivateEmailVisibleIfPrivate() {
+	ctx, userCtrl, usr, _ := rest.initTestCurrentAuthorized()
+	usr.EmailPrivate = true
+	_, err := testsupport.CreateTestUser(rest.DB, usr)
+	require.NoError(rest.T(), err)
+	_, returnedUser := test.ShowUserOK(rest.T(), ctx, nil, userCtrl, nil, nil)
+	require.NotNil(rest.T(), returnedUser)
+	require.NotEqual(rest.T(), "", *returnedUser.Data.Attributes.Email)
+	require.Equal(rest.T(), usr.Email, *returnedUser.Data.Attributes.Email)
+}
+
 func (rest *TestUserREST) initTestCurrentAuthorized() (context.Context, app.UserController, account.User, account.Identity) {
 	jwtToken := token.New(token.SigningMethodRS256)
 	jwtToken.Claims.(token.MapClaims)["sub"] = uuid.NewV4().String()
@@ -149,7 +166,8 @@ func (rest *TestUserREST) initTestCurrentAuthorized() (context.Context, app.User
 		},
 		FullName: "TestCurrentAuthorizedOK User",
 		ImageURL: "someURL",
-		Email:    "email@domain.com",
+		Cluster:  "cluster",
+		Email:    uuid.NewV4().String() + "email@domain.com",
 	}
 	ident := account.Identity{ID: uuid.NewV4(), Username: "TestUser", ProviderType: account.KeycloakIDP, User: usr, UserID: account.NullUUID{UUID: usr.ID, Valid: true}}
 	userCtrl := rest.newUserController(&ident, &usr)
@@ -171,7 +189,7 @@ func (rest *TestUserREST) assertResponseHeaders(res http.ResponseWriter, usr acc
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), usr.UpdatedAt.Truncate(time.Second).UTC().Format(http.TimeFormat), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), rest.config.GetCacheControlUser(), res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), rest.Configuration.GetCacheControlUser(), res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), app.GenerateEntityTag(usr), res.Header()[app.ETag][0])
 

--- a/controller/users.go
+++ b/controller/users.go
@@ -868,6 +868,10 @@ func loadKeyCloakIdentity(appl application.Application, user account.User) (*acc
 }
 
 // ConvertToAppUser converts a complete Identity object into REST representation
+// if isAuthenticated is set to True, then the 'email' field is populated irrespective of whether
+// 'email_private' = true/false.
+// if isAuthenticated is set of False, then the 'email' field is populated only if
+// 'email_private' = false.
 func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *account.Identity, isAuthenticated bool) *app.User {
 	userID := user.ID.String()
 	identityID := identity.ID.String()

--- a/controller/users.go
+++ b/controller/users.go
@@ -82,7 +82,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 			}
 		}
 		return ctx.ConditionalRequest(*user, c.config.GetCacheControlUser, func() error {
-			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, true))
+			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, false))
 		})
 	})
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -552,9 +552,9 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			(*keycloakUserProfile.Attributes)[login.URLAttributeName] = []string{*updateURL}
 		}
 
-		updatedEmailPrivate := ctx.Payload.Data.Attributes.EmailHidden
+		updatedEmailPrivate := ctx.Payload.Data.Attributes.EmailPrivate
 		if updatedEmailPrivate != nil {
-			user.EmailHidden = *updatedEmailPrivate
+			user.EmailPrivate = *updatedEmailPrivate
 		}
 
 		updatedCompany := ctx.Payload.Data.Attributes.Company
@@ -879,7 +879,7 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 	var bio string
 	var userURL string
 	var email string
-	var isEmailHidden bool
+	var isEmailPrivate bool
 	var createdAt time.Time
 	var updatedAt time.Time
 	var company string
@@ -891,10 +891,10 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 		imageURL = user.ImageURL
 		bio = user.Bio
 		userURL = user.URL
-		isEmailHidden = user.EmailHidden
+		isEmailPrivate = user.EmailPrivate
 		email = user.Email
 
-		if !isAuthenticated && isEmailHidden {
+		if !isAuthenticated && isEmailPrivate {
 			email = ""
 		}
 
@@ -916,7 +916,7 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 				Username:              &userName,
 				FullName:              &fullName,
 				ImageURL:              &imageURL,
-				EmailHidden:           &isEmailHidden,
+				EmailPrivate:          &isEmailPrivate,
 				Bio:                   &bio,
 				URL:                   &userURL,
 				UserID:                &userID,

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -72,7 +72,9 @@ func (s *TestUsersSuite) SecuredServiceAccountController(identity account.Identi
 func (s *TestUsersSuite) TestUpdateUserOK() {
 	// given
 	user := s.createRandomUser("TestUpdateUserOK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 	assert.Equal(s.T(), user.FullName, *result.Data.Attributes.FullName)
@@ -124,7 +126,9 @@ func (s *TestUsersSuite) TestUpdateUserOK() {
 func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
@@ -153,7 +157,9 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
@@ -176,7 +182,9 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 
 func (s *TestUsersSuite) TestUpdateRegistrationCompletedOK() {
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
@@ -198,7 +206,9 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedOK() {
 
 func (s *TestUsersSuite) TestUpdateRegistrationCompletedBadRequest() {
 	user := s.createRandomUser("OKRegCompleted")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
@@ -225,7 +235,9 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedAndUsernameOK() {
 	// as part of HTTP PATCH.
 
 	user := s.createRandomUser("OKRegCompleted")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
@@ -249,12 +261,15 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedAndUsernameOK() {
 func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 	// create 2 users.
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
 	user2 := s.createRandomUser("OK2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
 	_, result2 := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity2.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
 
@@ -273,12 +288,16 @@ func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
 	// create 2 users.
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
 	user2 := s.createRandomUser("OK2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	_, result2 := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity2.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
 
@@ -298,7 +317,9 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 
 	// given
 	user := s.createRandomUser("OK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assertUser(s.T(), result.Data, user, identity)
 	// when
@@ -352,7 +373,9 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 	// given
 	user := s.createRandomUser("TestUpdateUserUnsetVariableInContextInfo")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 	assert.Equal(s.T(), user.FullName, *result.Data.Attributes.FullName)
@@ -420,7 +443,9 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 func (s *TestUsersSuite) TestUpdateUserOKWithoutContextInfo() {
 	// given
 	user := s.createRandomUser("TestUpdateUserOKWithoutContextInfo")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 	assert.Equal(s.T(), user.FullName, *result.Data.Attributes.FullName)
@@ -444,7 +469,9 @@ func (s *TestUsersSuite) TestUpdateUserOKWithoutContextInfo() {
 func (s *TestUsersSuite) TestUpdateUserWithInvalidEmail() {
 	// given
 	user := s.createRandomUser("TestUpdateUserOKWithoutContextInfo")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 
 	// when
@@ -465,7 +492,9 @@ func (s *TestUsersSuite) TestUpdateUserWithInvalidEmail() {
 func (s *TestUsersSuite) TestUpdateUserWithInvalidUsername() {
 	// given
 	user := s.createRandomUser("TestUpdateUserOKWithoutContextInfo")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 
 	contextInformation := map[string]interface{}{
@@ -485,7 +514,9 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 
 	// given
 	user := s.createRandomUser("TestPatchUserContextInformation")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assertUser(s.T(), result.Data, user, identity)
 	// when
@@ -540,7 +571,9 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 func (s *TestUsersSuite) TestUpdateUserUnauthorized() {
 	// given
 	user := s.createRandomUser("TestUpdateUserUnauthorized")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 	assert.Equal(s.T(), user.FullName, *result.Data.Attributes.FullName)
@@ -565,7 +598,9 @@ func (s *TestUsersSuite) TestUpdateUserUnauthorized() {
 func (s *TestUsersSuite) TestShowUserOK() {
 	// given user
 	user := s.createRandomUser("TestShowUserOK")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when
 	res, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	// then
@@ -576,7 +611,9 @@ func (s *TestUsersSuite) TestShowUserOK() {
 func (s *TestUsersSuite) TestShowUserOKUsingExpiredIfModifedSinceHeader() {
 	// given user
 	user := s.createRandomUser("TestShowUserOKUsingExpiredIfModifedSinceHeader")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when
 	ifModifiedSince := app.ToHTTPTime(user.UpdatedAt.Add(-1 * time.Hour))
 	res, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), &ifModifiedSince, nil)
@@ -588,7 +625,9 @@ func (s *TestUsersSuite) TestShowUserOKUsingExpiredIfModifedSinceHeader() {
 func (s *TestUsersSuite) TestShowUserOKUsingExpiredIfNoneMatchHeader() {
 	// given user
 	user := s.createRandomUser("TestShowUserOKUsingExpiredIfNoneMatchHeader")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when
 	ifNoneMatch := "foo"
 	res, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, &ifNoneMatch)
@@ -600,7 +639,9 @@ func (s *TestUsersSuite) TestShowUserOKUsingExpiredIfNoneMatchHeader() {
 func (s *TestUsersSuite) TestShowUserNotModifiedUsingIfModifedSinceHeader() {
 	// given user
 	user := s.createRandomUser("TestShowUserNotModifiedUsingIfModifedSinceHeader")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when/then
 	ifModifiedSince := app.ToHTTPTime(user.UpdatedAt.UTC())
 	test.ShowUsersNotModified(s.T(), nil, nil, s.controller, identity.ID.String(), &ifModifiedSince, nil)
@@ -609,7 +650,9 @@ func (s *TestUsersSuite) TestShowUserNotModifiedUsingIfModifedSinceHeader() {
 func (s *TestUsersSuite) TestShowUserNotModifiedUsingIfNoneMatchHeader() {
 	// given user
 	user := s.createRandomUser("TestShowUserNotModifiedUsingIfNoneMatchHeader")
-	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when/then
 	ifNoneMatch := app.GenerateEntityTag(user)
 	test.ShowUsersNotModified(s.T(), nil, nil, s.controller, identity.ID.String(), nil, &ifNoneMatch)
@@ -618,7 +661,9 @@ func (s *TestUsersSuite) TestShowUserNotModifiedUsingIfNoneMatchHeader() {
 func (s *TestUsersSuite) TestShowUserNotFound() {
 	// given user
 	user := s.createRandomUser("TestShowUserNotFound")
-	s.createRandomIdentity(user, account.KeycloakIDP)
+	_, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when/then
 	test.ShowUsersNotFound(s.T(), nil, nil, s.controller, uuid.NewV4().String(), nil, nil)
 }
@@ -626,7 +671,9 @@ func (s *TestUsersSuite) TestShowUserNotFound() {
 func (s *TestUsersSuite) TestShowUserBadRequest() {
 	// given user
 	user := s.createRandomUser("TestShowUserBadRequest")
-	s.createRandomIdentity(user, account.KeycloakIDP)
+	_, err := testsupport.CreateTestUser(s.DB, &user)
+	require.NoError(s.T(), err)
+
 	// when/then
 	test.ShowUsersBadRequest(s.T(), nil, nil, s.controller, "invaliduuid", nil, nil)
 }
@@ -634,11 +681,14 @@ func (s *TestUsersSuite) TestShowUserBadRequest() {
 func (s *TestUsersSuite) TestListUsersOK() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	identity1 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, account.KeycloakIDP)
+	identity1, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	res, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity1.Username, nil, nil)
 	// then
@@ -653,10 +703,18 @@ func (s *TestUsersSuite) TestListUsersOK() {
 // to respond to the query if data some data is invalid.
 func (s *TestUsersSuite) TestListUsersWithMissingKeycloakIdentityOK() {
 	// given user1
-	s.createRandomUser("TestListUsersOK1")
+	user1 := s.createRandomUser("TestListUsersOK1")
+	identity1, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
+	identity1.ProviderType = ""
+	err = s.Application.Identities().Save(context.Background(), &identity1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
 	// when
 	res, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity2.Username, nil, nil)
 	// then
@@ -667,11 +725,14 @@ func (s *TestUsersSuite) TestListUsersWithMissingKeycloakIdentityOK() {
 func (s *TestUsersSuite) TestListUsersOKUsingExpiredIfModifiedSinceHeader() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOKUsingExpiredIfModifiedSinceHeader")
-	identity1 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, account.KeycloakIDP)
+	identity1, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOKUsingExpiredIfModifiedSinceHeader2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	ifModifiedSinceHeader := app.ToHTTPTime(user2.UpdatedAt.Add(-1 * time.Hour))
 	res, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity1.Username, &ifModifiedSinceHeader, nil)
@@ -686,11 +747,14 @@ func (s *TestUsersSuite) TestListUsersOKUsingExpiredIfModifiedSinceHeader() {
 func (s *TestUsersSuite) TestListUsersOKUsingExpiredIfNoneMatchHeader() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOKUsingExpiredIfNoneMatchHeader")
-	identity1 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "github-test")
+	identity1, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOKUsingExpiredIfNoneMatchHeader2")
-	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	identity2, err := testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	ifNoneMatch := "foo"
 	res, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity1.Username, nil, &ifNoneMatch)
@@ -706,11 +770,14 @@ func (s *TestUsersSuite) TestListUsersOKUsingExpiredIfNoneMatchHeader() {
 func (s *TestUsersSuite) TestListUsersNotModifiedUsingIfModifiedSinceHeader() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersNotModifiedUsingIfModifiedSinceHeader")
-	s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "github-test")
+	_, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersNotModifiedUsingIfModifiedSinceHeader2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	ifModifiedSinceHeader := app.ToHTTPTime(user2.UpdatedAt)
 	res := test.ListUsersNotModified(s.T(), nil, nil, s.controller, nil, nil, &ifModifiedSinceHeader, nil)
@@ -719,13 +786,19 @@ func (s *TestUsersSuite) TestListUsersNotModifiedUsingIfModifiedSinceHeader() {
 }
 
 func (s *TestUsersSuite) TestListUsersByUsernameOK() {
-	// given user1
+	// given 3 users
 	user1 := s.createRandomUser("TestListUsersOK1")
-	identity11 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "github-test")
-	// given user2
+	identity11, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
+	user3 := s.createRandomUser("TestListUsersOK3")
+	_, err = testsupport.CreateTestUser(s.DB, &user3)
+	require.NoError(s.T(), err)
+
 	// when
 	_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity11.Username, nil, nil)
 	// then
@@ -739,11 +812,14 @@ func (s *TestUsersSuite) TestListUsersByUsernameOK() {
 func (s *TestUsersSuite) TestListUsersByUsernameOKEmptyResult() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "github-test")
+	_, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	username := "foobar"
 	_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &username, nil, nil)
@@ -754,11 +830,14 @@ func (s *TestUsersSuite) TestListUsersByUsernameOKEmptyResult() {
 func (s *TestUsersSuite) TestListUsersByUsernameNotModifiedUsingIfNoneMatchHeader() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	identity11 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "github-test")
+	identity11, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	_, filteredUsers := test.ListUsersOK(s.T(), nil, nil, s.controller, nil, &identity11.Username, nil, nil)
 	// when/then
 	ifNoneMatch := s.generateUsersTag(*filteredUsers)
@@ -771,12 +850,14 @@ func (s *TestUsersSuite) TestListUsersByUsernameNotModifiedUsingIfNoneMatchHeade
 func (s *TestUsersSuite) TestListUsersByEmailOK() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	identity11 := s.createRandomIdentity(user1, account.KeycloakIDP)
-	_ = s.createRandomIdentity(user1, "xyz-idp")
+	identity11, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
 
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, &user1.Email, nil, nil, nil)
 	// then
@@ -792,11 +873,14 @@ func (s *TestUsersSuite) TestListUsersByEmailOK() {
 func (s *TestUsersSuite) TestListUsersByEmailOKEmptyResult() {
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "xyz-idp")
+	_, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	// when
 	email := "foo@bar.com"
 	_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
@@ -809,7 +893,9 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	identity := s.createRandomIdentity(user1, account.KeycloakIDP)
+	identity, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	secureService, secureController := s.SecuredController(identity)
 
 	// when
@@ -857,13 +943,17 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 }
 
 func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader() {
+
 	// given user1
 	user1 := s.createRandomUser("TestListUsersOK1")
-	s.createRandomIdentity(user1, account.KeycloakIDP)
-	s.createRandomIdentity(user1, "xyz-idp")
+	_, err := testsupport.CreateTestUser(s.DB, &user1)
+	require.NoError(s.T(), err)
+
 	// given user2
 	user2 := s.createRandomUser("TestListUsersOK2")
-	s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, err = testsupport.CreateTestUser(s.DB, &user2)
+	require.NoError(s.T(), err)
+
 	_, filteredUsers := test.ListUsersOK(s.T(), nil, nil, s.controller, &user1.Email, nil, nil, nil)
 	// when
 	ifNoneMatch := s.generateUsersTag(*filteredUsers)
@@ -882,22 +972,7 @@ func (s *TestUsersSuite) createRandomUser(fullname string) account.User {
 		Cluster:      "My OSO cluster url",
 		EmailPrivate: false, // being explicit
 	}
-	err := s.userRepo.Create(context.Background(), &user)
-	require.Nil(s.T(), err)
 	return user
-}
-func (s *TestUsersSuite) createRandomIdentity(user account.User, providerType string) account.Identity {
-	profile := "foobarforupdate.com/" + uuid.NewV4().String() + "/" + user.ID.String()
-	identity := account.Identity{
-		Username:     "TestUpdateUserIntegration123" + uuid.NewV4().String(),
-		ProviderType: providerType,
-		ProfileURL:   &profile,
-		User:         user,
-		UserID:       account.NullUUID{UUID: user.ID, Valid: true},
-	}
-	err := s.identityRepo.Create(context.Background(), &identity)
-	require.Nil(s.T(), err)
-	return identity
 }
 
 func findUser(id uuid.UUID, userData []*app.UserData) *app.UserData {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -842,15 +842,13 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 	returnedUserResult := result.Data[0]
 	require.Equal(s.T(), "", *returnedUserResult.Attributes.Email)
 
-	// even though the email_hidden=true,
+	// even though the email_private=true,
 	// the email address is visible to the user if her user token is passed.
 	_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
 	require.NotEqual(s.T(), user1.Email, *showUserResponse.Data.Attributes.Email)
 	require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)
 	require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
 
-	// since email_hidden=true, the GET /api/users API would not return the email.
-	//_, showUserResponse = test.Show
 }
 
 func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader() {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -828,7 +828,6 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 		"rate":         100.00,
 		"count":        3,
 	}
-	//secureController, secureService := createSecureController(t, identity)
 	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, contextInformation)
 	updateUsersPayload.Data.Attributes.EmailHidden = &boolTrue
 	_, updateResult := test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
@@ -936,7 +935,6 @@ func assertUser(t *testing.T, actual *app.UserData, expectedUser account.User, e
 	assert.Equal(t, expectedIdentity.ProviderType, *actual.Attributes.ProviderType)
 	assert.Equal(t, expectedUser.FullName, *actual.Attributes.FullName)
 	assert.Equal(t, expectedUser.ImageURL, *actual.Attributes.ImageURL)
-	//if actual.Attributes.EmailHidden != nil {
 	if !*actual.Attributes.EmailHidden {
 		assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
 	} else {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -818,7 +818,7 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 	_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
 	returnedUser := result.Data[0].Attributes
 	require.Equal(s.T(), email, *returnedUser.Email)
-	require.False(s.T(), *returnedUser.EmailHidden)
+	require.False(s.T(), *returnedUser.EmailPrivate)
 
 	secureService, secureController := s.SecuredController(identity)
 
@@ -829,11 +829,11 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 		"count":        3,
 	}
 	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, contextInformation)
-	updateUsersPayload.Data.Attributes.EmailHidden = &boolTrue
+	updateUsersPayload.Data.Attributes.EmailPrivate = &boolTrue
 	_, updateResult := test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 
 	// Email will be visible to the one who it belongs to
-	require.True(s.T(), *updateResult.Data.Attributes.EmailHidden)
+	require.True(s.T(), *updateResult.Data.Attributes.EmailPrivate)
 	require.Equal(s.T(), user1.Email, *updateResult.Data.Attributes.Email)
 
 	// But when you try to access the same with an API which doesn't respect auth,
@@ -846,7 +846,7 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 	// the email address is visible to the user if her user token is passed.
 	_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
 	require.Equal(s.T(), user1.Email, *showUserResponse.Data.Attributes.Email)
-	require.True(s.T(), *showUserResponse.Data.Attributes.EmailHidden)
+	require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
 }
 
 func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader() {
@@ -867,13 +867,13 @@ func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader()
 
 func (s *TestUsersSuite) createRandomUser(fullname string) account.User {
 	user := account.User{
-		Email:       uuid.NewV4().String() + "primaryForUpdat7e@example.com",
-		FullName:    fullname,
-		ImageURL:    "someURLForUpdate",
-		ID:          uuid.NewV4(),
-		Company:     uuid.NewV4().String() + "company",
-		Cluster:     "My OSO cluster url",
-		EmailHidden: false, // being explicit
+		Email:        uuid.NewV4().String() + "primaryForUpdat7e@example.com",
+		FullName:     fullname,
+		ImageURL:     "someURLForUpdate",
+		ID:           uuid.NewV4(),
+		Company:      uuid.NewV4().String() + "company",
+		Cluster:      "My OSO cluster url",
+		EmailPrivate: false, // being explicit
 	}
 	err := s.userRepo.Create(context.Background(), &user)
 	require.Nil(s.T(), err)
@@ -941,7 +941,7 @@ func assertUser(t *testing.T, actual *app.UserData, expectedUser account.User, e
 	assert.Equal(t, expectedIdentity.ProviderType, *actual.Attributes.ProviderType)
 	assert.Equal(t, expectedUser.FullName, *actual.Attributes.FullName)
 	assert.Equal(t, expectedUser.ImageURL, *actual.Attributes.ImageURL)
-	if !*actual.Attributes.EmailHidden {
+	if !*actual.Attributes.EmailPrivate {
 		assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
 	} else {
 		assert.Equal(t, "", *actual.Attributes.Email)

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -845,8 +845,12 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 	// even though the email_hidden=true,
 	// the email address is visible to the user if her user token is passed.
 	_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-	require.Equal(s.T(), user1.Email, *showUserResponse.Data.Attributes.Email)
+	require.NotEqual(s.T(), user1.Email, *showUserResponse.Data.Attributes.Email)
+	require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)
 	require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+
+	// since email_hidden=true, the GET /api/users API would not return the email.
+	//_, showUserResponse = test.Show
 }
 
 func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader() {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -841,6 +841,12 @@ func (s *TestUsersSuite) TestHideEmailOK() {
 	_, result = test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
 	returnedUserResult := result.Data[0]
 	require.Equal(s.T(), "", *returnedUserResult.Attributes.Email)
+
+	// even though the email_hidden=true,
+	// the email address is visible to the user if her user token is passed.
+	_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+	require.Equal(s.T(), user1.Email, *showUserResponse.Data.Attributes.Email)
+	require.True(s.T(), *showUserResponse.Data.Attributes.EmailHidden)
 }
 
 func (s *TestUsersSuite) TestListUsersByEmailNotModifiedUsingIfNoneMatchHeader() {

--- a/design/account.go
+++ b/design/account.go
@@ -203,7 +203,7 @@ var userDataAttributes = a.Type("UserDataAttributes", func() {
 	a.Attribute("username", d.String, "The username")
 	a.Attribute("registrationCompleted", d.Boolean, "Whether the registration has been completed")
 	a.Attribute("email", d.String, "The email")
-	a.Attribute("email_private", d.Boolean, "Whether the email address would be visible to other users.")
+	a.Attribute("email_private", d.Boolean, "Whether the email address would be private.")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
@@ -222,7 +222,7 @@ var updateUserDataAttributes = a.Type("UpdateIdentityDataAttributes", func() {
 	a.Attribute("email", d.String, "The email")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
-	a.Attribute("email_private", d.Boolean, "Whether the email address would be visible to other users.")
+	a.Attribute("email_private", d.Boolean, "Whether the email address would be private.")
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. This can only be set to true")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {

--- a/design/account.go
+++ b/design/account.go
@@ -203,6 +203,7 @@ var userDataAttributes = a.Type("UserDataAttributes", func() {
 	a.Attribute("username", d.String, "The username")
 	a.Attribute("registrationCompleted", d.Boolean, "Whether the registration has been completed")
 	a.Attribute("email", d.String, "The email")
+	a.Attribute("email_hidden", d.Boolean, "Whether the email address would be visible to other users.")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
@@ -221,6 +222,7 @@ var updateUserDataAttributes = a.Type("UpdateIdentityDataAttributes", func() {
 	a.Attribute("email", d.String, "The email")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
+	a.Attribute("email_hidden", d.Boolean, "Whether the email address would be visible to other users.")
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. This can only be set to true")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {

--- a/design/account.go
+++ b/design/account.go
@@ -203,7 +203,7 @@ var userDataAttributes = a.Type("UserDataAttributes", func() {
 	a.Attribute("username", d.String, "The username")
 	a.Attribute("registrationCompleted", d.Boolean, "Whether the registration has been completed")
 	a.Attribute("email", d.String, "The email")
-	a.Attribute("email_hidden", d.Boolean, "Whether the email address would be visible to other users.")
+	a.Attribute("email_private", d.Boolean, "Whether the email address would be visible to other users.")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
@@ -222,7 +222,7 @@ var updateUserDataAttributes = a.Type("UpdateIdentityDataAttributes", func() {
 	a.Attribute("email", d.String, "The email")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
-	a.Attribute("email_hidden", d.Boolean, "Whether the email address would be visible to other users.")
+	a.Attribute("email_private", d.Boolean, "Whether the email address would be visible to other users.")
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. This can only be set to true")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -143,6 +143,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// version 11
 	m = append(m, steps{ExecuteSQLFile("011-add-username-to-external-token.sql")})
 
+	// version 12
+	m = append(m, steps{ExecuteSQLFile("012-hide-email.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/012-hide-email.sql
+++ b/migration/sql-files/012-hide-email.sql
@@ -1,3 +1,3 @@
--- Store identity provider username for the external token
 ALTER TABLE users ADD COLUMN email_private boolean;
 UPDATE USERS SET email_private = false;
+ALTER TABLE USERS ALTER COLUMN email_private set NOT NULL;

--- a/migration/sql-files/012-hide-email.sql
+++ b/migration/sql-files/012-hide-email.sql
@@ -1,0 +1,3 @@
+-- Store identity provider username for the external token
+ALTER TABLE users ADD COLUMN email_hidden boolean;
+UPDATE USERS SET email_hidden = false;

--- a/migration/sql-files/012-hide-email.sql
+++ b/migration/sql-files/012-hide-email.sql
@@ -1,3 +1,3 @@
 -- Store identity provider username for the external token
-ALTER TABLE users ADD COLUMN email_hidden boolean;
-UPDATE USERS SET email_hidden = false;
+ALTER TABLE users ADD COLUMN email_private boolean;
+UPDATE USERS SET email_private = false;

--- a/test/account.go
+++ b/test/account.go
@@ -65,6 +65,27 @@ func CreateTestIdentity(db *gorm.DB, username, providerType string) (account.Ide
 	return testIdentity, err
 }
 
+// CreateTestUser creates a new user from a given user object
+func CreateTestUser(db *gorm.DB, user account.User) (account.Identity, error) {
+	userRepository := account.NewUserRepository(db)
+	identityRepository := account.NewIdentityRepository(db)
+	identity := account.Identity{
+		Username:     uuid.NewV4().String(),
+		ProviderType: "KC",
+	}
+	err := models.Transactional(db, func(tx *gorm.DB) error {
+		userCreationError := userRepository.Create(context.Background(), &user)
+		if userCreationError != nil {
+			return userCreationError
+		}
+		identity.User = user
+		identity.UserID.UUID = user.ID
+
+		return identityRepository.Create(context.Background(), &identity)
+	})
+	return identity, err
+}
+
 // CreateTestIdentityForAccountIdentity creates an account.Identity in the database. For testing purpose only.
 // This function unlike CreateTestIdentity() allows to create an Identity with pre-defined ID.
 func CreateTestIdentityForAccountIdentity(db *gorm.DB, identity *account.Identity) error {

--- a/test/account.go
+++ b/test/account.go
@@ -66,19 +66,19 @@ func CreateTestIdentity(db *gorm.DB, username, providerType string) (account.Ide
 }
 
 // CreateTestUser creates a new user from a given user object
-func CreateTestUser(db *gorm.DB, user account.User) (account.Identity, error) {
+func CreateTestUser(db *gorm.DB, user *account.User) (account.Identity, error) {
 	userRepository := account.NewUserRepository(db)
 	identityRepository := account.NewIdentityRepository(db)
 	identity := account.Identity{
 		Username:     uuid.NewV4().String(),
-		ProviderType: "KC",
+		ProviderType: account.KeycloakIDP,
 	}
 	err := models.Transactional(db, func(tx *gorm.DB) error {
-		userCreationError := userRepository.Create(context.Background(), &user)
+		userCreationError := userRepository.Create(context.Background(), user)
 		if userCreationError != nil {
 			return userCreationError
 		}
-		identity.User = user
+		identity.User = *user
 		identity.UserID.UUID = user.ID
 
 		return identityRepository.Create(context.Background(), &identity)


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-auth/issues/35

The objective of this PR is to provide a way to make email private using the `PATCH /api/users`

Make your email private : 
```
curl --request POST \
  --url http://localhost:8089/api/users \
  --header 'authorization: Bearer eyJhbGciOiJSUzI1NiIajg' \
  --header 'content-type: application/json' \
  --data '{"data": { "attributes": {"email_private":true},"type": "identities"}}'
```

The email should not be returned ( will be an empty string ) when a call similar to 
```
https://auth.openshift.io/api/users?filter[username]=shbose
```
is made.

However, a call to to 
```
curl --request GET \
  --url http://localhost:8089/api/user \
  --header 'authorization: Bearer eyJhbGciOiJSUzI1NiIajg' \
```

would return the email address irrespective of the `email_private` value.