### PR TITLE
Validate all incoming tokens

### DIFF
--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -2,29 +2,22 @@ package goamiddleware
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/token"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
-	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/goadesign/goa/middleware/security/jwt"
 )
 
 // TokenContext is a new goa middleware that aims to extract the token from the
 // Authorization header when possible. If the Authorization header is missing in the request,
 // no error is returned. However, if the Authorization header contains a
 // token, it will be stored it in the context.
-func TokenContext(validationKeys interface{}, validationFunc goa.Middleware, scheme *goa.JWTSecurity) goa.Middleware {
-	var rsaKeys []*rsa.PublicKey
-	var hmacKeys [][]byte
-
-	rsaKeys, ecdsaKeys, hmacKeys := partitionKeys(validationKeys)
-
+func TokenContext(tokenManager token.Manager, scheme *goa.JWTSecurity) goa.Middleware {
 	return func(nextHandler goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 			// TODO: implement the QUERY string handler too
@@ -38,118 +31,14 @@ func TokenContext(validationKeys interface{}, validationFunc goa.Middleware, sch
 				incomingToken := strings.Split(val, " ")[1]
 				log.Debug(ctx, nil, "extracted the incoming token %v ", incomingToken)
 
-				var (
-					token  *jwt.Token
-					err    error
-					parsed = false
-				)
-
-				if len(rsaKeys) > 0 {
-					token, err = parseRSAKeys(rsaKeys, "RS", incomingToken)
-					if err == nil {
-						parsed = true
-					}
+				token, err := tokenManager.Parse(ctx, incomingToken)
+				if err != nil {
+					return err
 				}
-
-				if !parsed && len(ecdsaKeys) > 0 {
-					token, err = parseECDSAKeys(ecdsaKeys, "ES", incomingToken)
-					if err == nil {
-						parsed = true
-					}
-				}
-
-				if !parsed && len(hmacKeys) > 0 {
-					token, err = parseHMACKeys(hmacKeys, "HS", incomingToken)
-					if err == nil {
-						parsed = true
-					}
-				}
-
-				if !parsed {
-					log.Warn(ctx, nil, "unable to parse JWT token: %v", err)
-				}
-
-				ctx = goajwt.WithJWT(ctx, token)
+				ctx = jwt.WithJWT(ctx, token)
 			}
 
 			return nextHandler(ctx, rw, req)
 		}
 	}
-}
-
-// partitionKeys sorts keys by their type.
-func partitionKeys(k interface{}) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) {
-	var (
-		rsaKeys   []*rsa.PublicKey
-		ecdsaKeys []*ecdsa.PublicKey
-		hmacKeys  [][]byte
-	)
-
-	switch typed := k.(type) {
-	case []byte:
-		hmacKeys = append(hmacKeys, typed)
-	case [][]byte:
-		hmacKeys = typed
-	case string:
-		hmacKeys = append(hmacKeys, []byte(typed))
-	case []string:
-		for _, s := range typed {
-			hmacKeys = append(hmacKeys, []byte(s))
-		}
-	case *rsa.PublicKey:
-		rsaKeys = append(rsaKeys, typed)
-	case []*rsa.PublicKey:
-		rsaKeys = typed
-	case *ecdsa.PublicKey:
-		ecdsaKeys = append(ecdsaKeys, typed)
-	case []*ecdsa.PublicKey:
-		ecdsaKeys = typed
-	}
-
-	return rsaKeys, ecdsaKeys, hmacKeys
-}
-
-func parseRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range rsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func parseECDSAKeys(ecdsaKeys []*ecdsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range ecdsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func parseHMACKeys(hmacKeys [][]byte, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, key := range hmacKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return key, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
 }

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func main() {
 		}, "failed to create token manager")
 	}
 	// Middleware that extracts and stores the token in the context
-	jwtMiddlewareTokenContext := goamiddleware.TokenContext(tokenManager.PublicKeys(), nil, app.NewJWTSecurity())
+	jwtMiddlewareTokenContext := goamiddleware.TokenContext(tokenManager, app.NewJWTSecurity())
 	service.Use(jwtMiddlewareTokenContext)
 
 	service.Use(login.InjectTokenManager(tokenManager))

--- a/token/token.go
+++ b/token/token.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sync"
 
+	autherrors "github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/log"
 	logintokencontext "github.com/fabric8-services/fabric8-auth/login/tokencontext"
 	"github.com/fabric8-services/fabric8-auth/rest"
@@ -82,6 +83,7 @@ type Permissions struct {
 // Manager generate and find auth token information
 type Manager interface {
 	Locate(ctx context.Context) (uuid.UUID, error)
+	Parse(ctx context.Context, tokenString string) (*jwt.Token, error)
 	ParseToken(ctx context.Context, tokenString string) (*TokenClaims, error)
 	ParseTokenWithMapClaims(ctx context.Context, tokenString string) (jwt.MapClaims, error)
 	PublicKey(keyID string) *rsa.PublicKey
@@ -445,6 +447,18 @@ func (mgm *tokenManager) GenerateUnsignedServiceAccountToken(req *goa.RequestDat
 	token.Claims.(jwt.MapClaims)["iss"] = rest.AbsoluteURL(req, "")
 	token.Claims.(jwt.MapClaims)["scopes"] = []string{"uma_protection"}
 	return token
+}
+
+func (mgm *tokenManager) Parse(ctx context.Context, tokenString string) (*jwt.Token, error) {
+	keyFunc := mgm.keyFunction(ctx)
+	jwtToken, err := jwt.Parse(tokenString, keyFunc)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "unable to parse token")
+		return nil, autherrors.NewUnauthorizedError(err.Error())
+	}
+	return jwtToken, nil
 }
 
 // IsSpecificServiceAccount checks if the request is done by a service account listed in the names param


### PR DESCRIPTION
Regardless of security declaration in goa design definition we should validate all incoming tokens.
For example if we do not require Authorization header in /api/users/:ID we still check the token in case the request is coming from a Service Account. We should validate such tokens anyway.

This PR modifies our logging middleware. Now we not only add all the tokens in the context but also validate them. If there is Authorization header with a bearer token then we will validate it. If token is not valid then 401 will be returned.