### PR TITLE
Override email privacy using notification service token

### DIFF
--- a/configuration/conf-files/service-account-secrets.conf
+++ b/configuration/conf-files/service-account-secrets.conf
@@ -24,6 +24,11 @@
             "name":"online-registration",
             "id":"f867ec72-3171-4b8f-8eec-90a32eab6e0b",
             "secrets":["jIR5FpYq0QUUzMEKqiAIVloNBCL3v1nOPxq9Wm07vTsJhKGNBRWWsdknK4x4el3"]
+        },
+        {
+            "name":"fabric8-notification",
+            "id":"4c34f6d4-f00b-487b-9a1f-e7d1adba6866",
+            "secrets":["$2a$04$ynqM/syKMYowMIn5cyqHuevWnfzIQqtyY4m.61B02qltY5SOyGIOe", "$2a$04$sbC/AfW2c33hv8orGA.1D.LXa/.IY76VWhsfqxCVhrhFkDfL0/XGK"]
         }
     ]
 }

--- a/configuration/conf-files/service-account-secrets.conf
+++ b/configuration/conf-files/service-account-secrets.conf
@@ -13,22 +13,22 @@
         {
             "name":"fabric8-jenkins-idler",
             "id":"341c283f-0cd7-48a8-9281-4583aceb3617",
-            "secrets":["$2a$04$hbGHAVKohpeDgHzafnLwdO4ZzhEn9ukVP/6CaOtf5o3Btp.r6tXTG"]
+            "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
         },
         {
             "name":"fabric8-oso-proxy",
             "id":"96ee3f91-f980-429f-a4e8-060c3258031d",
-            "secrets":["$2a$04$hbGHAVKohpeDgHzafnLwdO4ZzhEn9ukVP/6CaOtf5o3Btp.r6tXTG"]
+            "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
         },
         {
             "name":"online-registration",
             "id":"f867ec72-3171-4b8f-8eec-90a32eab6e0b",
-            "secrets":["jIR5FpYq0QUUzMEKqiAIVloNBCL3v1nOPxq9Wm07vTsJhKGNBRWWsdknK4x4el3"]
+            "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
         },
         {
             "name":"fabric8-notification",
             "id":"4c34f6d4-f00b-487b-9a1f-e7d1adba6866",
-            "secrets":["$2a$04$ynqM/syKMYowMIn5cyqHuevWnfzIQqtyY4m.61B02qltY5SOyGIOe", "$2a$04$sbC/AfW2c33hv8orGA.1D.LXa/.IY76VWhsfqxCVhrhFkDfL0/XGK"]
+            "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
         }
     ]
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -326,6 +326,13 @@ func (c *ConfigurationData) DefaultConfigurationError() error {
 }
 
 // GetServiceAccounts returns a map of service account configurations by service account ID
+// Default Service Account names and secrets used in Dev mode:
+// "fabric8-wit" : "witsecret"
+// "fabric8-tenant : ["tenantsecretOld", "tenantsecretNew"]
+// "fabric8-jenkins-idler : "secret"
+// "fabric8-oso-proxy : "secret"
+// "online-registration : "secret"
+// "fabric8-notification : "secret"
 func (c *ConfigurationData) GetServiceAccounts() map[string]ServiceAccount {
 	return c.sa
 }

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -373,16 +373,6 @@ func checkServiceAccountConfiguration(t *testing.T, accounts map[string]configur
 		ID:      "c211f1bd-17a7-4f8c-9f80-0917d167889d",
 		Name:    "fabric8-tenant",
 		Secrets: []string{"$2a$04$ynqM/syKMYowMIn5cyqHuevWnfzIQqtyY4m.61B02qltY5SOyGIOe", "$2a$04$sbC/AfW2c33hv8orGA.1D.LXa/.IY76VWhsfqxCVhrhFkDfL0/XGK"}})
-
-	checkServiceAccount(t, accounts, configuration.ServiceAccount{
-		ID:      "341c283f-0cd7-48a8-9281-4583aceb3617",
-		Name:    "fabric8-jenkins-idler",
-		Secrets: []string{"$2a$04$hbGHAVKohpeDgHzafnLwdO4ZzhEn9ukVP/6CaOtf5o3Btp.r6tXTG"}})
-
-	checkServiceAccount(t, accounts, configuration.ServiceAccount{
-		ID:      "f867ec72-3171-4b8f-8eec-90a32eab6e0b",
-		Name:    "online-registration",
-		Secrets: []string{"jIR5FpYq0QUUzMEKqiAIVloNBCL3v1nOPxq9Wm07vTsJhKGNBRWWsdknK4x4el3"}})
 }
 
 func checkServiceAccount(t *testing.T, accounts map[string]configuration.ServiceAccount, expected configuration.ServiceAccount) {

--- a/controller/users.go
+++ b/controller/users.go
@@ -66,6 +66,12 @@ func NewUsersController(service *goa.Service, db application.DB, config UsersCon
 
 // Show runs the show action.
 func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
+	isServiceAccount := token.IsSpecificServiceAccount(ctx, "fabric8-notification")
+	authenticatedRequest := false
+	if isServiceAccount {
+		authenticatedRequest = true
+	}
+
 	return application.Transactional(c.db, func(appl application.Application) error {
 		identityID, err := uuid.FromString(ctx.ID)
 		if err != nil {
@@ -85,7 +91,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 			}
 		}
 		return ctx.ConditionalRequest(*user, c.config.GetCacheControlUser, func() error {
-			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, false))
+			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, authenticatedRequest))
 		})
 	})
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -68,10 +68,6 @@ func NewUsersController(service *goa.Service, db application.DB, config UsersCon
 // Show runs the show action.
 func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 	isServiceAccount := token.IsSpecificServiceAccount(ctx, "fabric8-notification")
-	authenticatedRequest := false
-	if isServiceAccount {
-		authenticatedRequest = true
-	}
 
 	return application.Transactional(c.db, func(appl application.Application) error {
 		identityID, err := uuid.FromString(ctx.ID)
@@ -92,7 +88,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 			}
 		}
 		return ctx.ConditionalRequest(*user, c.config.GetCacheControlUser, func() error {
-			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, authenticatedRequest))
+			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity, isServiceAccount))
 		})
 	})
 }

--- a/test/account.go
+++ b/test/account.go
@@ -63,6 +63,12 @@ var TestOnlineRegistrationAppIdentity = account.Identity{
 	User:     TestUser,
 }
 
+var TestNotificationIdentity = account.Identity{
+	ID:       uuid.NewV4(),
+	Username: "fabric8-notification",
+	User:     TestUser,
+}
+
 // CreateTestIdentity creates an identity with the given `username` in the database. For testing purpose only.
 func CreateTestIdentity(db *gorm.DB, username, providerType string) (account.Identity, error) {
 	testIdentity := account.Identity{


### PR DESCRIPTION
Partially fixes https://github.com/fabric8-services/fabric8-notification/issues/52

**TODO**

- [x] Add tests
- [x] Update `GET /api/users/<ID>` API

**How to test**

1. Get service account token: 
```
curl --request POST   -d "grant_type=client_credentials&client_id=4c34f6d4-f00b-487b-9a1f-e7d1adba6866&client_secret=secret"  --url http://localhost:8089/api/token  
```

2. Pass token in the request 
```
curl --header "authorization: bearer $token" http://localhost:8089/api/users/7587730b-a4c0-4023-aa3a-dde91a3f5fd5
```
  
  