### PR TITLE
Endpoint to check if an external token is available

### DIFF
--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/fabric8-services/fabric8-auth/app/test"
 	. "github.com/fabric8-services/fabric8-auth/controller"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
-
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
 	"github.com/goadesign/goa"
-
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -25,19 +23,13 @@ type TestResourceREST struct {
 	securedController *ResourceController
 }
 
-func (s *TestResourceREST) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	var err error
-	s.testIdentity, err = testsupport.CreateTestIdentity(s.DB,
-		"TestRegisterResourceCreated-"+uuid.NewV4().String(),
-		"TestRegisterResourceCreated")
-	require.Nil(s.T(), err)
-
+func (rest *TestResourceREST) SetupSuite() {
+	rest.DBTestSuite.SetupSuite()
 	sa := account.Identity{
 		Username: "fabric8-wit",
 	}
-	s.service = testsupport.ServiceAsServiceAccountUser("Resource-Service", sa)
-	s.securedController = NewResourceController(s.service, s.Application)
+	rest.service = testsupport.ServiceAsServiceAccountUser("Resource-Service", sa)
+	rest.securedController = NewResourceController(rest.service, rest.Application)
 }
 
 func TestRunResourceREST(t *testing.T) {
@@ -45,6 +37,12 @@ func TestRunResourceREST(t *testing.T) {
 }
 
 func (rest *TestResourceREST) SecuredController(identity account.Identity) (*goa.Service, *ResourceController) {
+	var err error
+	rest.testIdentity, err = testsupport.CreateTestIdentity(rest.DB,
+		"TestRegisterResourceCreated-"+uuid.NewV4().String(),
+		"TestRegisterResourceCreated")
+	require.Nil(rest.T(), err)
+
 	svc := testsupport.ServiceAsUser("Resource-Service", identity)
 	return svc, NewResourceController(svc, rest.Application)
 }

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -351,7 +351,7 @@ func (rest *TestTokenStorageREST) checkStatusExternalTokenUnauthorized(for_ stri
 	u := &url.URL{
 		Scheme: "https",
 		Host:   "auth.localhost.io",
-		Path:   fmt.Sprintf("/api/token"),
+		Path:   fmt.Sprintf("/api/token/status"),
 	}
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -269,7 +269,7 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenInvalidOnForcePullInt
 }
 
 // This test demonstrates that the token retrieval works successfully without the ForcePull option
-// When the ForcePull option is passed, we determine that the token is valid.
+// When the ForcePull option is passed, we determine that the token is invalid.
 
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenValidOnForcePullInternalError() {
 

--- a/design/token.go
+++ b/design/token.go
@@ -37,12 +37,29 @@ var _ = a.Resource("token", func() {
 			a.GET(""),
 		)
 		a.Params(func() {
-			a.Param("for", d.String, "The resource for which the external token is being fetched, example https://github.com/fabric8-services/fabric8-auth or https://api.starter-us-east-2.openshift.com")
+			a.Param("for", d.String, "The resource for which the external token is being fetched, example https://github.com or https://api.starter-us-east-2.openshift.com")
 			a.Param("force_pull", d.Boolean, "Pull the user's details for the specific connected account, example, the user's updated github username would be fetched from github. If this is not set or false, then the user profile will be pulled only if the stored user's details did not have the username")
 			a.Required("for")
 		})
 		a.Description("Get the external token for resources belonging to external providers like Github and OpenShift")
 		a.Response(d.OK, externalToken)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+
+	a.Action("Status", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("status"),
+		)
+		a.Params(func() {
+			a.Param("for", d.String, "The resource for which the external token is being checked, example https://github.com or https://api.starter-us-east-2.openshift.com")
+			a.Param("force_pull", d.Boolean, "Pull the user's details for the specific connected account, example, the user's updated github username would be fetched from github. If this is not set or false, then the user profile will be pulled only if the stored user's details did not have the username")
+			a.Required("for")
+		})
+		a.Description("Check if the external token is available. Returns 200 OK if the token is available and 401 Unauthorized if no token available")
+		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
@@ -54,7 +71,7 @@ var _ = a.Resource("token", func() {
 			a.DELETE(""),
 		)
 		a.Params(func() {
-			a.Param("for", d.String, "The resource for which the external token is being deleted, example https://github.com/fabric8-services/fabric8-auth or https://api.starter-us-east-2.openshift.com")
+			a.Param("for", d.String, "The resource for which the external token is being deleted, example https://github.com or https://api.starter-us-east-2.openshift.com")
 			a.Required("for")
 		})
 		a.Description("Delete the external token for resources belonging to external providers like Github and OpenShift")

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -15,8 +15,6 @@ import (
 // and returns a function which can be called on defer to delete created
 // entities in reverse order on function exit.
 //
-// In addition to that, the WIT cache is cleared as well in order to respect any
-// deletions made to the db.
 //
 // Usage:
 //


### PR DESCRIPTION
```
GET /api/token/status?for=<resource>&force_pull=true|false
Authorization: Bearer <token>
```

Response: `200 OK` - token is present
Response: `401` token is not present or invalid (if force_pull == true)

Fixes https://github.com/fabric8-services/fabric8-auth/issues/312