### PR TITLE
Fix test failures on conditional request (#299)

### DIFF
--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -1,7 +1,6 @@
 package controller_test
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -18,7 +17,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormapplication"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
-	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/resource"
 	"github.com/fabric8-services/fabric8-auth/space/authz"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
@@ -595,16 +593,6 @@ func assertResponseHeaders(t *testing.T, res http.ResponseWriter) (string, strin
 	cacheControl, err := getHeader(res, app.CacheControl)
 	require.NoError(t, err)
 	return *eTag, *lastModified, *cacheControl
-}
-
-func getHeader(res http.ResponseWriter, headerName string) (*string, error) {
-	values := res.Header()[headerName]
-	if len(values) == 0 {
-		return nil, fmt.Errorf("No '%s' header was found in the response", values)
-	}
-	value := values[0]
-	log.Debug(nil, map[string]interface{}{headerName: value}, "retrieved response header")
-	return &value, nil
 }
 
 type DummyResourceManager struct {

--- a/controller/conditional_request_test.go
+++ b/controller/conditional_request_test.go
@@ -1,0 +1,19 @@
+package controller_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/fabric8-services/fabric8-auth/log"
+)
+
+// getHeader a utility function to retrieve the (first) value of a response header given its name.
+func getHeader(res http.ResponseWriter, headerName string) (*string, error) {
+	values := res.Header()[headerName]
+	if len(values) == 0 {
+		return nil, fmt.Errorf("No '%s' header was found in the response", values)
+	}
+	value := values[0]
+	log.Debug(nil, map[string]interface{}{headerName: value}, "retrieved response header")
+	return &value, nil
+}


### PR DESCRIPTION
Instead of computing the value of the request header to use
(`If-Modified-Since` or `If-None-Match`), send a request with
no specific header, read the response header and reuse it in a
subsequent request to check that the server responds with a
`304 Not Modified` response. The test does not need to make the
header computation, just verify that the server can process it
as expected.

Fixes #299

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>