### PR TITLE
Add console and metrics URLs to /clusters

### DIFF
--- a/configuration/conf-files/tests/oso-clusters-custom-urls.conf
+++ b/configuration/conf-files/tests/oso-clusters-custom-urls.conf
@@ -1,0 +1,17 @@
+{
+    "clusters": [
+        {
+            "name":"us-east-2",
+            "api-url":"https://api.starter-us-east-2.openshift.com",
+            "console-url": "custom.console.url",
+            "metrics-url": "custom.metrics.url",
+            "app-dns":"8a09.starter-us-east-2.openshiftapps.com",
+            "service-account-token":"fX0nH3d68LQ6SK5wBE6QeKJ6X8AZGVQO3dGQZZETakhmgmWAqr2KDFXE65KUwBO69aWoq",
+            "service-account-username":"dsaas",
+            "token-provider-id":"f867ac10-5e05-4359-a0c6-b855ece59090",
+            "auth-client-id":"autheast2",
+            "auth-client-secret":"autheast2secret",
+            "auth-client-default-scope":"user:full"
+        }
+    ]
+}

--- a/configuration/conf-files/tests/oso-clusters-missing-keys.conf
+++ b/configuration/conf-files/tests/oso-clusters-missing-keys.conf
@@ -1,0 +1,7 @@
+{
+    "clusters": [
+        {
+            "api-url":"https://api.starter-us-east-2.openshift.com"
+        }
+    ]
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -14,6 +14,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
+	"net/url"
+	"reflect"
 )
 
 // String returns the current configuration as a string
