### PR TITLE
Updated instructions and kedge files for deploying to minishift

### DIFF
--- a/minishift/README.md
+++ b/minishift/README.md
@@ -5,11 +5,13 @@ These instructions will help you run your services on OpenShift using MiniShift.
 ### Prerequisites
 
 
-[Kedge](kedgeproject.org)
+[Kedge 0.9.0](kedgeproject.org)
 
-[MiniShift](https://docs.openshift.org/latest/minishift/getting-started/installing.html)
+[MiniShift v1.13.1](https://docs.openshift.org/latest/minishift/getting-started/installing.html)
 
-[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+[Kubectl 1.9.3](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+[KVM Hypervisor](https://www.linux-kvm.org/page/Downloads)
 
 
 ### Installation (Linux)
@@ -19,7 +21,7 @@ These instructions will help you run your services on OpenShift using MiniShift.
 Following steps will download and install Kedge on your machine and put it in your $PATH. For more detailed information please visit [kedgeproject.org](http://kedgeproject.org/)
 
 ```
-curl -L https://github.com/kedgeproject/kedge/releases/download/v0.5.1/kedge-linux-amd64 -o kedge
+curl -L https://github.com/kedgeproject/kedge/releases/download/v0.9.0/kedge-linux-amd64 -o kedge
 ```
 
 Verify installation by running following command, you should get version number.

--- a/minishift/kedge/auth-local.yml
+++ b/minishift/kedge/auth-local.yml
@@ -1,16 +1,15 @@
 name: auth
-containers:
-- image: fabric8/fabric8-auth:dev
-  env:
-  - name: AUTH_DEVELOPER_MODE_ENABLED
-    value: "true"
-  - name: AUTH_POSTGRES_HOST
-    value: "db-auth"
-  - name: AUTH_POSTGRES_PORT
-    value: "5432"
+deployments:
+- containers:
+  - image: fabric8/fabric8-auth:dev
+    env:
+    - name: AUTH_DEVELOPER_MODE_ENABLED
+      value: "true"
+    - name: AUTH_POSTGRES_HOST
+      value: "db-auth"
+    - name: AUTH_POSTGRES_PORT
+      value: "5432"
 services:
 - name: auth
-  type: NodePort
-  ports:
-  - port: 8089
-    nodePort: 31000
+  portMappings:
+  - 8089:31000

--- a/minishift/kedge/auth-local.yml
+++ b/minishift/kedge/auth-local.yml
@@ -11,5 +11,7 @@ deployments:
       value: "5432"
 services:
 - name: auth
-  portMappings:
-  - 8089:31000
+  type: NodePort
+  ports:
+  - port: 8089
+    nodePort: 31000

--- a/minishift/kedge/auth.yml
+++ b/minishift/kedge/auth.yml
@@ -11,5 +11,7 @@ deployments:
       value: "5432"
 services:
 - name: auth
-  portMappings:
-  - 8089:31000
+  type: NodePort
+  ports:
+  - port: 8089
+    nodePort: 31000

--- a/minishift/kedge/auth.yml
+++ b/minishift/kedge/auth.yml
@@ -1,16 +1,15 @@
 name: auth
-containers:
-- image: docker.io/fabric8/fabric8-auth:latest
-  env:
-  - name: AUTH_DEVELOPER_MODE_ENABLED
-    value: "true"
-  - name: AUTH_POSTGRES_HOST
-    value: "db-auth"
-  - name: AUTH_POSTGRES_PORT
-    value: "5432"
+deployments:
+- containers:
+  - image: docker.io/fabric8/fabric8-auth:latest
+    env:
+    - name: AUTH_DEVELOPER_MODE_ENABLED
+      value: "true"
+    - name: AUTH_POSTGRES_HOST
+      value: "db-auth"
+    - name: AUTH_POSTGRES_PORT
+      value: "5432"
 services:
 - name: auth
-  type: NodePort
-  ports:
-  - port: 8089
-    nodePort: 31000
+  portMappings:
+  - 8089:31000

--- a/minishift/kedge/db-auth.yml
+++ b/minishift/kedge/db-auth.yml
@@ -1,12 +1,13 @@
 name: db-auth
-containers:
-- image: registry.centos.org/postgresql/postgresql:9.6
-  env:
-  - name: POSTGRESQL_ADMIN_PASSWORD
-    value: mysecretpassword
+
+deployments:
+- containers:
+  - image: registry.centos.org/postgresql/postgresql:9.6
+    env:
+    - name: POSTGRESQL_ADMIN_PASSWORD
+      value: mysecretpassword
+
 services:
 - name: db-auth
-  type: NodePort
-  ports:
-  - port: 5432
-    nodePort: 31001
+  portMappings:
+  - 5432:31001

--- a/minishift/kedge/db-auth.yml
+++ b/minishift/kedge/db-auth.yml
@@ -9,5 +9,7 @@ deployments:
 
 services:
 - name: db-auth
-  portMappings:
-  - 5432:31001
+  type: NodePort
+  ports:
+  - port: 5432
+    nodePort: 31001


### PR DESCRIPTION
Fixes #328 

This PR updates the kedge files to work with the latest version (as of now 0.9.0) of Kedge, and updates `minishift/README.MD` with more specifics about supported version numbers and environments.

```
shane@shane-ThinkPad-W541:~/go/src/github.com/fabric8-services/fabric8-auth$ minishift stop
Stopping local OpenShift cluster...
Cluster stopped.
shane@shane-ThinkPad-W541:~/go/src/github.com/fabric8-services/fabric8-auth$ minishift delete
You are deleting the Minishift VM: 'minishift'. Do you want to continue [y/N]?: y
Deleting the Minishift VM...
Minishift VM deleted.
shane@shane-ThinkPad-W541:~/go/src/github.com/fabric8-services/fabric8-auth$ make dev-openshift
GO15VENDOREXPERIMENT=1 GOARCH=amd64 GOOS=linux go build -o bin/docker/fabric8-auth-linux
minishift start --cpus 4
-- Starting profile 'minishift'
-- Checking if requested hypervisor 'kvm' is supported on this platform ... OK
-- Checking if KVM driver is installed ... 
   Driver is available at /usr/local/bin/docker-machine-driver-kvm ... 
   Checking driver binary is executable ... OK
-- Checking if Libvirt is installed ... OK
-- Checking if Libvirt default network is present ... OK
-- Checking if Libvirt default network is active ... OK
-- Checking the ISO URL ... OK
-- Starting local OpenShift cluster using 'kvm' hypervisor ...
-- Minishift VM will be configured with ...
   Memory:    4 GB
   vCPUs :    4
   Disk size: 20 GB
-- Starting Minishift VM ......................... OK
-- Checking for IP address ... OK
-- Checking if external host is reachable from the Minishift VM ... 
   Pinging 8.8.8.8 ... OK
-- Checking HTTP connectivity from the VM ... 
   Retrieving http://minishift.io/index.html ... OK
-- Checking if persistent storage volume is mounted ... OK
-- Checking available disk space ... 0% used OK
   Importing 'openshift/origin:v3.7.1' ..................... OK
   Importing 'openshift/origin-docker-registry:v3.7.1' ...... OK
   Importing 'openshift/origin-haproxy-router:v3.7.1' ....... OK
-- OpenShift cluster will be configured with ...
   Version: v3.7.1
-- Checking 'oc' support for startup flags ... 
   host-config-dir ... OK
   host-data-dir ... OK
   host-pv-dir ... OK
   host-volumes-dir ... OK
   routing-suffix ... OK
Starting OpenShift using openshift/origin:v3.7.1 ...
OpenShift server started.

The server is accessible via web console at:
    https://192.168.42.160:8443

You are logged in as:
    User:     developer
    Password: <any value>

To login as administrator:
    oc login -u system:admin

./minishift/check_hosts.sh
Updating /etc/hosts (Remove old minishift.local if any and add new one)
[sudo] password for shane: 
192.168.42.160 minishift.local
eval `minishift oc-env` &&  oc login -u developer -p developer && oc new-project auth-openshift
Login successful.

You have one project on this server: "myproject"

Using project "myproject".
Now using project "auth-openshift" on server "https://192.168.42.160:8443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git

to build a new example application in Ruby.
AUTH_DEVELOPER_MODE_ENABLED=true \
kedge apply -f minishift/kedge/db-auth.yml
service "db-auth" created
deployment "db-auth" created
sleep 5s
eval `minishift docker-env` && docker login -u developer -p $(oc whoami -t) $(minishift openshift registry) && docker build -t fabric8/fabric8-auth:dev bin/docker
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
Sending build context to Docker daemon  20.37MB
Step 1 : FROM fabric8/fabric8-auth:v6a56c54
v6a56c54: Pulling from fabric8/fabric8-auth
74f0853ba93b: Pull complete 
9186c25d74ab: Pull complete 
8d697c690cf7: Pull complete 
8c630910e5f0: Pull complete 
eda41d6efddc: Pull complete 
ec02f8f3d4e6: Pull complete 
a1a79ad96400: Pull complete 
Digest: sha256:458644cce55bf7d20be0afb645cecfc5c03d6443f7919591254b922837126409
Status: Downloaded newer image for fabric8/fabric8-auth:v6a56c54
 ---> 81de9f704f1d
Step 2 : COPY fabric8-auth-linux /usr/local/auth/bin/auth
 ---> 2566b55990d5
Removing intermediate container 7516a4fac974
Step 3 : RUN echo chmod +x /usr/local/auth/bin/auth
 ---> Running in 0473a805f675
chmod +x /usr/local/auth/bin/auth
 ---> 9a202f4da985
Removing intermediate container 0473a805f675
Successfully built 9a202f4da985
kedge delete -f minishift/kedge/auth-local.yml
Error from server (NotFound): error when deleting "STDIN": services "auth" not found
failed to execute command: failed to execute command: exit status 1
Makefile:326: recipe for target 'dev-openshift' failed
make: [dev-openshift] Error 255 (ignored)
kedge apply -f minishift/kedge/auth-local.yml
service "auth" created
deployment "auth" created
shane@shane-ThinkPad-W541:~/go/src/github.com/fabric8-services/fabric8-auth$ wget -qO- /dev/null http://minishift.local:31000/api/users
{"data":[]}

```