### PR TITLE
Add alias for user's OSO url to /api/token?for=<alias>

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -217,11 +217,11 @@ func (c *TokenController) Status(ctx *app.StatusTokenContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	tokeStatus := &app.ExternalTokenStatus{
-		Username:    appToken.Username,
-		ProviderURL: appToken.ProviderURL,
+	tokenStatus := &app.ExternalTokenStatus{
+		Username:       appToken.Username,
+		ProviderAPIURL: appToken.ProviderAPIURL,
 	}
-	return ctx.OK(tokeStatus)
+	return ctx.OK(tokenStatus)
 }
 
 func (c *TokenController) retrieveToken(ctx context.Context, forResource string, req *goa.RequestData, forcePull *bool) (*app.ExternalToken, *string, error) {
@@ -246,11 +246,11 @@ func (c *TokenController) retrieveToken(ctx context.Context, forResource string,
 	if ok && token.IsSpecificServiceAccount(ctx, token.OsoProxy, token.Tenant) {
 		// This is a request from OSO proxy or tenant service to obtain a cluster wide token
 		clusterToken := app.ExternalToken{
-			Scope:       "<unknown>",
-			AccessToken: osConfig.Cluster.ServiceAccountToken,
-			TokenType:   "bearer",
-			Username:    osConfig.Cluster.ServiceAccountUsername,
-			ProviderURL: osConfig.Cluster.APIURL,
+			Scope:          "<unknown>",
+			AccessToken:    osConfig.Cluster.ServiceAccountToken,
+			TokenType:      "bearer",
+			Username:       osConfig.Cluster.ServiceAccountUsername,
+			ProviderAPIURL: osConfig.Cluster.APIURL,
 		}
 		log.Info(ctx, map[string]interface{}{
 			"cluster": osConfig.Cluster.Name,
@@ -621,13 +621,13 @@ func (c *TokenController) loadToken(ctx context.Context, providerConfig link.Pro
 	return externalToken, err
 }
 
-func modelToAppExternalToken(externalToken provider.ExternalToken, providerURL string) app.ExternalToken {
+func modelToAppExternalToken(externalToken provider.ExternalToken, providerAPIURL string) app.ExternalToken {
 	return app.ExternalToken{
-		Scope:       externalToken.Scope,
-		AccessToken: externalToken.Token,
-		TokenType:   "bearer", // We aren't saving the token_type in the database
-		Username:    externalToken.Username,
-		ProviderURL: providerURL,
+		Scope:          externalToken.Scope,
+		AccessToken:    externalToken.Token,
+		TokenType:      "bearer", // We aren't saving the token_type in the database
+		Username:       externalToken.Username,
+		ProviderAPIURL: providerAPIURL,
 	}
 }
 

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -49,8 +49,8 @@ func (rest *TestTokenStorageREST) SetupTest() {
 	rest.identityRepository = account.NewIdentityRepository(rest.DB)
 	rest.externalTokenRepository = provider.NewExternalTokenRepository(rest.DB)
 	rest.userRepository = account.NewUserRepository(rest.DB)
-	rest.providerConfigFactory = link.NewOauthProviderFactory(rest.Configuration)
-	rest.dummyProviderConfigFactory = &testsupport.DummyProviderFactory{Token: uuid.NewV4().String(), Config: rest.Configuration}
+	rest.providerConfigFactory = link.NewOauthProviderFactory(rest.Configuration, rest.Application)
+	rest.dummyProviderConfigFactory = &testsupport.DummyProviderFactory{Token: uuid.NewV4().String(), Config: rest.Configuration, DB: rest.Application}
 }
 
 func (rest *TestTokenStorageREST) UnSecuredController() (*goa.Service, *TokenController) {
@@ -99,7 +99,8 @@ func (rest *TestTokenStorageREST) checkRetrieveOSOServiceAccountToken(saName str
 		assert.Equal(rest.T(), "<unknown>", tokenResponse.Scope)
 		assert.Equal(rest.T(), "bearer", tokenResponse.TokenType)
 		require.NotNil(rest.T(), tokenResponse.Username)
-		assert.Equal(rest.T(), "dsaas", *tokenResponse.Username)
+		assert.Equal(rest.T(), "dsaas", tokenResponse.Username)
+		assert.Equal(rest.T(), cluster.APIURL, tokenResponse.ProviderURL)
 	}
 }
 
@@ -124,14 +125,19 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenGithubOK() {
 	_, tokenResponse := test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
 
 	expectedToken := positiveKCResponseGithub()
-	rest.assertKeycloakTokenResponse(expectedToken, tokenResponse)
+	rest.assertKeycloakTokenResponse("https://github.com", expectedToken, tokenResponse)
+
+	// Alias
+	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "github", nil)
+	rest.assertKeycloakTokenResponse("https://github.com", expectedToken, tokenResponse)
 }
 
-func (rest *TestTokenStorageREST) assertKeycloakTokenResponse(expected *keycloak.KeycloakExternalTokenResponse, actual *app.ExternalToken) {
+func (rest *TestTokenStorageREST) assertKeycloakTokenResponse(expectedProviderURL string, expected *keycloak.KeycloakExternalTokenResponse, actual *app.ExternalToken) {
 	require.Equal(rest.T(), expected.AccessToken, actual.AccessToken)
 	require.Equal(rest.T(), expected.Scope, actual.Scope)
 	require.Equal(rest.T(), expected.TokenType, actual.TokenType)
-	require.Equal(rest.T(), expected.AccessToken+"testuser", *actual.Username)
+	require.Equal(rest.T(), expected.AccessToken+"testuser", actual.Username)
+	require.Equal(rest.T(), expectedProviderURL, actual.ProviderURL)
 }
 
 // Not present in DB but present in Keycloak
@@ -143,15 +149,30 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenOSOOK() {
 	_, tokenResponse := test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2.openshift.com", nil)
 
 	expectedToken := positiveKCResponseOpenShift()
-	rest.assertKeycloakTokenResponse(expectedToken, tokenResponse)
+	rest.assertKeycloakTokenResponse("https://api.starter-us-east-2.openshift.com", expectedToken, tokenResponse)
+
+	// Alias
+	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
+	rest.assertKeycloakTokenResponse("https://api.starter-us-east-2.openshift.com", expectedToken, tokenResponse)
+
+	// Another cluster
+	identity, err = testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, uuid.NewV4().String())
+	service, controller = rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
+	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
+	rest.assertKeycloakTokenResponse("https://api.starter-us-east-2a.openshift.com", expectedToken, tokenResponse)
 }
 
 // Not present in DB and failed in Keycloak for any reason
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenUnauthorized() {
 	rest.checkRetrieveExternalTokenUnauthorized("https://github.com/sbose78", "github", "unlinked")
+	rest.checkRetrieveExternalTokenUnauthorized("github", "github", "unlinked")
+	rest.checkRetrieveExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "unlinked")
+	rest.checkRetrieveExternalTokenUnauthorized("openshift", "openshift-v3", "unlinked")
+
+	rest.checkRetrieveExternalTokenUnauthorized("https://github.com/sbose78", "github", "internalError")
+	rest.checkRetrieveExternalTokenUnauthorized("github", "github", "internalError")
 	rest.checkRetrieveExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "internalError")
-	rest.checkRetrieveExternalTokenUnauthorized("https://github.com/sbose78", "github", "unlinked")
-	rest.checkRetrieveExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "internalError")
+	rest.checkRetrieveExternalTokenUnauthorized("openshift", "openshift-v3", "internalError")
 }
 
 func (rest *TestTokenStorageREST) checkRetrieveExternalTokenUnauthorized(for_ string, providerName string, kcScenario string) {
@@ -193,10 +214,17 @@ func (rest *TestTokenStorageREST) checkRetrieveExternalTokenUnauthorized(for_ st
 
 // Identity does not exist.
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenIdentityNotPresent() {
-	identity := testsupport.TestIdentity // using an Identity which does not exist in the database.
+	// using an Identity which does not exist in the database.
+	identity := account.Identity{
+		ID:       uuid.NewV4(),
+		Username: "TestDeveloper",
+	}
 	rest.mockKeycloakExternalTokenServiceClient.scenario = "positive"
 	service, controller := rest.SecuredControllerWithIdentity(identity)
 	test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+	test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, "github", nil)
+	test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2.openshift.com", nil)
+	test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, "openshift", nil)
 }
 
 // Not present in Keycloak but present in DB.
@@ -210,10 +238,11 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenFailedInKeycloak() {
 }
 
 func (rest *TestTokenStorageREST) retrieveExternalTokenFailingInKeycloak(scenario string) {
-	rest.retrieveExternalTokenFromDBSuccess(scenario)
+	rest.retrieveExternalGitHubTokenFromDBSuccess(scenario)
+	rest.retrieveExternalOSOTokenFromDBSuccess(scenario)
 }
 
-func (rest *TestTokenStorageREST) retrieveExternalTokenFromDBSuccess(scenario string) (account.Identity, provider.ExternalToken) {
+func (rest *TestTokenStorageREST) retrieveExternalGitHubTokenFromDBSuccess(scenario string) (account.Identity, provider.ExternalToken) {
 	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
 	require.Nil(rest.T(), err)
 
@@ -223,7 +252,7 @@ func (rest *TestTokenStorageREST) retrieveExternalTokenFromDBSuccess(scenario st
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.example.org"},
 	}
-	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), r, "https://github.com/a/b")
+	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), identity.ID, r, "https://github.com/a/b")
 	require.Nil(rest.T(), err)
 
 	expectedToken := provider.ExternalToken{
@@ -239,8 +268,58 @@ func (rest *TestTokenStorageREST) retrieveExternalTokenFromDBSuccess(scenario st
 	_, tokenResponse := test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
 	require.Equal(rest.T(), expectedToken.Token, tokenResponse.AccessToken)
 	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
-	require.Equal(rest.T(), expectedToken.Username, *tokenResponse.Username)
+	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
 	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
+	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderURL)
+
+	// Alias
+	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "github", nil)
+	require.Equal(rest.T(), expectedToken.Token, tokenResponse.AccessToken)
+	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
+	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
+	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
+	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderURL)
+
+	return identity, expectedToken
+}
+
+func (rest *TestTokenStorageREST) retrieveExternalOSOTokenFromDBSuccess(scenario string) (account.Identity, provider.ExternalToken) {
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, uuid.NewV4().String())
+	require.Nil(rest.T(), err)
+
+	rest.mockKeycloakExternalTokenServiceClient.scenario = scenario
+	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
+
+	r := &goa.RequestData{
+		Request: &http.Request{Host: "api.example.org"},
+	}
+	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), identity.ID, r, "https://api.starter-us-east-2a.openshift.com")
+	require.Nil(rest.T(), err)
+
+	expectedToken := provider.ExternalToken{
+		ProviderID: providerConfig.ID(),
+		Scope:      providerConfig.Scopes(),
+		IdentityID: identity.ID,
+		Token:      "1234-from-db",
+		Username:   "1234-from-dbtestuser",
+	}
+	rest.externalTokenRepository.Create(context.Background(), &expectedToken)
+
+	// This call should end up in a failed KC response but a positive retrieval from the database.
+	_, tokenResponse := test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2a.openshift.com", nil)
+	require.Equal(rest.T(), expectedToken.Token, tokenResponse.AccessToken)
+	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
+	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
+	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
+	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderURL)
+
+	// Alias
+	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
+	require.Equal(rest.T(), expectedToken.Token, tokenResponse.AccessToken)
+	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
+	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
+	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
+	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderURL)
 
 	return identity, expectedToken
 }
