### PR TITLE
Remove expiry

### DIFF
--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -221,6 +221,8 @@ func (rest *TestTokenREST) checkAuthorizationCode(service *goa.Service, controll
 	require.Equal(rest.T(), rest.sampleAccessToken, *token.AccessToken)
 	require.NotNil(rest.T(), token.RefreshToken)
 	require.Equal(rest.T(), rest.sampleRefreshToken, *token.RefreshToken)
+	thirtyDays := string(60 * 60 * 24 * 30)
+	require.Equal(rest.T(), thirtyDays, *token.ExpiresIn)
 }
 
 type DummyLinkService struct {

--- a/design/token.go
+++ b/design/token.go
@@ -219,14 +219,12 @@ var OauthToken = a.MediaType("application/vnd.oauthtoken+json", func() {
 	a.Attributes(func() {
 		a.Attribute("access_token", d.String, "Access token")
 		a.Attribute("expires_in", d.String, "Access token expires in seconds")
-		a.Attribute("expiry", d.String, "The same as expires_in.")
 		a.Attribute("refresh_token", d.String, "RefreshToken")
 		a.Attribute("token_type", d.String, "Token type")
 	})
 	a.View("default", func() {
 		a.Attribute("access_token")
 		a.Attribute("expires_in")
-		a.Attribute("expiry")
 		a.Attribute("refresh_token")
 		a.Attribute("token_type")
 	})


### PR DESCRIPTION
OAuth2 and OpenID Connect specifies expire_in. Not expiry. Some dialects still use expiry (for example go oauth2 token uses expiry) but we do not have any clients yet which use our authorize and token/refresh endpoints. So, it's safe now to support the OAuth2 and OpenID Connect expire_in attribute only and drop expiry. Especially because we misused expiry attribute. Expiry is supposed to be an int which represents a Unix time stamp. Not a string.