### PR TITLE
Explicitly read response body when closing it to avoid FD leaks

### DIFF
--- a/auth/authz.go
+++ b/auth/authz.go
@@ -198,7 +198,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		}, "unable to create a Keycloak resource")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create a Keycloak resource"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusCreated {
 		log.Error(ctx, map[string]interface{}{
@@ -247,7 +247,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 		}, "unable to obtain keycloak client ID")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to obtain keycloak client ID"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{
@@ -308,7 +308,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		}, "unable to create the Keycloak policy")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create the Keycloak policy"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusCreated {
 		log.Error(ctx, map[string]interface{}{
@@ -363,7 +363,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 		}, "unable to create the Keycloak permission")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create the Keycloak permission"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusCreated {
 		log.Error(ctx, map[string]interface{}{
@@ -415,7 +415,7 @@ func DeleteResource(ctx context.Context, kcResourceID string, authzEndpoint stri
 		}, "unable to delete the Keycloak resource")
 		return errors.NewInternalError(ctx, errs.Wrap(err, "unable to delete the Keycloak resource"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusNoContent {
 		log.Error(ctx, map[string]interface{}{
@@ -455,7 +455,7 @@ func DeletePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		}, "unable to delete the Keycloak policy")
 		return errors.NewInternalError(ctx, errs.Wrap(err, "unable to delete the Keycloak policy"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusNoContent {
 		log.Error(ctx, map[string]interface{}{
@@ -495,7 +495,7 @@ func DeletePermission(ctx context.Context, clientsEndpoint string, clientID stri
 		}, "unable to delete the Keycloak permission")
 		return errors.NewInternalError(ctx, errs.Wrap(err, "unable to delete the Keycloak permission"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusNoContent {
 		log.Error(ctx, map[string]interface{}{
@@ -536,7 +536,7 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 		}, "unable to obtain a Keycloak policy")
 		return nil, errors.NewInternalError(ctx, errs.Wrap(err, "unable to obtain a Keycloak policy"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	switch res.StatusCode {
 	case http.StatusOK:
@@ -604,7 +604,7 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		}, "unable to update the Keycloak policy")
 		return errors.NewInternalError(ctx, errs.Wrap(err, "unable to update the Keycloak policy"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusCreated {
 		log.Error(ctx, map[string]interface{}{
@@ -656,7 +656,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 		}, "unable to obtain entitlement resource")
 		return nil, errors.NewInternalError(ctx, errs.Wrap(err, "unable to obtain entitlement resource"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	switch res.StatusCode {
 	case http.StatusOK:
@@ -702,7 +702,7 @@ func GetUserInfo(ctx context.Context, userInfoEndpoint string, userAccessToken s
 		}, "unable to get user info from Keycloak")
 		return nil, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get user info from Keycloak"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{
@@ -739,7 +739,7 @@ func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, pro
 		}, "unable to get user from Keycloak")
 		return false, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get user from Keycloak"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	switch res.StatusCode {
 	case http.StatusOK:
@@ -767,7 +767,7 @@ func GetProtectedAPIToken(ctx context.Context, openidConnectTokenURL string, cli
 	if err != nil {
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "error when obtaining token"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	switch res.StatusCode {
 	case http.StatusOK:
 		// OK

--- a/controller/token.go
+++ b/controller/token.go
@@ -402,7 +402,7 @@ func (c *TokenController) exchangeWithGrantTypeRefreshToken(ctx *app.ExchangeTok
 		}, "unable to refresh token in Keycloak")
 		return nil, errors.NewInternalErrorFromString(ctx, "unable to refresh token in Keycloak")
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	switch res.StatusCode {
 	case 200:
 		// OK
@@ -647,7 +647,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 	if err != nil {
 		return nil, errors.NewInternalError(ctx, errs.Wrap(err, "error when obtaining token"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	if res.StatusCode != http.StatusOK {
 		bodyString := rest.ReadBody(res.Body)
 		log.Error(ctx, map[string]interface{}{

--- a/login/link/keycloak_idp.go
+++ b/login/link/keycloak_idp.go
@@ -63,7 +63,7 @@ func (c *KeycloakIDPServiceClient) Create(ctx context.Context, keycloakLinkIDPRe
 		}, "Unable to create idp link for RHD")
 		return errors.NewInternalError(ctx, err)
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 
 	bodyString := rest.ReadBody(resp.Body)

--- a/login/profile.go
+++ b/login/profile.go
@@ -141,7 +141,7 @@ func (userProfileClient *KeycloakUserProfileClient) CreateOrUpdate(ctx context.C
 		}, "Unable to create Keycloak user")
 		return nil, false, errors.NewInternalError(ctx, err)
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 
 	bodyString := rest.ReadBody(resp.Body)
@@ -237,7 +237,7 @@ func (userProfileClient *KeycloakUserProfileClient) updateAsAdmin(ctx context.Co
 		}, "Unable to update Keycloak user")
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer rest.CloseResponse(resp)
 
 	bodyString := rest.ReadBody(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
@@ -290,7 +290,7 @@ func (userProfileClient *KeycloakUserProfileClient) loadUser(ctx context.Context
 		}, "Unable to load Keycloak user")
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer rest.CloseResponse(resp)
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -347,7 +347,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(ctx context.Context, 
 		}, "Unable to update Keycloak user profile")
 		return errors.NewInternalError(ctx, err)
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 
 	bodyString := rest.ReadBody(resp.Body)
@@ -400,7 +400,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(ctx context.Context, acc
 		}, "Unable to fetch Keycloak user profile")
 		return nil, errors.NewInternalError(ctx, err)
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/token/keycloak/external_token.go
+++ b/token/keycloak/external_token.go
@@ -67,7 +67,7 @@ func (c *KeycloakExternalTokenServiceClient) Get(ctx context.Context, accessToke
 		}, "Unable to fetch external keycloak token")
 		return nil, errors.NewInternalError(ctx, err)
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		bodyString := rest.ReadBody(resp.Body)
@@ -124,7 +124,7 @@ func (c *KeycloakExternalTokenServiceClient) Delete(ctx context.Context, keycloa
 		}, "Unable to delete Identity Provider link from Keycloak")
 		return err
 	} else if resp != nil {
-		defer resp.Body.Close()
+		defer rest.CloseResponse(resp)
 	}
 	if resp.StatusCode != http.StatusNoContent {
 		log.Info(ctx, map[string]interface{}{

--- a/token/keycloak/token.go
+++ b/token/keycloak/token.go
@@ -2,13 +2,14 @@ package keycloak
 
 import (
 	"context"
+	"net/http"
+	"net/url"
+	"time"
+
 	autherrors "github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/rest"
 	"github.com/fabric8-services/fabric8-auth/token"
 	errs "github.com/pkg/errors"
-	"net/http"
-	"net/url"
-	"time"
 )
 
 func RefreshToken(ctx context.Context, refreshTokenEndpoint string, clientID string, clientSecret string, refreshTokenString string) (*token.TokenSet, error) {
@@ -23,7 +24,7 @@ func RefreshToken(ctx context.Context, refreshTokenEndpoint string, clientID str
 	if err != nil {
 		return nil, autherrors.NewInternalError(ctx, errs.Wrap(err, "error when obtaining token"))
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	switch res.StatusCode {
 	case 200:
 		// OK

--- a/token/oauth/oauth2.go
+++ b/token/oauth/oauth2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/auth"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/rest"
 
 	"github.com/satori/go.uuid"
 	netcontext "golang.org/x/net/context"
@@ -60,7 +61,7 @@ func (provider *OauthIdentityProvider) UserProfilePayload(ctx context.Context, t
 		}, "unable to get user profile")
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{

--- a/token/token.go
+++ b/token/token.go
@@ -216,7 +216,7 @@ func FetchKeys(keysEndpointURL string) ([]*PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusOK {
 		log.Error(nil, map[string]interface{}{

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -55,7 +55,7 @@ func (r *RemoteWITServiceCaller) UpdateWITUser(ctx context.Context, req *goa.Req
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{
@@ -97,7 +97,7 @@ func (r *RemoteWITServiceCaller) CreateWITUser(ctx context.Context, req *goa.Req
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{


### PR DESCRIPTION
It seems that we already read the body before we close it but maybe we still miss it somewhere or there is a panic or something else. So just in case let's explicitly read response body when closing it in defer to make sure we are not leaking FDs.