### PR TITLE
Fix params in email verify redirect URL

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -859,7 +859,7 @@ func (c *UsersController) VerifyEmail(ctx *app.VerifyEmailUsersContext) error {
 		return err
 	}
 	if errResponse != "" {
-		redirectURL, err = rest.AddParam(c.config.GetEmailVerifiedRedirectURL(), "error", errResponse)
+		redirectURL, err = rest.AddParam(redirectURL, "error", errResponse)
 		if err != nil {
 			return err
 		}

--- a/controller/users.go
+++ b/controller/users.go
@@ -24,7 +24,7 @@ import (
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 // UsersController implements the users resource.
@@ -854,7 +854,16 @@ func (c *UsersController) VerifyEmail(ctx *app.VerifyEmailUsersContext) error {
 		errResponse = "unable to verify code"
 		isVerified = "false"
 	}
-	redirectURL := fmt.Sprintf("%s?verified=%s&error=%s", c.config.GetEmailVerifiedRedirectURL(), isVerified, errResponse)
+	redirectURL, err := rest.AddParam(c.config.GetEmailVerifiedRedirectURL(), "verified", string(isVerified))
+	if err != nil {
+		return err
+	}
+	if errResponse != "" {
+		redirectURL, err = rest.AddParam(c.config.GetEmailVerifiedRedirectURL(), "error", errResponse)
+		if err != nil {
+			return err
+		}
+	}
 	ctx.ResponseData.Header().Set("Location", redirectURL)
 	return ctx.TemporaryRedirect()
 }

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -850,7 +850,7 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 
 		rw := test.VerifyEmailUsersTemporaryRedirect(s.T(), secureService.Context, secureService, secureController, verificationCode)
 		redirectLocation := rw.Header().Get("Location")
-		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?verified=true&error=", redirectLocation)
+		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?verified=true", redirectLocation)
 
 		codes, err = s.Application.VerificationCodes().Query(account.VerificationCodeWithUser(), account.VerificationCodeFilterByUserID(user.ID))
 		require.NoError(s.T(), err)
@@ -866,7 +866,7 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 		secureService, secureController := s.SecuredController(identity)
 		rw := test.VerifyEmailUsersTemporaryRedirect(s.T(), secureService.Context, secureService, secureController, "ABCD")
 		redirectLocation := rw.Header().Get("Location")
-		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?verified=false&error=code with id 'ABCD' not found", redirectLocation)
+		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?error=code+with+id+%27ABCD%27+not+found", redirectLocation)
 	})
 
 }

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/login/link"
 	"github.com/fabric8-services/fabric8-auth/resource"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
+
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -866,9 +867,9 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 		secureService, secureController := s.SecuredController(identity)
 		rw := test.VerifyEmailUsersTemporaryRedirect(s.T(), secureService.Context, secureService, secureController, "ABCD")
 		redirectLocation := rw.Header().Get("Location")
-		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?error=code+with+id+%27ABCD%27+not+found", redirectLocation)
+		require.Nil(s.T(), err)
+		testsupport.EqualURLs(s.T(), "https://prod-preview.openshift.io/_home?verified=false&error=code+with+id+%27ABCD%27+not+found", redirectLocation)
 	})
-
 }
 
 func (s *UsersControllerTestSuite) TestShowUserOK() {

--- a/rest/url.go
+++ b/rest/url.go
@@ -70,7 +70,7 @@ func AddParams(urlString string, params map[string]string) (string, error) {
 		return "", err
 	}
 
-	parameters := url.Values{}
+	parameters := parsedURL.Query()
 	for k, v := range params {
 		parameters.Add(k, v)
 	}

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/fabric8-services/fabric8-auth/resource"
+
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,4 +120,22 @@ func TestAddParamSuccess(t *testing.T) {
 	generatedURL, err := AddParam("https://openshift.io", "param1", "a")
 	require.NoError(t, err)
 	assert.Equal(t, "https://openshift.io?param1=a", generatedURL)
+
+	generatedURL, err = AddParam(generatedURL, "param2", "abc")
+	require.NoError(t, err)
+	equalURLs(t, "https://openshift.io?param1=a&param2=abc", generatedURL)
+}
+
+// Can't use test.EqualURLs() because of cycle dependency
+func equalURLs(t *testing.T, expected string, actual string) {
+	expectedURL, err := url.Parse(expected)
+	require.Nil(t, err)
+	actualURL, err := url.Parse(actual)
+	require.Nil(t, err)
+	assert.Equal(t, expectedURL.Scheme, actualURL.Scheme)
+	assert.Equal(t, expectedURL.Host, actualURL.Host)
+	assert.Equal(t, len(expectedURL.Query()), len(actualURL.Query()))
+	for name, value := range expectedURL.Query() {
+		assert.Equal(t, value, actualURL.Query()[name])
+	}
 }

--- a/test/common.go
+++ b/test/common.go
@@ -9,10 +9,6 @@ import (
 	"testing"
 )
 
-const maxValidNameLength = 62
-
-var TestOversizedNameObj = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 // CreateRandomValidTestName functions creates a valid lenght name
 func CreateRandomValidTestName(name string) string {
 	randomName := name + uuid.NewV4().String()

--- a/test/common.go
+++ b/test/common.go
@@ -2,7 +2,11 @@
 package test
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/url"
+	"testing"
 )
 
 const maxValidNameLength = 62
@@ -16,4 +20,17 @@ func CreateRandomValidTestName(name string) string {
 		return randomName[:61]
 	}
 	return randomName
+}
+
+func EqualURLs(t *testing.T, expected string, actual string) {
+	expectedURL, err := url.Parse(expected)
+	require.Nil(t, err)
+	actualURL, err := url.Parse(actual)
+	require.Nil(t, err)
+	assert.Equal(t, expectedURL.Scheme, actualURL.Scheme)
+	assert.Equal(t, expectedURL.Host, actualURL.Host)
+	assert.Equal(t, len(expectedURL.Query()), len(actualURL.Query()))
+	for name, value := range expectedURL.Query() {
+		assert.Equal(t, value, actualURL.Query()[name])
+	}
 }


### PR DESCRIPTION
- If no there is no error then do not add "error" param
- Encode params so the redirect URL can contain predefined params in configuration. Plus error message can may be not URL friendly.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/258