### PR TITLE
Make the `featureLevel` not optional in the user's profile (OSIO#1937)

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -31,7 +31,7 @@ type User struct {
 	Bio                string             // The bio of the User
 	URL                string             // The URL of the User
 	Company            string             // The (optional) Company of the User
-	FeatureLevel       string             // the (optional) level of features that the user opted in (to access unreleased features). Defaults to `released` so no non-released feature is enabled for the user.
+	FeatureLevel       string             // the level of features that the user opted in (to access unreleased features). Defaults to `released` so no non-released feature is enabled for the user.
 	Cluster            string             // The OpenShift cluster allocted to the user.
 	EmailVerified      bool               // The verification status of the updated email.
 	Identities         []Identity         // has many Identities from different IDPs

--- a/account/user.go
+++ b/account/user.go
@@ -31,12 +31,17 @@ type User struct {
 	Bio                string             // The bio of the User
 	URL                string             // The URL of the User
 	Company            string             // The (optional) Company of the User
-	FeatureLevel       *string            // the (optional) level of features that the user opted in (to access unreleased features). Defaults to `released` so no non-released feature is enabled for the user.
+	FeatureLevel       string             // the (optional) level of features that the user opted in (to access unreleased features). Defaults to `released` so no non-released feature is enabled for the user.
 	Cluster            string             // The OpenShift cluster allocted to the user.
 	EmailVerified      bool               // The verification status of the updated email.
 	Identities         []Identity         // has many Identities from different IDPs
 	ContextInformation ContextInformation `sql:"type:jsonb"` // context information of the user activity
 }
+
+const (
+	// DefaultFeatureLevel the default feature level for users: `released`, which means that they don't have access to preproduction/unreleased features.
+	DefaultFeatureLevel string = "released" // the default value, which is also the default DB column value
+)
 
 // TableName overrides the table name settings in Gorm to force a specific table name
 // in the database.

--- a/design/account.go
+++ b/design/account.go
@@ -278,6 +278,7 @@ var createUserDataAttributes = a.Type("CreateIdentityDataAttributes", func() {
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("cluster", d.String, "The OpenShift API URL of the cluster where the user is provisioned to")
 	a.Attribute("providerType", d.String, "The IDP provided this identity")
+	a.Attribute("featureLevel", d.String, "The level of features that the user wants to use (for unreleased features)")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})
 	})

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -158,6 +158,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// verion 16
 	m = append(m, steps{ExecuteSQLFile("016-add-state-to-auth-state-reference.sql")})
 
+	// verion 17
+	m = append(m, steps{ExecuteSQLFile("017-feature-level-not-null.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/017-feature-level-not-null.sql
+++ b/migration/sql-files/017-feature-level-not-null.sql
@@ -1,0 +1,4 @@
+-- the 'feature_level' column as not null with a default value
+UPDATE users SET feature_level = 'released' WHERE feature_level IS NULL;
+ALTER TABLE users ALTER COLUMN feature_level SET NOT NULL;
+ALTER TABLE users ALTER COLUMN feature_level SET default 'released';

--- a/test/account.go
+++ b/test/account.go
@@ -100,13 +100,12 @@ func CreateTestUser(db *gorm.DB, user *account.User) (account.Identity, error) {
 		ProviderType: account.KeycloakIDP,
 	}
 	err := models.Transactional(db, func(tx *gorm.DB) error {
-		userCreationError := userRepository.Create(context.Background(), user)
-		if userCreationError != nil {
-			return userCreationError
+		err := userRepository.Create(context.Background(), user)
+		if err != nil {
+			return err
 		}
 		identity.User = *user
 		identity.UserID.UUID = user.ID
-
 		return identityRepository.Create(context.Background(), &identity)
 	})
 	return identity, err


### PR DESCRIPTION
Make the field in the `user` type as a `string` instead of `*string`.
Make the DB column `NOT NULL` in the DB with a default value to `released`,
and update all existing records.

Also, refactored some code to reduce the amount of lines to init user/indentity.

Fixes openshiftio/openshift.io#1937

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>