### PR TITLE
update keycloak on email verification

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -889,6 +889,10 @@ func (c *UsersController) VerifyEmail(ctx *app.VerifyEmailUsersContext) error {
 
 			identity, err := loadKeyCloakIdentity(c.db, verfiedUser)
 			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"err":     err,
+					"user_id": verfiedUser.ID,
+				}, "failed to fetch identity for a specific user")
 				return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 			}
 

--- a/controller/users.go
+++ b/controller/users.go
@@ -865,8 +865,8 @@ func (c *UsersController) VerifyEmail(ctx *app.VerifyEmailUsersContext) error {
 		}
 	}
 
-	verfiedUser := verifiedCode.User
 	if isVerified {
+		verfiedUser := verifiedCode.User
 		tokenEndpoint, err := c.config.GetKeycloakEndpointToken(ctx.RequestData)
 		if err != nil {
 			return errors.NewInternalError(ctx, err)

--- a/controller/users.go
+++ b/controller/users.go
@@ -876,6 +876,7 @@ func (c *UsersController) VerifyEmail(ctx *app.VerifyEmailUsersContext) error {
 			log.Error(ctx, map[string]interface{}{
 				"keycloak_client_id": c.config.GetKeycloakClientID(),
 				"token_endpoint":     tokenEndpoint,
+				"err":                err,
 			}, "error generating PAT")
 			// if there's an error, we are not gonna bother the user
 		}


### PR DESCRIPTION
Upon email verification, I'm using the same API we used to create/update user , to update the user.
Not using the user profile Update API because that needs a user token, and in the verification controller, the user token is absent.