@@ -253,36 +332,47 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenBadRequest() {
 
 // This test demonstrates that the token retrieval works successfully without the ForcePull option
 // However, when the ForcePull option is passed, we determine that the token is invalid.
-
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenInvalidOnForcePullInternalError() {
+	identity, _ := rest.retrieveExternalGitHubTokenFromDBSuccess("linked")
+	rest.checkRetrieveExternalTokenInvalidOnForcePullInternalError(identity, "https://github.com/a/b", "github")
+	rest.checkRetrieveExternalTokenInvalidOnForcePullInternalError(identity, "github", "github")
 
-	identity, _ := rest.retrieveExternalTokenFromDBSuccess("linked")
-	// Token retrieved from database is successful, but when tested with github it's invalid.
+	identity, _ = rest.retrieveExternalOSOTokenFromDBSuccess("linked")
+	rest.checkRetrieveExternalTokenInvalidOnForcePullInternalError(identity, "https://api.starter-us-east-2a.openshift.com", "openshift-v3")
+	rest.checkRetrieveExternalTokenInvalidOnForcePullInternalError(identity, "openshift", "openshift-v3")
+}
+
+func (rest *TestTokenStorageREST) checkRetrieveExternalTokenInvalidOnForcePullInternalError(identity account.Identity, for_, providerName string) {
+	// Token status is OK, but when tested with provider it's invalid.
 	forcePull := true
-	forProvider := "https://github.com/a/b"
 	rest.dummyProviderConfigFactory.LoadProfileFail = true
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	rw, _ := test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, forProvider, &forcePull)
-	assert.Equal(rest.T(), rw.Header().Get("WWW-Authenticate"), "LINK url=http:///api/token/link?for=https://github.com/a/b, description=\"github token is not valid or expired. Relink github account\"")
+	rw, _ := test.RetrieveTokenUnauthorized(rest.T(), service.Context, service, controller, for_, &forcePull)
+	assert.Equal(rest.T(), rw.Header().Get("WWW-Authenticate"), fmt.Sprintf("LINK url=http:///api/token/link?for=%s, description=\"%s token is not valid or expired. Relink %s account\"", for_, providerName, providerName))
 	assert.Contains(rest.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
-	rest.dummyProviderConfigFactory.LoadProfileFail = false // reset to default
 }
 
 // This test demonstrates that the token retrieval works successfully without the ForcePull option
 // When the ForcePull option is passed, we determine that the token is invalid.
 
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenValidOnForcePullInternalError() {
-
 	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
 	require.Nil(rest.T(), err)
 
+	rest.checkRetrieveExternalTokenValidOnForcePullInternalError(identity, "https://github.com/a/b")
+	rest.checkRetrieveExternalTokenValidOnForcePullInternalError(identity, "github")
+	rest.checkRetrieveExternalTokenValidOnForcePullInternalError(identity, "https://api.starter-us-east-2.openshift.com")
+	rest.checkRetrieveExternalTokenValidOnForcePullInternalError(identity, "openshift")
+}
+
+func (rest *TestTokenStorageREST) checkRetrieveExternalTokenValidOnForcePullInternalError(identity account.Identity, for_ string) {
 	rest.mockKeycloakExternalTokenServiceClient.scenario = "linked"
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
 
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.example.org"},
 	}
-	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), r, "https://github.com/a/b")
+	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), identity.ID, r, for_)
 	require.Nil(rest.T(), err)
 
 	expectedToken := provider.ExternalToken{
@@ -294,15 +384,13 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenValidOnForcePullInter
 	}
 	rest.externalTokenRepository.Create(context.Background(), &expectedToken)
 
