### PR TITLE
WIP More tests for creating and listing orgs

### DIFF
--- a/authorization/model/organization_model_service_blackbox_test.go
+++ b/authorization/model/organization_model_service_blackbox_test.go
@@ -74,6 +74,10 @@ func (s *organizationModelServiceBlackBoxTest) TestCreateOrganization() {
 	require.Nil(s.T(), err, "Could not load the organization's resource")
 
 	require.Equal(s.T(), common.IdentityResourceTypeOrganization, orgResource.ResourceType.Name, "Organization resource type is invalid")
+
+	require.Equal(s.T(), orgResource.Name, "Test Organization ZXYAAA")
+
+	// TODO Check the owner role assigned to the creator
 }
 
 func (s *organizationModelServiceBlackBoxTest) TestListOrganization() {

--- a/authorization/model/organization_model_service_blackbox_test.go
+++ b/authorization/model/organization_model_service_blackbox_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/account"
+	"github.com/fabric8-services/fabric8-auth/authorization/common"
 	"github.com/fabric8-services/fabric8-auth/authorization/model"
 	"github.com/fabric8-services/fabric8-auth/authorization/resource"
-	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
-
-	"github.com/fabric8-services/fabric8-auth/authorization/common"
 	"github.com/fabric8-services/fabric8-auth/authorization/role"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/fabric8-services/fabric8-auth/test"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -50,12 +50,7 @@ func (s *organizationModelServiceBlackBoxTest) SetupTest() {
 }
 
 func (s *organizationModelServiceBlackBoxTest) TestCreateOrganization() {
-	identity := &account.Identity{
-		ID:           uuid.NewV4(),
-		Username:     "identity_role_blackbox_test_someuserTestIdentity2",
-		ProviderType: account.KeycloakIDP}
-
-	err := s.identityRepo.Create(s.Ctx, identity)
+	identity, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "organizationModelServiceBlackBoxTest-TestCreateOrganization")
 	require.Nil(s.T(), err, "Could not create identity")
 
 	orgId, err := s.orgModelService.CreateOrganization(s.Ctx, identity.ID, "Test Organization ZXYAAA")
@@ -81,28 +76,37 @@ func (s *organizationModelServiceBlackBoxTest) TestCreateOrganization() {
 }
 
 func (s *organizationModelServiceBlackBoxTest) TestListOrganization() {
-	identity := &account.Identity{
-		ID:           uuid.NewV4(),
-		Username:     "identity_role_blackbox_test_someuserTestIdentity2",
-		ProviderType: account.KeycloakIDP}
-
-	err := s.identityRepo.Create(s.Ctx, identity)
+	identityOwner, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "organizationModelServiceBlackBoxTest-TestListOrganization")
 	require.Nil(s.T(), err, "Could not create identity")
 
-	orgId, err := s.orgModelService.CreateOrganization(s.Ctx, identity.ID, "Test Organization MMMYYY")
+	identityAnother, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "organizationModelServiceBlackBoxTest-TestListOrganization2")
+	require.Nil(s.T(), err, "Could not create identity")
+
+	// Orgs created by the first user
+	orgId, err := s.orgModelService.CreateOrganization(s.Ctx, identityOwner.ID, "Test Organization MMMYYY")
+	require.Nil(s.T(), err, "Could not create organization")
+	orgId2, err := s.orgModelService.CreateOrganization(s.Ctx, identityOwner.ID, "One More Test Organization MMMYYY")
 	require.Nil(s.T(), err, "Could not create organization")
 
-	orgs, err := s.orgModelService.ListOrganizations(s.Ctx, identity.ID)
+	// Org created by the second user
+	_, err = s.orgModelService.CreateOrganization(s.Ctx, identityAnother.ID, "One More Test Organization MMMYYY")
+	require.Nil(s.T(), err, "Could not create organization")
+
+	// Load orgs where the first user is a member
+	orgs, err := s.orgModelService.ListOrganizations(s.Ctx, identityOwner.ID)
 	require.Nil(s.T(), err, "Could not list organizations")
 
-	// Check we get one organization back
-	require.Equal(s.T(), 1, len(orgs), "Did not get exactly 1 organization in list")
+	// Check we get two organizations back
+	require.Equal(s.T(), 2, len(orgs), "Did not get exactly 2 organizations in list")
 
-	org := orgs[0]
+	s.equalOrganization(*orgId, "Test Organization MMMYYY", orgs[0])
+	s.equalOrganization(*orgId2, "One More Test Organization MMMYYY", orgs[1])
+}
 
-	require.Equal(s.T(), *orgId, org.OrganizationID, "Organization ID is different")
-	require.Equal(s.T(), false, org.Member, "User should not be a member of newly created organization")
-	require.Equal(s.T(), "Test Organization MMMYYY", org.Name, "Organization name is different")
-	require.Equal(s.T(), 1, len(org.Roles), "New organization should have assigned exactly 1 role")
-	require.Equal(s.T(), common.OrganizationOwnerRole, org.Roles[0], "New organization should have assigned owner role")
+func (s *organizationModelServiceBlackBoxTest) equalOrganization(expectedOrgID uuid.UUID, expectedOrgName string, actualOrg common.IdentityOrganization) {
+	require.Equal(s.T(), expectedOrgID, actualOrg.OrganizationID, "Organization ID is different")
+	require.Equal(s.T(), false, actualOrg.Member, "User should not be a member of newly created organization")
+	require.Equal(s.T(), expectedOrgName, actualOrg.Name, "Organization name is different")
+	require.Equal(s.T(), 1, len(actualOrg.Roles), "New organization should have assigned exactly 1 role")
+	require.Equal(s.T(), common.OrganizationOwnerRole, actualOrg.Roles[0], "New organization should have assigned owner role")
 }

--- a/design/organization.go
+++ b/design/organization.go
@@ -10,6 +10,7 @@ var _ = a.Resource("organization", func() {
 	a.BasePath("/organizations")
 
 	a.Action("create", func() {
+		a.Security("jwt")
 		a.Routing(
 			a.POST(""),
 		)
@@ -22,6 +23,7 @@ var _ = a.Resource("organization", func() {
 	})
 
 	a.Action("list", func() {
+		a.Security("jwt")
 		a.Routing(
 			a.GET(""),
 		)


### PR DESCRIPTION
This is a followup on https://github.com/fabric8-services/fabric8-auth/pull/317

- [x] Check org name when testing GORMOrganizationModelService.CreateOrganization()
- [x] Check owner role assigned to the org creator when testing GORMOrganizationModelService.CreateOrganization().
- [x] Create multiple orgs and check that only the relevant ones are returned by GORMOrganizationModelService.ListOrganizations() 
- [x] Add JWT security to org endpoints (**!!!**)
- [x] Log errors in org controller
- [x] Refactor controller tests, so they use user/identity instead of Service Accounts. Plus add tests for 401 responses.