### PR TITLE
Fix health prob

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -220,10 +220,11 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 		msg := "no restrictions for valid redirect URLs"
 		c.appendDefaultConfigErrorMessage(&msg)
 	}
-	if c.GetNotificationServiceURL() == "" {
-		msg := "notification service url is empty"
-		c.appendDefaultConfigErrorMessage(&msg)
-	}
+	// TODO add this env var via Config Map first:
+	// if c.GetNotificationServiceURL() == "" {
+	// 	msg := "notification service url is empty"
+	// 	c.appendDefaultConfigErrorMessage(&msg)
+	// }
 	if c.defaultConfigurationError != nil {
 		log.WithFields(map[string]interface{}{
 			"default_configuration_error": c.defaultConfigurationError.Error(),

--- a/controller/status_test.go
+++ b/controller/status_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	expectedDefaultConfDevModeErrorMessage  = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; developer Mode is enabled; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used; no restrictions for valid redirect URLs; notification service url is empty"
-	expectedDefaultConfProdModeErrorMessage = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used; notification service url is empty"
+	expectedDefaultConfDevModeErrorMessage  = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; developer Mode is enabled; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used; no restrictions for valid redirect URLs"
+	expectedDefaultConfProdModeErrorMessage = "Error: /etc/fabric8/service-account-secrets.conf is not used; /etc/fabric8/oso-clusters.conf is not used; default service account private key is used; default service account private key ID is used; default DB password is used; default Keycloak client secret is used; default GitHub client secret is used"
 )
 
 type TestStatusREST struct {


### PR DESCRIPTION
Readiness prob is broken after merging https://github.com/fabric8-services/fabric8-auth/pull/227
We need to add the tenant URL in Config Map first then we can check if it's empty in our readiness prob.

Removing it from the prob until we fix our Config Map.