-	test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+	test.RetrieveTokenOK(rest.T(), service.Context, service, controller, for_, nil)
 
-	// Token retrieved from database is successful, but when tested with github it's invalid.
+	// Token retrieved from database is successful and when tested with github it's valid.
 	forcePull := true
-	forProvider := "https://github.com/a/b"
 	rest.dummyProviderConfigFactory.LoadProfileFail = false
 	service, controller = rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	test.RetrieveTokenOK(rest.T(), service.Context, service, controller, forProvider, &forcePull)
-
+	test.RetrieveTokenOK(rest.T(), service.Context, service, controller, for_, &forcePull)
 }
 
 // Not present in DB but present in Keycloak
@@ -311,33 +399,81 @@ func (rest *TestTokenStorageREST) TestStatusExternalTokenGithubOK() {
 	require.Nil(rest.T(), err)
 	rest.mockKeycloakExternalTokenServiceClient.scenario = "positive"
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
-	test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2.openshift.com", nil)
+
+	_, tokenStatus := test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+	rest.assertTokenStatusAndTokenResponse(positiveKCResponseGithub(), "https://github.com", tokenStatus)
+
+	_, tokenStatus = test.StatusTokenOK(rest.T(), service.Context, service, controller, "github", nil)
+	rest.assertTokenStatusAndTokenResponse(positiveKCResponseGithub(), "https://github.com", tokenStatus)
+
+	_, tokenStatus = test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2.openshift.com", nil)
+	rest.assertTokenStatusAndTokenResponse(positiveKCResponseOpenShift(), "https://api.starter-us-east-2.openshift.com", tokenStatus)
+
+	_, tokenStatus = test.StatusTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
+	rest.assertTokenStatusAndTokenResponse(positiveKCResponseOpenShift(), "https://api.starter-us-east-2.openshift.com", tokenStatus)
+}
+
+func (rest *TestTokenStorageREST) assertTokenStatusAndTokenResponse(expectedTokenResponse *keycloak.KeycloakExternalTokenResponse, expectedURL string, actualStatus *app.ExternalTokenStatus) {
+	require.NotNil(rest.T(), actualStatus)
+	assert.Equal(rest.T(), expectedTokenResponse.AccessToken+"testuser", actualStatus.Username)
+	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderURL)
+}
+
+func (rest *TestTokenStorageREST) assertTokenStatus(expectedUsername, expectedURL string, actualStatus *app.ExternalTokenStatus) {
+	require.NotNil(rest.T(), actualStatus)
+	assert.Equal(rest.T(), expectedUsername, actualStatus.Username)
+	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderURL)
 }
 
 // Not present in Keycloak but present in DB.
 func (rest *TestTokenStorageREST) TestStatusExternalTokenPresentInDB() {
-	rest.statusExternalTokenFromDBSuccess("unlinked")
+	rest.statusExternalGitHubTokenFromDBSuccess("unlinked")
+	rest.statusExternalOSOTokenFromDBSuccess("unlinked")
 }
 
 // Get token from keycloak fails for any reason but token present in DB.
 func (rest *TestTokenStorageREST) TestStatusExternalTokenFailedInKeycloak() {
-	rest.statusExternalTokenFromDBSuccess("internalError")
+	rest.statusExternalGitHubTokenFromDBSuccess("internalError")
+	rest.statusExternalOSOTokenFromDBSuccess("internalError")
 }
 
-func (rest *TestTokenStorageREST) statusExternalTokenFromDBSuccess(scenario string) account.Identity {
-	identity, _ := rest.retrieveExternalTokenFromDBSuccess(scenario)
+func (rest *TestTokenStorageREST) statusExternalGitHubTokenFromDBSuccess(scenario string) account.Identity {
+	identity, _ := rest.retrieveExternalGitHubTokenFromDBSuccess(scenario)
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+
+	_, tokenStatus := test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+	rest.assertTokenStatus("1234-from-dbtestuser", "https://github.com", tokenStatus)
+
+	_, tokenStatus = test.StatusTokenOK(rest.T(), service.Context, service, controller, "github", nil)
+	rest.assertTokenStatus("1234-from-dbtestuser", "https://github.com", tokenStatus)
+
+	return identity
+}
+
+func (rest *TestTokenStorageREST) statusExternalOSOTokenFromDBSuccess(scenario string) account.Identity {
+	identity, _ := rest.retrieveExternalOSOTokenFromDBSuccess(scenario)
+	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
+
+	_, tokenStatus := test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2a.openshift.com", nil)
+	rest.assertTokenStatus("1234-from-dbtestuser", "https://api.starter-us-east-2a.openshift.com", tokenStatus)
+
+	_, tokenStatus = test.StatusTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
+	rest.assertTokenStatus("1234-from-dbtestuser", "https://api.starter-us-east-2a.openshift.com", tokenStatus)
+
 	return identity
 }
 
 // Not present in DB and failed in Keycloak for any reason
 func (rest *TestTokenStorageREST) TestStatusExternalTokenUnauthorized() {
 	rest.checkStatusExternalTokenUnauthorized("https://github.com/sbose78", "github", "unlinked")
+	rest.checkStatusExternalTokenUnauthorized("github", "github", "unlinked")
+	rest.checkStatusExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "unlinked")
+	rest.checkStatusExternalTokenUnauthorized("openshift", "openshift-v3", "unlinked")
+
+	rest.checkStatusExternalTokenUnauthorized("https://github.com/sbose78", "github", "internalError")
+	rest.checkStatusExternalTokenUnauthorized("github", "github", "internalError")
 	rest.checkStatusExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "internalError")
