### PR TITLE
Add expires_in to token response. Some cleanup

### DIFF
--- a/design/token.go
+++ b/design/token.go
@@ -218,12 +218,14 @@ var OauthToken = a.MediaType("application/vnd.oauthtoken+json", func() {
 	a.Description("Oauth 2.0 token payload")
 	a.Attributes(func() {
 		a.Attribute("access_token", d.String, "Access token")
-		a.Attribute("expiry", d.String, "Expiry")
+		a.Attribute("expires_in", d.String, "Access token expires in seconds")
+		a.Attribute("expiry", d.String, "The same as expires_in.")
 		a.Attribute("refresh_token", d.String, "RefreshToken")
 		a.Attribute("token_type", d.String, "Token type")
 	})
 	a.View("default", func() {
 		a.Attribute("access_token")
+		a.Attribute("expires_in")
 		a.Attribute("expiry")
 		a.Attribute("refresh_token")
 		a.Attribute("token_type")


### PR DESCRIPTION
- Adds `expires_in` to token response. `expires_in` seems to be a standard name for that attribute in OAuth2 and OpenID Connect but some dialects uses expiry. So, let's use both to be safe.
- Some clean up

This is a followup on https://github.com/fabric8-services/fabric8-auth/pull/272 and https://github.com/fabric8-services/fabric8-auth/issues/270
