### PR TITLE
Accept RHD user ID in Create User Payload

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -278,10 +278,11 @@ func (c *UsersController) createUserInDB(ctx *app.CreateUsersContext, identityID
 	// "username", "email", "cluster"
 
 	user = &account.User{
-		ID:           userID,
-		Email:        ctx.Payload.Data.Attributes.Email,
-		Cluster:      ctx.Payload.Data.Attributes.Cluster,
-		EmailPrivate: false,
+		ID:            userID,
+		Email:         ctx.Payload.Data.Attributes.Email,
+		Cluster:       ctx.Payload.Data.Attributes.Cluster,
+		EmailPrivate:  false,
+		EmailVerified: true,
 	}
 	identity = &account.Identity{
 		ID:           identityID,

--- a/controller/users.go
+++ b/controller/users.go
@@ -170,10 +170,10 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 	return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, true))
 }
 
-func (c *UsersController) linkUserToRHD(ctx *app.CreateUsersContext, identityID string, rhdUsername string, protectedAccessToken string) error {
+func (c *UsersController) linkUserToRHD(ctx *app.CreateUsersContext, identityID string, rhdUsername string, rhdUserID string, protectedAccessToken string) error {
 	idpName := "rhd"
 	linkRequest := linkAPI.KeycloakLinkIDPRequest{
-		UserID:           &identityID,
+		UserID:           &rhdUserID,
 		Username:         &rhdUsername,
 		IdentityProvider: &idpName,
 	}
@@ -253,7 +253,8 @@ func (c *UsersController) createOrUpdateUserInKeycloak(ctx *app.CreateUsersConte
 
 	// Link only new accounts. Do not link already existing (and updated) ones
 	if created {
-		err = c.linkUserToRHD(ctx, identityID, rhdUserName(*ctx.Payload.Data.Attributes), protectedAccessToken)
+		rhdUserID := userAttributes.RhdUserID
+		err = c.linkUserToRHD(ctx, identityID, rhdUserName(*ctx.Payload.Data.Attributes), rhdUserID, protectedAccessToken)
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"err":              err,

--- a/controller/users.go
+++ b/controller/users.go
@@ -278,9 +278,10 @@ func (c *UsersController) createUserInDB(ctx *app.CreateUsersContext, identityID
 	// "username", "email", "cluster"
 
 	user = &account.User{
-		ID:      userID,
-		Email:   ctx.Payload.Data.Attributes.Email,
-		Cluster: ctx.Payload.Data.Attributes.Cluster,
+		ID:           userID,
+		Email:        ctx.Payload.Data.Attributes.Email,
+		Cluster:      ctx.Payload.Data.Attributes.Cluster,
+		EmailPrivate: false,
 	}
 	identity = &account.Identity{
 		ID:           identityID,

--- a/design/account.go
+++ b/design/account.go
@@ -270,6 +270,7 @@ var createUserDataAttributes = a.Type("CreateIdentityDataAttributes", func() {
 	a.Attribute("emailVerified", d.Boolean, "Whether email is verified")
 	a.Attribute("enabled", d.Boolean, "Whether the user is enabled")
 	a.Attribute("rhd_username", d.String, "The associated Red Hat Developers account. If not set then username is used as the RHD username")
+	a.Attribute("rhd_user_id", d.String, "The Red Hat Developers User ID of the user")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
@@ -279,5 +280,5 @@ var createUserDataAttributes = a.Type("CreateIdentityDataAttributes", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})
 	})
 	// Based on the request from online-registration app.
-	a.Required("username", "email", "cluster")
+	a.Required("username", "email", "cluster", "rhd_user_id")
 })

--- a/login/profile.go
+++ b/login/profile.go
@@ -103,8 +103,9 @@ func NewKeycloakUserProfileClient() *KeycloakUserProfileClient {
 // If the user already exists then the user will be updated
 // Returns true if a new user has been created and false if the existing user has been updated
 func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, bool, error) {
-	defaultEnabledState := true
-	keycloakUserRequest.Enabled = &defaultEnabledState
+	defaultState := true
+	keycloakUserRequest.Enabled = &defaultState
+	keycloakUserRequest.EmailVerified = &defaultState
 
 	body, err := json.Marshal(keycloakUserRequest)
 	if err != nil {

--- a/login/profile.go
+++ b/login/profile.go
@@ -103,6 +103,9 @@ func NewKeycloakUserProfileClient() *KeycloakUserProfileClient {
 // If the user already exists then the user will be updated
 // Returns true if a new user has been created and false if the existing user has been updated
 func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.Context, keycloakUserRequest *KeytcloakUserRequest, protectedAccessToken string, keycloakAdminUserAPIURL string) (*string, bool, error) {
+	defaultEnabledState := true
+	keycloakUserRequest.Enabled = &defaultEnabledState
+
 	body, err := json.Marshal(keycloakUserRequest)
 	if err != nil {
 		return nil, false, errors.NewInternalError(ctx, err)

--- a/login/profile_user_blackbox_test.go
+++ b/login/profile_user_blackbox_test.go
@@ -166,6 +166,34 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakUpdateExistingUser() {
 
 }
 
+func (s *ProfileUserBlackBoxTest) TestCreateKeycloakUserWithDefaults() {
+
+	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
+	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
+	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.NewV4().String()
+	testURL := "updatedURLNew" + uuid.NewV4().String()
+	testImageURL := "updatedBio" + uuid.NewV4().String()
+	testUserName := "sev1testsbosetestusercreate" + uuid.NewV4().String()
+
+	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{
+		login.ImageURLAttributeName: []string{testImageURL},
+		login.BioAttributeName:      []string{testBio},
+		login.URLAttributeName:      []string{testURL},
+	}
+
+	testKeycloakUserData := login.KeytcloakUserRequest{
+		Username:   &testUserName,
+		FirstName:  &testFirstName,
+		LastName:   &testLastName,
+		Email:      &testEmail,
+		Attributes: testKeycloakUserProfileAttributes,
+	}
+
+	s.createUser(&testKeycloakUserData)
+	// verified on keycloak
+}
+
 func (s *ProfileUserBlackBoxTest) TestKeycloakCreateNewUserWithExistingEmail() {
 	// UPDATE the user profile
 


### PR DESCRIPTION
- when new user is created by online-registration app, `enable` it  and also set `emailVerified=true` *always*.
- when new user is created, make `emailPrivate = false` in order to not deviate from current behavior.
- support passing of the RHD user id in the payload. That would be used for linking.
  