-	rest.checkStatusExternalTokenUnauthorized("https://github.com/sbose78", "github", "unlinked")
-	rest.checkStatusExternalTokenUnauthorized("https://api.starter-us-east-2.openshift.com", "openshift-v3", "internalError")
+	rest.checkStatusExternalTokenUnauthorized("openshift", "openshift-v3", "internalError")
 }
 
 func (rest *TestTokenStorageREST) checkStatusExternalTokenUnauthorized(for_ string, providerName string, kcScenario string) {
@@ -380,16 +516,23 @@ func (rest *TestTokenStorageREST) checkStatusExternalTokenUnauthorized(for_ stri
 // This test demonstrates that the token status works successfully without the ForcePull option
 // However, when the ForcePull option is passed, we determine that the token is invalid.
 func (rest *TestTokenStorageREST) TestStatusExternalTokenInvalidOnForcePullInternalError() {
-	identity := rest.statusExternalTokenFromDBSuccess("linked")
-	// Token status is OK, but when tested with github it's invalid.
+	identity := rest.statusExternalGitHubTokenFromDBSuccess("linked")
+	rest.checkStatusExternalTokenInvalidOnForcePullInternalError(identity, "https://github.com/a/b", "github")
+	rest.checkStatusExternalTokenInvalidOnForcePullInternalError(identity, "github", "github")
+
+	identity = rest.statusExternalOSOTokenFromDBSuccess("linked")
+	rest.checkStatusExternalTokenInvalidOnForcePullInternalError(identity, "https://api.starter-us-east-2a.openshift.com", "openshift-v3")
+	rest.checkStatusExternalTokenInvalidOnForcePullInternalError(identity, "openshift", "openshift-v3")
+}
+
+func (rest *TestTokenStorageREST) checkStatusExternalTokenInvalidOnForcePullInternalError(identity account.Identity, for_, providerName string) {
+	// Token status is OK, but when tested with provider it's invalid.
 	forcePull := true
-	forProvider := "https://github.com/a/b"
 	rest.dummyProviderConfigFactory.LoadProfileFail = true
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	rw, _ := test.StatusTokenUnauthorized(rest.T(), service.Context, service, controller, forProvider, &forcePull)
-	assert.Equal(rest.T(), rw.Header().Get("WWW-Authenticate"), "LINK url=http:///api/token/link?for=https://github.com/a/b, description=\"github token is not valid or expired. Relink github account\"")
+	rw, _ := test.StatusTokenUnauthorized(rest.T(), service.Context, service, controller, for_, &forcePull)
+	assert.Equal(rest.T(), rw.Header().Get("WWW-Authenticate"), fmt.Sprintf("LINK url=http:///api/token/link?for=%s, description=\"%s token is not valid or expired. Relink %s account\"", for_, providerName, providerName))
 	assert.Contains(rest.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
-	rest.dummyProviderConfigFactory.LoadProfileFail = false // reset to default
 }
 
 // This test demonstrates that the token status works successfully without the ForcePull option
@@ -397,14 +540,20 @@ func (rest *TestTokenStorageREST) TestStatusExternalTokenInvalidOnForcePullInter
 func (rest *TestTokenStorageREST) TestStatusExternalTokenValidOnForcePullInternalError() {
 	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
 	require.Nil(rest.T(), err)
+	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "https://github.com/a/b", "https://github.com")
+	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "github", "https://github.com")
+	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "openshift", "https://api.starter-us-east-2.openshift.com")
+	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "https://api.starter-us-east-2.openshift.com", "https://api.starter-us-east-2.openshift.com")
+}
 
+func (rest *TestTokenStorageREST) checkStatusExternalTokenValidOnForcePullInternalError(identity account.Identity, for_, expectedProviderURL string) {
 	rest.mockKeycloakExternalTokenServiceClient.scenario = "linked"
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
 
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.example.org"},
 	}
-	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), r, "https://github.com/a/b")
+	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), identity.ID, r, for_)
 	require.Nil(rest.T(), err)
 
 	expectedToken := provider.ExternalToken{
@@ -416,14 +565,14 @@ func (rest *TestTokenStorageREST) TestStatusExternalTokenValidOnForcePullInterna
 	}
 	rest.externalTokenRepository.Create(context.Background(), &expectedToken)
 
-	test.StatusTokenOK(rest.T(), service.Context, service, controller, "https://github.com/a/b", nil)
+	test.StatusTokenOK(rest.T(), service.Context, service, controller, for_, nil)
 
-	// Token status is OK, but when tested with github it's invalid.
+	// Token status is OK and when tested with provider it's valid.
 	forcePull := true
-	forProvider := "https://github.com/a/b"
 	rest.dummyProviderConfigFactory.LoadProfileFail = false
 	service, controller = rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