@@ -116,6 +118,8 @@ type ServiceAccount struct {
 type OSOCluster struct {
 	Name                   string `mapstructure:"name"`
 	APIURL                 string `mapstructure:"api-url"`
+	ConsoleURL             string `mapstructure:"console-url"` // Optional in oso-clusters.conf
+	MetricsURL             string `mapstructure:"metrics-url"` // Optional in oso-clusters.conf
 	AppDNS                 string `mapstructure:"app-dns"`
 	ServiceAccountToken    string `mapstructure:"service-account-token"`
 	ServiceAccountUsername string `mapstructure:"service-account-username"`
@@ -141,7 +145,7 @@ type ConfigurationData struct {
 
 // NewConfigurationData creates a configuration reader object using configurable configuration file paths
 func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string, osoClusterConfigFile string) (*ConfigurationData, error) {
-	c := ConfigurationData{
+	c := &ConfigurationData{
 		v: viper.New(),
 	}
 
@@ -163,6 +167,9 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 
 	// Set up the service account configuration (stored in a separate config file)
 	saViper, defaultConfigErrorMsg, err := readFromJSONFile(serviceAccountConfigFile, defaultServiceAccountConfigPath, serviceAccountConfigFileName)
+	if err != nil {
+		return nil, err
+	}
 	c.appendDefaultConfigErrorMessage(defaultConfigErrorMsg)
 
 	var saConf serviceAccountConfig
@@ -177,15 +184,30 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 
 	// Set up the OSO cluster configuration (stored in a separate config file)
 	clusterViper, defaultConfigErrorMsg, err := readFromJSONFile(osoClusterConfigFile, defaultOsoClusterConfigPath, osoClusterConfigFileName)
+	if err != nil {
+		return nil, err
+	}
 	c.appendDefaultConfigErrorMessage(defaultConfigErrorMsg)
 
 	var clusterConf osoClusterConfig
-	err = clusterViper.UnmarshalExact(&clusterConf)
+	err = clusterViper.Unmarshal(&clusterConf)
 	if err != nil {
 		return nil, err
 	}
 	c.clusters = map[string]OSOCluster{}
 	for _, cluster := range clusterConf.Clusters {
+		if cluster.ConsoleURL == "" {
+			cluster.ConsoleURL, err = convertAPIURL(cluster.APIURL, "console", "console")
+			if err != nil {
+				return nil, err
+			}
+		}
+		if cluster.MetricsURL == "" {
+			cluster.MetricsURL, err = convertAPIURL(cluster.APIURL, "metrics", "hawkular/metrics/m/stats/query")
+			if err != nil {
+				return nil, err
+			}
+		}
 		c.clusters[cluster.APIURL] = cluster
 	}
 
@@ -227,13 +249,50 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 		msg := "notification service url is empty"
 		c.appendDefaultConfigErrorMessage(&msg)
 	}
+	c.checkClusterConfig()
 	if c.defaultConfigurationError != nil {
 		log.WithFields(map[string]interface{}{
 			"default_configuration_error": c.defaultConfigurationError.Error(),
 		}).Warningln("Default config is used! This is OK in Dev Mode.")
 	}
 
-	return &c, nil
+	return c, nil
+}
+
+// checkClusterConfig checks if there is any missing keys or empty values in oso-clusters.conf
+func (c *ConfigurationData) checkClusterConfig() {
+	for _, cluster := range c.clusters {
+		iVal := reflect.ValueOf(&cluster).Elem()
+		typ := iVal.Type()
+		for i := 0; i < iVal.NumField(); i++ {
+			f := iVal.Field(i)
+			tag := typ.Field(i).Tag.Get("mapstructure")
+			switch f.Interface().(type) {
+			case string:
+				if f.String() == "" {
+					msg := fmt.Sprintf("key %v is missing in cluster config", tag)
+					c.appendDefaultConfigErrorMessage(&msg)
+				}
+			default:
+				msg := fmt.Sprintf("wront type of key %v", tag)
+				c.appendDefaultConfigErrorMessage(&msg)
+			}
+		}
+	}
+}
+
+func convertAPIURL(apiURL string, newPrefix string, newPath string) (string, error) {
+	newURL, err := url.Parse(apiURL)
+	if err != nil {
+		return "", err
+	}
+	newHost, err := rest.ReplaceDomainPrefix(newURL.Host, newPrefix)
+	if err != nil {
+		return "", err
+	}
+	newURL.Host = newHost
+	newURL.Path = newPath
+	return newURL.String(), nil
 }
 
 func readFromJSONFile(configFilePath string, defaultConfigFilePath string, configFileName string) (*viper.Viper, *string, error) {

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -396,10 +396,47 @@ func TestLoadClusterConfigurationFromFile(t *testing.T) {
 	checkClusterConfiguration(t, clusters)
 }
 
+func TestClusterConfigurationWithMissingKeys(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	clusterConfig, err := configuration.NewConfigurationData("", "", "./conf-files/tests/oso-clusters-missing-keys.conf")
+	require.Nil(t, err)
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key name is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key app-dns is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key service-account-token is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key service-account-username is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key token-provider-id is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key auth-client-id is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key auth-client-secret is missing")
+	assert.Contains(t, clusterConfig.DefaultConfigurationError().Error(), "key auth-client-default-scope is missing")
+}
+
+func TestClusterConfigurationWithGeneratedURLs(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	clusterConfig, err := configuration.NewConfigurationData("", "", "./conf-files/tests/oso-clusters-custom-urls.conf")
+	require.Nil(t, err)
+	checkCluster(t, clusterConfig.GetOSOClusters(), configuration.OSOCluster{
+		Name:                   "us-east-2",
+		APIURL:                 "https://api.starter-us-east-2.openshift.com",
+		ConsoleURL:             "custom.console.url",
+		MetricsURL:             "custom.metrics.url",
+		AppDNS:                 "8a09.starter-us-east-2.openshiftapps.com",
+		ServiceAccountToken:    "fX0nH3d68LQ6SK5wBE6QeKJ6X8AZGVQO3dGQZZETakhmgmWAqr2KDFXE65KUwBO69aWoq",
+		ServiceAccountUsername: "dsaas",
+		TokenProviderID:        "f867ac10-5e05-4359-a0c6-b855ece59090",
+		AuthClientID:           "autheast2",
+		AuthClientSecret:       "autheast2secret",
+		AuthClientDefaultScope: "user:full",
+	})
+}
+
 func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.OSOCluster) {
 	checkCluster(t, clusters, configuration.OSOCluster{
 		Name:                   "us-east-2",
 		APIURL:                 "https://api.starter-us-east-2.openshift.com",
+		ConsoleURL:             "https://console.starter-us-east-2.openshift.com/console",
+		MetricsURL:             "https://metrics.starter-us-east-2.openshift.com/hawkular/metrics/m/stats/query",
 		AppDNS:                 "8a09.starter-us-east-2.openshiftapps.com",
 		ServiceAccountToken:    "fX0nH3d68LQ6SK5wBE6QeKJ6X8AZGVQO3dGQZZETakhmgmWAqr2KDFXE65KUwBO69aWoq",
 		ServiceAccountUsername: "dsaas",
@@ -411,6 +448,8 @@ func checkClusterConfiguration(t *testing.T, clusters map[string]configuration.O
 	checkCluster(t, clusters, configuration.OSOCluster{
 		Name:                   "us-east-2a",
 		APIURL:                 "https://api.starter-us-east-2a.openshift.com",
+		ConsoleURL:             "https://console.starter-us-east-2a.openshift.com/console",
+		MetricsURL:             "https://metrics.starter-us-east-2a.openshift.com/hawkular/metrics/m/stats/query",
 		AppDNS:                 "b542.starter-us-east-2a.openshiftapps.com",
 		ServiceAccountToken:    "ak61T6RSAacWFruh1vZP8cyUOBtQ3Chv1rdOBddSuc9nZ2wEcs81DHXRO55NpIpVQ8uiH",
 		ServiceAccountUsername: "dsaas",

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -38,9 +38,11 @@ func (c *ClustersController) Show(ctx *app.ShowClustersContext) error {
 	var data []*app.ClusterData
 	for _, clusterConfig := range c.config.GetOSOClusters() {
 		cluster := &app.ClusterData{
-			Name:   clusterConfig.Name,
-			APIURL: clusterConfig.APIURL,
-			AppDNS: clusterConfig.AppDNS,
+			Name:       clusterConfig.Name,
+			APIURL:     clusterConfig.APIURL,
+			ConsoleURL: clusterConfig.ConsoleURL,
+			MetricsURL: clusterConfig.MetricsURL,
+			AppDNS:     clusterConfig.AppDNS,
 		}
 		data = append(data, cluster)
 	}

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -47,6 +47,8 @@ func (rest *TestClustersREST) checkShowForServiceAccount(saName string) {
 		require.True(rest.T(), ok)
 		require.Equal(rest.T(), configCluster.Name, cluster.Name)
 		require.Equal(rest.T(), configCluster.APIURL, cluster.APIURL)
+		require.Equal(rest.T(), configCluster.ConsoleURL, cluster.ConsoleURL)
+		require.Equal(rest.T(), configCluster.MetricsURL, cluster.MetricsURL)
 		require.Equal(rest.T(), configCluster.AppDNS, cluster.AppDNS)
 	}
 }

--- a/design/clusters.go
+++ b/design/clusters.go
@@ -16,8 +16,10 @@ var clusterList = JSONList(
 var clusterData = a.Type("ClusterData", func() {
 	a.Attribute("name", d.String, "Cluster name")
 	a.Attribute("api-url", d.String, "API URL")
+	a.Attribute("console-url", d.String, "Web console URL")
+	a.Attribute("metrics-url", d.String, "Metrics URL")
 	a.Attribute("app-dns", d.String, "User application domain name in the cluster")
-	a.Required("name", "api-url", "app-dns")
+	a.Required("name", "console-url", "metrics-url", "api-url", "app-dns")
 })
 
 var _ = a.Resource("clusters", func() {


### PR DESCRIPTION
Two new URLs in cluster config are "console-url' and "metrics-url":

```
GET /api/clusters

{
    "data": [
        {
            "api-url": "https://api.starter-us-east-2.openshift.com",
            "app-dns": "8a09.starter-us-east-2.openshiftapps.com",
            "console-url": "https://console.starter-us-east-2.openshift.com/console",
            "metrics-url": "https://metrics.starter-us-east-2.openshift.com/hawkular/metrics/m/stats/query",
            "name": "us-east-2"
        }
    ]
}
```

Fixes https://github.com/fabric8-services/fabric8-auth/issues/302