### PR TITLE
Add for param to WWW-authenticate header to link accounts

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -272,7 +272,7 @@ func (c *TokenController) Retrieve(ctx *app.RetrieveTokenContext) error {
 			"provider_name": providerName,
 		}, "Unable to obtain external token from Keycloak. Account linking may be required.")
 
-		linkURL := rest.AbsoluteURL(ctx.RequestData, client.LinkTokenPath())
+		linkURL := rest.AbsoluteURL(ctx.RequestData, fmt.Sprintf("%s?for=%s", client.LinkTokenPath(), ctx.For))
 		errorResponse := fmt.Sprintf("LINK url=%s, description=\"%s token is missing. Link %s account\"", linkURL, providerName, providerName)
 		ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
 		ctx.ResponseData.Header().Set("WWW-Authenticate", errorResponse)

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -184,7 +184,7 @@ func (rest *TestTokenStorageREST) checkRetrieveExternalTokenUnauthorized(for_ st
 
 	err = controller.Retrieve(tokenCtx)
 	require.NotNil(rest.T(), err)
-	expectedHeaderValue := fmt.Sprintf("LINK url=https://auth.localhost.io/api/token/link, description=\"%s token is missing. Link %s account\"", providerName, providerName)
+	expectedHeaderValue := fmt.Sprintf("LINK url=https://auth.localhost.io/api/token/link?for=%s, description=\"%s token is missing. Link %s account\"", for_, providerName, providerName)
 	assert.Contains(rest.T(), rw.Header().Get("WWW-Authenticate"), expectedHeaderValue)
 	assert.Contains(rest.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
 }


### PR DESCRIPTION
So, the new format is `WWW-Authenticate: LINK url=https://auth.openshift.io/api/token/link?for=https://github.com, description=”GitHub token is missing. Link GitHub account”`