-	test.StatusTokenOK(rest.T(), service.Context, service, controller, forProvider, &forcePull)
+	_, tokenStatus := test.StatusTokenOK(rest.T(), service.Context, service, controller, for_, &forcePull)
+	rest.assertTokenStatus(expectedToken.Username, expectedProviderURL, tokenStatus)
 }
 
 func (rest *TestTokenStorageREST) TestDeleteExternalTokenBadRequest() {
@@ -437,14 +586,16 @@ func (rest *TestTokenStorageREST) TestDeleteExternalTokenIdentityNotPresent() {
 	rest.mockKeycloakExternalTokenServiceClient.scenario = "unlinked"
 	service, controller := rest.SecuredControllerWithIdentity(identity)
 	test.DeleteTokenUnauthorized(rest.T(), service.Context, service, controller, "https://github.com/a/b")
+	test.DeleteTokenUnauthorized(rest.T(), service.Context, service, controller, "github")
+	test.DeleteTokenUnauthorized(rest.T(), service.Context, service, controller, "https://api.starter-us-east-2.openshift.com")
+	test.DeleteTokenUnauthorized(rest.T(), service.Context, service, controller, "openshift")
 }
 
-func (rest *TestTokenStorageREST) TestDeleteExternalTokenGithubOK() {
+func (rest *TestTokenStorageREST) TestDeleteExternalTokenOK() {
 	rest.deleteExternalTokenOK("https://github.com/a/b")
-}
-
-func (rest *TestTokenStorageREST) TestDeleteExternalTokenOSOOK() {
+	rest.deleteExternalTokenOK("github")
 	rest.deleteExternalTokenOK("https://api.starter-us-east-2.openshift.com")
+	rest.deleteExternalTokenOK("openshift")
 }
 
 func (rest *TestTokenStorageREST) deleteExternalTokenOK(forResource string) {
@@ -464,7 +615,7 @@ func (rest *TestTokenStorageREST) deleteExternalToken(forResource string, number
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.example.org"},
 	}
-	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), r, forResource)
+	providerConfig, err := rest.providerConfigFactory.NewOauthProvider(context.Background(), identity.ID, r, forResource)
 	require.Nil(rest.T(), err)
 
 	// OK is returned even if there is nothing to delete
@@ -525,7 +676,7 @@ func (client mockKeycloakExternalTokenServiceClient) Delete(ctx context.Context,
 func positiveKCResponseGithub() *keycloak.KeycloakExternalTokenResponse {
 	return &keycloak.KeycloakExternalTokenResponse{
 		AccessToken: "1234-github",
-		Scope:       "testscope",
+		Scope:       "admin:repo_hook read:org repo user gist",
 		TokenType:   "bearer",
 	}
 }
@@ -533,7 +684,7 @@ func positiveKCResponseGithub() *keycloak.KeycloakExternalTokenResponse {
 func positiveKCResponseOpenShift() *keycloak.KeycloakExternalTokenResponse {
 	return &keycloak.KeycloakExternalTokenResponse{
 		AccessToken: "1234-openshift",
-		Scope:       "testscope",
+		Scope:       "user:full",
 		TokenType:   "bearer",
 	}
 }

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -100,7 +100,7 @@ func (rest *TestTokenStorageREST) checkRetrieveOSOServiceAccountToken(saName str
 		assert.Equal(rest.T(), "bearer", tokenResponse.TokenType)
 		require.NotNil(rest.T(), tokenResponse.Username)
 		assert.Equal(rest.T(), "dsaas", tokenResponse.Username)
-		assert.Equal(rest.T(), cluster.APIURL, tokenResponse.ProviderURL)
+		assert.Equal(rest.T(), cluster.APIURL, tokenResponse.ProviderAPIURL)
 	}
 }
 
@@ -137,7 +137,7 @@ func (rest *TestTokenStorageREST) assertKeycloakTokenResponse(expectedProviderUR
 	require.Equal(rest.T(), expected.Scope, actual.Scope)
 	require.Equal(rest.T(), expected.TokenType, actual.TokenType)
 	require.Equal(rest.T(), expected.AccessToken+"testuser", actual.Username)
-	require.Equal(rest.T(), expectedProviderURL, actual.ProviderURL)
+	require.Equal(rest.T(), expectedProviderURL, actual.ProviderAPIURL)
 }
 
 // Not present in DB but present in Keycloak
@@ -270,7 +270,7 @@ func (rest *TestTokenStorageREST) retrieveExternalGitHubTokenFromDBSuccess(scena
 	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
 	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
 	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
-	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderURL)
+	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderAPIURL)
 
 	// Alias
 	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "github", nil)
@@ -278,7 +278,7 @@ func (rest *TestTokenStorageREST) retrieveExternalGitHubTokenFromDBSuccess(scena
 	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
 	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
 	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
-	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderURL)
+	require.Equal(rest.T(), "https://github.com", tokenResponse.ProviderAPIURL)
 
 	return identity, expectedToken
 }
@@ -311,7 +311,7 @@ func (rest *TestTokenStorageREST) retrieveExternalOSOTokenFromDBSuccess(scenario
 	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
 	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
 	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
-	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderURL)
+	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderAPIURL)
 
 	// Alias
 	_, tokenResponse = test.RetrieveTokenOK(rest.T(), service.Context, service, controller, "openshift", nil)
@@ -319,7 +319,7 @@ func (rest *TestTokenStorageREST) retrieveExternalOSOTokenFromDBSuccess(scenario
 	require.Equal(rest.T(), expectedToken.Scope, tokenResponse.Scope)
 	require.Equal(rest.T(), expectedToken.Username, tokenResponse.Username)
 	require.Equal(rest.T(), "bearer", tokenResponse.TokenType)
-	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderURL)
+	require.Equal(rest.T(), "https://api.starter-us-east-2a.openshift.com", tokenResponse.ProviderAPIURL)
 
 	return identity, expectedToken
 }
@@ -416,13 +416,13 @@ func (rest *TestTokenStorageREST) TestStatusExternalTokenGithubOK() {
 func (rest *TestTokenStorageREST) assertTokenStatusAndTokenResponse(expectedTokenResponse *keycloak.KeycloakExternalTokenResponse, expectedURL string, actualStatus *app.ExternalTokenStatus) {
 	require.NotNil(rest.T(), actualStatus)
 	assert.Equal(rest.T(), expectedTokenResponse.AccessToken+"testuser", actualStatus.Username)
-	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderURL)
+	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderAPIURL)
 }
 
 func (rest *TestTokenStorageREST) assertTokenStatus(expectedUsername, expectedURL string, actualStatus *app.ExternalTokenStatus) {
 	require.NotNil(rest.T(), actualStatus)
 	assert.Equal(rest.T(), expectedUsername, actualStatus.Username)
-	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderURL)
+	assert.Equal(rest.T(), expectedURL, actualStatus.ProviderAPIURL)
 }
 
 // Not present in Keycloak but present in DB.

