### PR TITLE
Support force_pull for /api/token when retrieving cluster tokens

### DIFF
--- a/test/oauth.go
+++ b/test/oauth.go
@@ -68,3 +68,7 @@ func (provider *DummyProvider) Profile(ctx context.Context, token oauth2.Token) 
 		Username: token.AccessToken + "testuser",
 	}, nil
 }
+
+func (provider *DummyProvider) OSOCluster() configuration.OSOCluster {
+	return *provider.factory.Config.GetOSOClusterByURL(provider.URL())
+}

--- a/token/link/link.go
+++ b/token/link/link.go
@@ -268,7 +268,6 @@ func (service *LinkService) Callback(ctx context.Context, req *goa.RequestData, 
 // NewOauthProvider creates a new oauth provider for the given resource URL or provider alias
 func (service *OauthProviderFactoryService) NewOauthProvider(ctx context.Context, identityID uuid.UUID, req *goa.RequestData, forResource string) (ProviderConfig, error) {
 	authURL := rest.AbsoluteURL(req, "")
-
 	// Check if the forResource is actually a provider alias like "github" or "openshift"
 	if forResource == GitHubProviderAlias {
 		return NewGitHubIdentityProvider(service.config.GetGitHubClientID(), service.config.GetGitHubClientSecret(), service.config.GetGitHubClientDefaultScopes(), authURL), nil

--- a/token/link/openshift.go
+++ b/token/link/openshift.go
@@ -18,6 +18,12 @@ const (
 	OpenShiftProviderAlias = "openshift"
 )
 
+// OpenShiftIdentityProviderConfig represents an OpenShift Identity Provider
+type OpenShiftIdentityProviderConfig interface {
+	oauth.IdentityProvider
+	OSOCluster() configuration.OSOCluster
+}
+
 type OpenShiftIdentityProvider struct {
 	oauth.OauthIdentityProvider
 	Cluster configuration.OSOCluster
@@ -62,6 +68,10 @@ func (provider *OpenShiftIdentityProvider) Scopes() string {
 
 func (provider *OpenShiftIdentityProvider) TypeName() string {
 	return "openshift-v3"
+}
+
+func (provider *OpenShiftIdentityProvider) OSOCluster() configuration.OSOCluster {
+	return provider.Cluster
 }
 
 func (provider *OpenShiftIdentityProvider) URL() string {


### PR DESCRIPTION
Currently we support force_pull param in /api/token?for=<oso_resource> endpoint when retrieving user OSO tokens.
This PR also adds support of the same force_pull param for cluster tokens too. Not only for user tokens.
When force_pull=true the auth service will load the user profile using the stored dsaas user token. It will return 401 if the token is not valid and rejected by OSO.

Required for https://github.com/openshiftio/openshift.io/issues/2304
