### PR TITLE
send the identity id instead of user id

### DIFF
--- a/account/email/verification_service_blackbox_test.go
+++ b/account/email/verification_service_blackbox_test.go
@@ -41,7 +41,7 @@ func (s *verificationServiceBlackboxTest) TestSendVerificationCodeOK() {
 		Request: &http.Request{Host: "example.com"},
 	}
 
-	generatedCode, err := s.verificationService.SendVerificationCode(context.Background(), r, identity.User)
+	generatedCode, err := s.verificationService.SendVerificationCode(context.Background(), r, identity)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), generatedCode)
 

--- a/controller/users.go
+++ b/controller/users.go
@@ -614,6 +614,8 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			return err
 		}
 
+		identity.User = *user
+
 		return nil
 	})
 
@@ -626,7 +628,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 	}
 
 	if isEmailVerificationNeeded {
-		_, err = c.EmailVerificationService.SendVerificationCode(ctx, ctx.RequestData, *user)
+		_, err = c.EmailVerificationService.SendVerificationCode(ctx, ctx.RequestData, *identity)
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"identity_id": id.String(),

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -171,7 +171,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 
 		t.Run("internal level allowed", func(t *testing.T) {
 			// given
-			user := s.createRandomUser("TestUpdateUserOK", WithEmailAddress("user@redhat.com"), WithEmailAddressVerified(true))
+			user := s.createRandomUser("TestUpdateUserOK", WithEmailAddress(uuid.NewV4().String()+"user@redhat.com"), WithEmailAddressVerified(true))
 			identity, err := testsupport.CreateTestUser(s.DB, &user)
 			require.NoError(t, err)
 			// when


### PR DESCRIPTION
because the notification service uses the `GET /api/users/<identity-id>` to look up user details.
  