--- a/design/token.go
+++ b/design/token.go
@@ -13,8 +13,9 @@ var externalToken = a.MediaType("application/vnd.externalToken+json", func() {
 		a.Attribute("access_token", d.String, "The token associated with the identity for the specific external provider")
 		a.Attribute("scope", d.String, "The scope associated with the token")
 		a.Attribute("token_type", d.String, "The type of the toke, example : bearer")
-		a.Attribute("username", d.String, "The username of the identity loaded from the specific external provider. Optional attribute.")
-		a.Required("access_token", "scope", "token_type")
+		a.Attribute("username", d.String, "The username of the identity loaded from the specific external provider")
+		a.Attribute("provider_url", d.String, "The external provider URL.")
+		a.Required("access_token", "scope", "token_type", "username", "provider_url")
 	})
 
 	a.View("default", func() {
@@ -22,9 +23,26 @@ var externalToken = a.MediaType("application/vnd.externalToken+json", func() {
 		a.Attribute("scope")
 		a.Attribute("token_type")
 		a.Attribute("username")
-		a.Required("access_token", "scope", "token_type")
+		a.Attribute("provider_url")
+		a.Required("access_token", "scope", "token_type", "username", "provider_url")
+	})
+})
+
+// externalTokenStatus represents a token status object
+var externalTokenStatus = a.MediaType("application/vnd.externalTokenStatus+json", func() {
+	a.TypeName("ExternalTokenStatus")
+	a.Description("This endpoint can be used to obtain a status of the available token from external providers such as GitHub or OpenShift")
+	a.Attributes(func() {
+		a.Attribute("username", d.String, "The username of the identity loaded from the specific external provider.")
+		a.Attribute("provider_url", d.String, "The external provider URL.")
+		a.Required("username", "provider_url")
 	})
 
+	a.View("default", func() {
+		a.Attribute("username")
+		a.Attribute("provider_url")
+		a.Required("username", "provider_url")
+	})
 })
 
 var _ = a.Resource("token", func() {
@@ -59,7 +77,7 @@ var _ = a.Resource("token", func() {
 			a.Required("for")
 		})
 		a.Description("Check if the external token is available. Returns 200 OK if the token is available and 401 Unauthorized if no token available")
-		a.Response(d.OK)
+		a.Response(d.OK, externalTokenStatus)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)

--- a/design/token.go
+++ b/design/token.go
@@ -14,8 +14,8 @@ var externalToken = a.MediaType("application/vnd.externalToken+json", func() {
 		a.Attribute("scope", d.String, "The scope associated with the token")
 		a.Attribute("token_type", d.String, "The type of the toke, example : bearer")
 		a.Attribute("username", d.String, "The username of the identity loaded from the specific external provider")
-		a.Attribute("provider_url", d.String, "The external provider URL.")
-		a.Required("access_token", "scope", "token_type", "username", "provider_url")
+		a.Attribute("provider_api_url", d.String, "The external provider URL.")
+		a.Required("access_token", "scope", "token_type", "username", "provider_api_url")
 	})
 
 	a.View("default", func() {
@@ -23,8 +23,8 @@ var externalToken = a.MediaType("application/vnd.externalToken+json", func() {
 		a.Attribute("scope")
 		a.Attribute("token_type")
 		a.Attribute("username")
-		a.Attribute("provider_url")
-		a.Required("access_token", "scope", "token_type", "username", "provider_url")
+		a.Attribute("provider_api_url")
+		a.Required("access_token", "scope", "token_type", "username", "provider_api_url")
 	})
 })
 
@@ -34,14 +34,14 @@ var externalTokenStatus = a.MediaType("application/vnd.externalTokenStatus+json"
 	a.Description("This endpoint can be used to obtain a status of the available token from external providers such as GitHub or OpenShift")
 	a.Attributes(func() {
 		a.Attribute("username", d.String, "The username of the identity loaded from the specific external provider.")
-		a.Attribute("provider_url", d.String, "The external provider URL.")
-		a.Required("username", "provider_url")
+		a.Attribute("provider_api_url", d.String, "The external provider URL.")
+		a.Required("username", "provider_api_url")
 	})
 
 	a.View("default", func() {
 		a.Attribute("username")
-		a.Attribute("provider_url")
-		a.Required("username", "provider_url")
+		a.Attribute("provider_api_url")
+		a.Required("username", "provider_api_url")
 	})
 })
 

