### PR TITLE
Show Go version when building

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -28,7 +28,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 
 # Get glide for Go package management
 RUN cd /tmp \
-    && wget https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz \
+    && wget https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz \
     && tar xzf glide-v*.tar.gz \
     && mv linux-amd64/glide /usr/bin \
     && rm -rfv glide-v* linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -328,8 +328,13 @@ clean-openshift:
 	-kedge delete -f minishift/kedge/auth.yml -f minishift/kedge/db-auth.yml
 	-eval oc delete project auth-openshift --grace-period=1
 
+.PHONY: show-info
+show-info:
+	$(call log-info,"$(shell go version)")
+	$(call log-info,"$(shell go env)")
+
 .PHONY: prebuild-check
-prebuild-check: $(TMP_PATH) $(INSTALL_PREFIX) $(CHECK_GOPATH_BIN)
+prebuild-check: $(TMP_PATH) $(INSTALL_PREFIX) $(CHECK_GOPATH_BIN) show-info
 # Check that all tools where found
 ifndef GIT_BIN
 	$(error The "$(GIT_BIN_NAME)" executable could not be found in your PATH)


### PR DESCRIPTION
- [x] Show Go version when building:
```
INFO: go version go1.8.3 linux/amd64
INFO: GOARCH=amd64 GOBIN= GOEXE= GOHOSTARCH=amd64 GOHOSTOS=linux GOOS=linux GOPATH=/home/...
```
- [x] Update glide for a docker build to 1.13.1

Based on https://github.com/fabric8-services/fabric8-wit/pull/1935
