### PR TITLE
Add trailing slash to user.cluster, APIURL, ConsoleURL, and MetricsURL

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/rest"
 
+	"net/url"
+	"reflect"
+
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
-	"net/url"
-	"reflect"
 )
 
 // String returns the current configuration as a string
@@ -401,6 +402,21 @@ func (c *ConfigurationData) GetServiceAccounts() map[string]ServiceAccount {
 // GetOSOClusters returns a map of OSO cluster configurations by cluster API URL
 func (c *ConfigurationData) GetOSOClusters() map[string]OSOCluster {
 	return c.clusters
+}
+
+// GetOSOClusterByURL returns a OSO cluster configurations by matching URL
+// Regardles of trailing slashes if cluster API URL == "https://api.openshift.com"
+// or "https://api.openshift.com/" it will match any "https://api.openshift.com*"
+// like "https://api.openshift.com", "https://api.openshift.com/", or "https://api.openshift.com/patch"
+// Returns nil if no matching API URL found
+func (c *ConfigurationData) GetOSOClusterByURL(url string) *OSOCluster {
+	for apiURL, cluster := range c.GetOSOClusters() {
+		if strings.HasPrefix(rest.AddTrailingSlashToURL(url), apiURL) {
+			return &cluster
+		}
+	}
+
+	return nil
 }
 
 // GetDefaultConfigurationFile returns the default configuration file.

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -2,13 +2,11 @@ package configuration_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
-
-	"net/http"
-
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -385,6 +383,15 @@ func TestLoadDefaultClusterConfiguration(t *testing.T) {
 
 	clusters := config.GetOSOClusters()
 	checkClusterConfiguration(t, clusters)
+
+	cluster := config.GetOSOClusterByURL("https://api.starter-us-east-2.openshift.com")
+	assert.NotNil(t, cluster)
+	cluster = config.GetOSOClusterByURL("https://api.starter-us-east-2.openshift.com/")
+	assert.NotNil(t, cluster)
+	cluster = config.GetOSOClusterByURL("https://api.starter-us-east-2.openshift.com/path")
+	assert.NotNil(t, cluster)
+	cluster = config.GetOSOClusterByURL("https://api.starter-us-east-2.openshift.unknown")
+	assert.Nil(t, cluster)
 }
 
 func TestLoadClusterConfigurationFromFile(t *testing.T) {

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/rest"
 	"github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/goadesign/goa"
@@ -39,9 +40,9 @@ func (c *ClustersController) Show(ctx *app.ShowClustersContext) error {
 	for _, clusterConfig := range c.config.GetOSOClusters() {
 		cluster := &app.ClusterData{
 			Name:       clusterConfig.Name,
-			APIURL:     clusterConfig.APIURL,
-			ConsoleURL: clusterConfig.ConsoleURL,
-			MetricsURL: clusterConfig.MetricsURL,
+			APIURL:     rest.AddTrailingSlashToURL(clusterConfig.APIURL),
+			ConsoleURL: rest.AddTrailingSlashToURL(clusterConfig.ConsoleURL),
+			MetricsURL: rest.AddTrailingSlashToURL(clusterConfig.MetricsURL),
 			AppDNS:     clusterConfig.AppDNS,
 		}
 		data = append(data, cluster)

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -3,12 +3,13 @@ package controller_test
 import (
 	"testing"
 
+	"github.com/fabric8-services/fabric8-auth/account"
+	"github.com/fabric8-services/fabric8-auth/app/test"
 	. "github.com/fabric8-services/fabric8-auth/controller"
+	authrest "github.com/fabric8-services/fabric8-auth/rest"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
 
-	"github.com/fabric8-services/fabric8-auth/account"
-	"github.com/fabric8-services/fabric8-auth/app/test"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -43,12 +44,12 @@ func (rest *TestClustersREST) checkShowForServiceAccount(saName string) {
 	require.NotNil(rest.T(), clusters.Data)
 	require.Equal(rest.T(), len(rest.Config.GetOSOClusters()), len(clusters.Data))
 	for _, cluster := range clusters.Data {
-		configCluster, ok := rest.Config.GetOSOClusters()[cluster.APIURL]
-		require.True(rest.T(), ok)
+		configCluster := rest.Config.GetOSOClusterByURL(cluster.APIURL)
+		require.NotNil(rest.T(), configCluster)
 		require.Equal(rest.T(), configCluster.Name, cluster.Name)
-		require.Equal(rest.T(), configCluster.APIURL, cluster.APIURL)
-		require.Equal(rest.T(), configCluster.ConsoleURL, cluster.ConsoleURL)
-		require.Equal(rest.T(), configCluster.MetricsURL, cluster.MetricsURL)
+		require.Equal(rest.T(), authrest.AddTrailingSlashToURL(configCluster.APIURL), cluster.APIURL)
+		require.Equal(rest.T(), authrest.AddTrailingSlashToURL(configCluster.ConsoleURL), cluster.ConsoleURL)
+		require.Equal(rest.T(), authrest.AddTrailingSlashToURL(configCluster.MetricsURL), cluster.MetricsURL)
 		require.Equal(rest.T(), configCluster.AppDNS, cluster.AppDNS)
 	}
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -1052,7 +1052,7 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 
 		company = user.Company
 		contextInformation = user.ContextInformation
-		cluster = user.Cluster
+		cluster = rest.AddTrailingSlashToURL(user.Cluster)
 		featureLevel = user.FeatureLevel
 		// CreatedAt and UpdatedAt fields in the resulting app.Identity are based on the 'user' entity
 		createdAt = user.CreatedAt

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -1057,7 +1057,7 @@ func (s *UsersControllerTestSuite) createRandomUserIdentity(t *testing.T, fullna
 		ImageURL:     "someURLForUpdate",
 		ID:           uuid.NewV4(),
 		Company:      uuid.NewV4().String() + "company",
-		Cluster:      "My OSO cluster url",
+		Cluster:      "https://api.openshift.com",
 		EmailPrivate: false,                       // being explicit
 		FeatureLevel: account.DefaultFeatureLevel, // being explicit
 	}
@@ -1091,7 +1091,7 @@ func assertCreatedUser(t *testing.T, actual *app.UserData, expectedUser account.
 	assert.Equal(t, expectedUser.ImageURL, *actual.Attributes.ImageURL)
 	assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
 	assert.Equal(t, expectedUser.Company, *actual.Attributes.Company)
-	assert.Equal(t, expectedUser.Cluster, *actual.Attributes.Cluster)
+	assert.Equal(t, expectedUser.Cluster+"/", *actual.Attributes.Cluster)
 	assert.Equal(t, expectedUser.URL, *actual.Attributes.URL)
 	assert.Equal(t, expectedUser.Bio, *actual.Attributes.Bio)
 	assert.Equal(t, expectedUser.FeatureLevel, *actual.Attributes.FeatureLevel)
@@ -1127,7 +1127,7 @@ func assertUser(t *testing.T, actual *app.UserData, expectedUser account.User, e
 	assert.Equal(t, expectedIdentity.ID.String(), *actual.Attributes.IdentityID)
 	assert.Equal(t, expectedIdentity.ProviderType, *actual.Attributes.ProviderType)
 	assert.Equal(t, expectedUser.Company, *actual.Attributes.Company)
-	assert.Equal(t, expectedUser.Cluster, *actual.Attributes.Cluster)
+	assert.Equal(t, expectedUser.Cluster+"/", *actual.Attributes.Cluster)
 }
 
 func assertSingleUserResponseHeaders(t *testing.T, res http.ResponseWriter, appUser *app.User, modelUser account.User) {
@@ -1320,7 +1320,7 @@ func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountWithAllFieldsOK
 	user.Bio = "some bio"
 	user.ImageURL = "some image"
 	user.URL = "some url"
-	user.Cluster = "some cluster"
+	user.Cluster = "https://some.cluster.com"
 	user.FeatureLevel = account.DefaultFeatureLevel
 	rhdUserName := "somerhdusername"
 	approved := false
@@ -1340,7 +1340,7 @@ func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountForExistingUser
 	identity := testsupport.TestIdentity
 	identity.User = user
 	identity.ProviderType = ""
-	user.Cluster = "some cluster"
+	user.Cluster = "https://some.cluster.com"
 
 	secureService, secureController := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
 

--- a/rest/url.go
+++ b/rest/url.go
@@ -78,3 +78,12 @@ func AddParams(urlString string, params map[string]string) (string, error) {
 
 	return parsedURL.String(), nil
 }
+
+// AddTrailingSlashToURL adds a trailing slash to the URL if it doesn't have it already
+// If URL is an empty string the function returns an empty string too
+func AddTrailingSlashToURL(url string) string {
+	if url != "" && !strings.HasSuffix(url, "/") {
+		return url + "/"
+	}
+	return url
+}

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -1,10 +1,9 @@
 package rest
 
 import (
-	"testing"
-
 	"net/http"
 	"net/url"
+	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/resource"
 
@@ -124,6 +123,15 @@ func TestAddParamSuccess(t *testing.T) {
 	generatedURL, err = AddParam(generatedURL, "param2", "abc")
 	require.NoError(t, err)
 	equalURLs(t, "https://openshift.io?param1=a&param2=abc", generatedURL)
+}
+
+func TestAddTrailingSlashToURLSuccess(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	assert.Equal(t, "https://openshift.io/", AddTrailingSlashToURL("https://openshift.io"))
+	assert.Equal(t, "https://openshift.io/", AddTrailingSlashToURL("https://openshift.io/"))
+	assert.Equal(t, "", AddTrailingSlashToURL(""))
 }
 
 // Can't use test.EqualURLs() because of cycle dependency

--- a/token/link/link.go
+++ b/token/link/link.go
@@ -48,6 +48,7 @@ type LinkConfig interface {
 	GetGitHubClientSecret() string
 	IsTLSInsecureSkipVerify() bool
 	GetOSOClusters() map[string]configuration.OSOCluster
+	GetOSOClusterByURL(url string) *configuration.OSOCluster
 }
 
 // OauthProviderFactory represents oauth provider factory
@@ -265,11 +266,9 @@ func (service *OauthProviderFactoryService) NewOauthProvider(ctx context.Context
 	if resourceURL.Host == "github.com" {
 		return NewGitHubIdentityProvider(service.config.GetGitHubClientID(), service.config.GetGitHubClientSecret(), service.config.GetGitHubClientDefaultScopes(), authURL), nil
 	}
-	clusters := service.config.GetOSOClusters()
-	for apiURL, cluster := range clusters {
-		if strings.HasPrefix(forResource, apiURL) {
-			return NewOpenShiftIdentityProvider(cluster, authURL)
-		}
+	cluster := service.config.GetOSOClusterByURL(forResource)
+	if cluster != nil {
+		return NewOpenShiftIdentityProvider(*cluster, authURL)
 	}
 	log.Error(ctx, map[string]interface{}{
 		"for": forResource,

--- a/token/link/link_test.go
+++ b/token/link/link_test.go
@@ -78,14 +78,27 @@ func (s *LinkTestSuite) TestCallbackWithUnknownStateFails() {
 }
 
 func (s *LinkTestSuite) TestGitHubProviderRedirectsToAuthorize() {
-	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), "https://github.com/org/repo", "https://openshift.io/home")
+	s.checkGitHubProviderRedirectsToAuthorize("https://github.com")
+	s.checkGitHubProviderRedirectsToAuthorize("https://github.com/")
+	s.checkGitHubProviderRedirectsToAuthorize("https://github.com/org/repo")
+}
+
+func (s *LinkTestSuite) checkGitHubProviderRedirectsToAuthorize(for_ string) {
+	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), for_, "https://openshift.io/home")
 	require.Nil(s.T(), err)
 	require.True(s.T(), strings.HasPrefix(location, "https://github.com/login/oauth/authorize"))
 	require.NotEmpty(s.T(), s.stateParam(location))
 }
 
 func (s *LinkTestSuite) TestOSOProviderRedirectsToAuthorize() {
-	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), s.Configuration.GetOpenShiftClientApiUrl(), "https://openshift.io/home")
+	s.checkOSOProviderRedirectsToAuthorize(s.Configuration.GetOpenShiftClientApiUrl())
+	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com")
+	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com/")
+	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com/path")
+}
+
+func (s *LinkTestSuite) checkOSOProviderRedirectsToAuthorize(for_ string) {
+	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), for_, "https://openshift.io/home")
 	require.Nil(s.T(), err)
 	require.Contains(s.T(), location, fmt.Sprintf("%s/oauth/authorize", s.Configuration.GetOpenShiftClientApiUrl()))
 	require.NotEmpty(s.T(), s.stateParam(location))


### PR DESCRIPTION
Regardless of actual URLs we store in user's profile and cluster configuration for OSO API, Console, and Metrics URL we should return these URLs with a trailing slash (for example "https://api.*.openshift.com/")