--- a/main.go
+++ b/main.go
@@ -191,9 +191,8 @@ func main() {
 	logoutCtrl := controller.NewLogoutController(service, &login.KeycloakLogoutService{}, config)
 	app.MountLogoutController(service, logoutCtrl)
 
-	providerFactory := link.NewOauthProviderFactory(config)
+	providerFactory := link.NewOauthProviderFactory(config, appDB)
 	linkService := link.NewLinkServiceWithFactory(config, appDB, providerFactory)
-	//providerFactory := link.NewOauthProviderFactory(configuration, appDB)
 	keycloakExternalTokenService := keycloak.NewKeycloakTokenServiceClient(config)
 	// Mount "token" controller
 	tokenCtrl := controller.NewTokenController(service, appDB, loginService, linkService, providerFactory, tokenManager, &keycloakExternalTokenService, config)

--- a/test/account.go
+++ b/test/account.go
@@ -17,7 +17,7 @@ var TestUser = account.User{
 	ID:       uuid.NewV4(),
 	Email:    "testdeveloper@testalm.io",
 	FullName: "Test Developer",
-	Cluster:  "Test Cluster",
+	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
 
 // TestUser2 only creates in memory obj for testing purposes.
@@ -27,6 +27,7 @@ var TestUser2 = account.User{
 	ID:       uuid.NewV4(),
 	Email:    "testdeveloper2@testalm.io",
 	FullName: "Test Developer 2",
+	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
 
 // TestUser only creates in memory obj for testing purposes
@@ -34,7 +35,7 @@ var TestUser3 = account.User{
 	ID:       uuid.NewV4(),
 	Email:    uuid.NewV4().String(),
 	FullName: "Test Developer",
-	Cluster:  "Test Cluster",
+	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
 
 // TestUserPrivate only creates in memory obj for testing purposes
@@ -42,7 +43,7 @@ var TestUserPrivate = account.User{
 	ID:           uuid.NewV4(),
 	Email:        uuid.NewV4().String(),
 	FullName:     "Test Developer",
-	Cluster:      "Test Cluster",
+	Cluster:      "https://api.starter-us-east-2.openshift.com",
 	EmailPrivate: true,
 }
 
@@ -102,7 +103,7 @@ func CreateTestIdentityAndUser(db *gorm.DB, username, providerType string) (acco
 		ID:       uuid.NewV4(),
 		Email:    uuid.NewV4().String(),
 		FullName: "Test Developer",
-		Cluster:  "Test Cluster",
+		Cluster:  "https://api.starter-us-east-2a.openshift.com",
 	}
 	testIdentity := account.Identity{
 		Username:     username,

--- a/token/link/github.go
+++ b/token/link/github.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	GitHubProviderID = "2f6b7176-8f4b-4204-962d-606033275397" // Do not change! This ID is used as provider ID in the external token table
+	GitHubProviderID    = "2f6b7176-8f4b-4204-962d-606033275397" // Do not change! This ID is used as provider ID in the external token table
+	GitHubProviderAlias = "github"
 )
 
 type GitHubIdentityProvider struct {
@@ -48,6 +49,10 @@ func (provider *GitHubIdentityProvider) Scopes() string {
 
 func (provider *GitHubIdentityProvider) TypeName() string {
 	return "github"
+}
+
+func (provider *GitHubIdentityProvider) URL() string {
+	return "https://github.com"
 }
 
 // Profile fetches a user profile from the Identity Provider

--- a/token/link/link.go
+++ b/token/link/link.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -33,6 +34,7 @@ type ProviderConfig interface {
 	ID() uuid.UUID
 	Scopes() string
 	TypeName() string
+	URL() string
 }
 
 // LinkOAuthService represents OAuth service interface for linking accounts
@@ -53,19 +55,21 @@ type LinkConfig interface {
 
 // OauthProviderFactory represents oauth provider factory
 type OauthProviderFactory interface {
-	NewOauthProvider(ctx context.Context, req *goa.RequestData, forResource string) (ProviderConfig, error)
+	NewOauthProvider(ctx context.Context, identityID uuid.UUID, req *goa.RequestData, forResource string) (ProviderConfig, error)
 }
 
 // NewOauthProviderFactory returns the default Oauth provider factory.
-func NewOauthProviderFactory(config LinkConfig) *OauthProviderFactoryService {
+func NewOauthProviderFactory(config LinkConfig, db application.DB) *OauthProviderFactoryService {
 	service := &OauthProviderFactoryService{
 		config: config,
+		db:     db,
 	}
 	return service
 }
 
 type OauthProviderFactoryService struct {
 	config LinkConfig
+	db     application.DB
 }
 
 // LinkService represents service for linking accounts
@@ -110,7 +114,11 @@ func (service *LinkService) ProviderLocation(ctx context.Context, req *goa.Reque
 	linkURL.RawQuery = parameters.Encode()
 	redirectURL = linkURL.String()
 
-	oauthProvider, err := service.providerFactory.NewOauthProvider(ctx, req, forResources[0])
+	identityUUID, err := uuid.FromString(identityID)
+	if err != nil {
+		return "", err
+	}
+	oauthProvider, err := service.providerFactory.NewOauthProvider(ctx, identityUUID, req, forResources[0])
 	if err != nil {
 		return "", err
 	}
@@ -159,7 +167,7 @@ func (service *LinkService) Callback(ctx context.Context, req *goa.RequestData, 
 
 	forResource := referrerURL.Query().Get(forParam)
 
-	oauthProvider, err := service.providerFactory.NewOauthProvider(ctx, req, forResource)
+	oauthProvider, err := service.providerFactory.NewOauthProvider(ctx, identityUUID, req, forResource)
 	if err != nil {
 		return "", err
 	}
@@ -256,9 +264,52 @@ func (service *LinkService) Callback(ctx context.Context, req *goa.RequestData, 
 	return knownReferrer, nil
 }
 
-// NewOauthProvider creates a new oauth provider for the given resource URL
-func (service *OauthProviderFactoryService) NewOauthProvider(ctx context.Context, req *goa.RequestData, forResource string) (ProviderConfig, error) {
+// NewOauthProvider creates a new oauth provider for the given resource URL or provider alias
+func (service *OauthProviderFactoryService) NewOauthProvider(ctx context.Context, identityID uuid.UUID, req *goa.RequestData, forResource string) (ProviderConfig, error) {
 	authURL := rest.AbsoluteURL(req, "")
+
+	// Check if the forResource is actually a provider alias like "github" or "openshift"
+	if forResource == GitHubProviderAlias {
+		return NewGitHubIdentityProvider(service.config.GetGitHubClientID(), service.config.GetGitHubClientSecret(), service.config.GetGitHubClientDefaultScopes(), authURL), nil
+	}
+	if forResource == OpenShiftProviderAlias {
+		// Look up the user's OpenShift cluster
+		var clusterURL string
+		err := application.Transactional(service.db, func(appl application.Application) error {
+			identity, err := appl.Identities().Load(ctx, identityID)
+			if err != nil {
+				return err
+			}
+			userID := identity.UserID
+			if !userID.Valid {
+				return errors.New("unable to load user for identity")
+			}
+			user, err := appl.Users().Load(ctx, userID.UUID)
+			if err != nil {
+				return err
+			}
+			clusterURL = user.Cluster
+			return nil
+		})
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"identity_id": identityID,
+				"err":         err,
+			}, "unable to lookup user's cluster URL for identity %s", identityID)
+			return nil, errs.NewUnauthorizedError(err.Error())
+		}
+		cluster := service.config.GetOSOClusterByURL(clusterURL)
+		if cluster == nil {
+			log.Error(ctx, map[string]interface{}{
+				"for":         forResource,
+				"cluster_url": clusterURL,
+			}, "unable to find oauth config for provider alias")
+			return nil, errs.NewInternalErrorFromString(ctx, fmt.Sprintf("unable to load provider for cluster URL %s", clusterURL))
+		}
+		return NewOpenShiftIdentityProvider(*cluster, authURL)
+	}
+
+	// Check if the forResource is some known resource URL like "https://github.com" or "https://api.starter-us-east-2.openshift.com"
 	resourceURL, err := url.Parse(forResource)
 	if err != nil {
 		return nil, err

--- a/token/link/link_test.go
+++ b/token/link/link_test.go
@@ -39,7 +39,7 @@ func TestRunLinkTestSuite(t *testing.T) {
 
 func (s *LinkTestSuite) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
-	providerFactory := NewOauthProviderFactory(s.Configuration)
+	providerFactory := NewOauthProviderFactory(s.Configuration, s.Application)
 	s.linkService = NewLinkServiceWithFactory(s.Configuration, s.Application, providerFactory)
 	s.requestData = &goa.RequestData{Request: &http.Request{
 		URL: &url.URL{Scheme: "https", Host: "auth.openshift.io"},
@@ -81,6 +81,8 @@ func (s *LinkTestSuite) TestGitHubProviderRedirectsToAuthorize() {
 	s.checkGitHubProviderRedirectsToAuthorize("https://github.com")
 	s.checkGitHubProviderRedirectsToAuthorize("https://github.com/")
 	s.checkGitHubProviderRedirectsToAuthorize("https://github.com/org/repo")
+	// Check alias
+	s.checkGitHubProviderRedirectsToAuthorize("github")
 }
 
 func (s *LinkTestSuite) checkGitHubProviderRedirectsToAuthorize(for_ string) {
@@ -95,6 +97,14 @@ func (s *LinkTestSuite) TestOSOProviderRedirectsToAuthorize() {
 	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com")
 	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com/")
 	s.checkOSOProviderRedirectsToAuthorize("https://api.starter-us-east-2.openshift.com/path")
+	s.checkOSO2aProviderRedirectsToAuthorize(s.testIdentity, "https://api.starter-us-east-2a.openshift.com/path")
+	// Check alias
+	s.checkOSOProviderRedirectsToAuthorize("openshift")
+
+	// Check another cluster
+	testIdentityCluster2a, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "testOSOProviderRedirectsToAuthorizeUser")
+	require.Nil(s.T(), err)
+	s.checkOSO2aProviderRedirectsToAuthorize(testIdentityCluster2a, "openshift")
 }
 
 func (s *LinkTestSuite) checkOSOProviderRedirectsToAuthorize(for_ string) {
@@ -104,8 +114,21 @@ func (s *LinkTestSuite) checkOSOProviderRedirectsToAuthorize(for_ string) {
 	require.NotEmpty(s.T(), s.stateParam(location))
 }
 
+func (s *LinkTestSuite) checkOSO2aProviderRedirectsToAuthorize(identity account.Identity, for_ string) {
+	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, identity.ID.String(), for_, "https://openshift.io/home")
+	require.Nil(s.T(), err)
+	require.Contains(s.T(), location, "https://api.starter-us-east-2a.openshift.com/oauth/authorize")
+	require.NotEmpty(s.T(), s.stateParam(location))
+}
+
 func (s *LinkTestSuite) TestMultipleProvidersRedirectsToAuthorize() {
 	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), "https://github.com/org/repo,https://openshift.io/home", "https://openshift.io/_home")
+	require.Nil(s.T(), err)
+	require.True(s.T(), strings.HasPrefix(location, "https://github.com/login/oauth/authorize"))
+	require.NotEmpty(s.T(), s.stateParam(location))
+
+	// Aliases
+	location, err = s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), "github,openshift", "https://openshift.io/_home")
 	require.Nil(s.T(), err)
 	require.True(s.T(), strings.HasPrefix(location, "https://github.com/login/oauth/authorize"))
 	require.NotEmpty(s.T(), s.stateParam(location))
@@ -126,7 +149,7 @@ func (s *LinkTestSuite) TestCallbackFailsForUnknownIdentity() {
 	require.Nil(s.T(), err)
 	state := s.stateParam(location)
 
-	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: uuid.NewV4().String(), Config: s.Configuration})
+	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: uuid.NewV4().String(), Config: s.Configuration, DB: s.Application})
 
 	code := uuid.NewV4().String()
 	_, err = linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
@@ -139,7 +162,7 @@ func (s *LinkTestSuite) TestProviderSavesTokenOK() {
 	state := s.stateParam(location)
 
 	token := uuid.NewV4().String()
-	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration})
+	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, DB: s.Application})
 
 	code := uuid.NewV4().String()
 	callbackLocation, err := linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
@@ -155,7 +178,7 @@ func (s *LinkTestSuite) TestProviderSavesTokenWithUnavailableProfileFails() {
 	state := s.stateParam(location)
 
 	token := uuid.NewV4().String()
-	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, LoadProfileFail: true})
+	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, LoadProfileFail: true, DB: s.Application})
 
 	code := uuid.NewV4().String()
 	_, err = linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
@@ -180,9 +203,26 @@ func (s *LinkTestSuite) TestProviderSavesTokensForMultipleResources() {
 	s.checkCallback(s.Configuration.GetOSOClusters()["https://api.starter-us-east-2.openshift.com"].TokenProviderID, s.stateParam(callbackLocation), url.URL{Scheme: "https", Host: "openshift.io", Path: "/_home"})
 }
 
+func (s *LinkTestSuite) TestProviderSavesTokensForMultipleAliases() {
+	// Redirect to GitHub first
+	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, s.testIdentity.ID.String(), "github,openshift", "https://openshift.io/_home")
+	require.Nil(s.T(), err)
+	locationURL, err := url.Parse(location)
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), "https", locationURL.Scheme)
+	require.Equal(s.T(), "github.com", locationURL.Host)
+	require.Equal(s.T(), "/login/oauth/authorize", locationURL.Path)
+
+	// Callback from GitHub should redirect to OSO
+	callbackLocation := s.checkCallback(GitHubProviderID, s.stateParam(location), url.URL{Scheme: "https", Host: "api.starter-us-east-2.openshift.com", Path: "/oauth/authorize"})
+
+	// Callback from OSO should redirect back to the original redirect URL
+	s.checkCallback(s.Configuration.GetOSOClusters()["https://api.starter-us-east-2.openshift.com"].TokenProviderID, s.stateParam(callbackLocation), url.URL{Scheme: "https", Host: "openshift.io", Path: "/_home"})
+}
+
 func (s *LinkTestSuite) checkCallback(providerID string, state string, expectedURL url.URL) string {
 	token := uuid.NewV4().String()
-	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration})
+	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, DB: s.Application})
 	callbackLocation, err := linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, uuid.NewV4().String())
 	require.Nil(s.T(), err)
 	locationURL, err := url.Parse(callbackLocation)

--- a/token/link/openshift.go
+++ b/token/link/openshift.go
@@ -14,6 +14,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	OpenShiftProviderAlias = "openshift"
+)
+
 type OpenShiftIdentityProvider struct {
 	oauth.OauthIdentityProvider
 	Cluster configuration.OSOCluster
@@ -58,6 +62,10 @@ func (provider *OpenShiftIdentityProvider) Scopes() string {
 
 func (provider *OpenShiftIdentityProvider) TypeName() string {
 	return "openshift-v3"
+}
+
+func (provider *OpenShiftIdentityProvider) URL() string {
+	return provider.Cluster.APIURL
 }
 
 // Profile fetches a user profile from the Identity Provider


### PR DESCRIPTION
- [x] `openshift` and `github` aliases added to `GET and DELETE /api/token?for=<alias>` and `GET /api/token/status?for=<alias>`
This PR adds a special alias for the user's cluster URL - `/api/token?for=openshift`. Auth service looks up for the cluster URL where the user is provisioned to and returns the token for that cluster.
There is also `github` alias available for `https://github.com` - `/api/token?for=github`

- [x] new `provider_api_url` claim is added to the response:
```
GET /api/token?for=openshift
Authorization: Bearer <OSIO_USER_TOKEN>

OK 200
{
  "access_token": "asdd123213hsd",
  "scope": "user:full",
  "token_type": "Bearer",
  "username": "johnsmith",
  "provider_api_url": "https://api.starter-us-east-2.openshift.com"
}
```

- [x] Similar payload is now returned for `/api/token/status`:
```
GET /api/token/status?for=openshift
Authorization: Bearer <OSIO_USER_TOKEN>

200 OK
{
  "username": "johnsmith",
  "provider_api_url": "https://api.starter-us-east-2a.openshift.com"
}
```

Fixes https://github.com/fabric8-services/fabric8-auth/issues/334