### PR TITLE
Add Jenkins-Idler SA to cluster and token API

### DIFF
--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -32,7 +32,7 @@ func NewClustersController(service *goa.Service, config clusterConfiguration) *C
 
 // Show runs the list of available OSO clusters.
 func (c *ClustersController) Show(ctx *app.ShowClustersContext) error {
-	if !token.IsSpecificServiceAccount(ctx, token.OsoProxy, token.Tenant) {
+	if !token.IsSpecificServiceAccount(ctx, token.OsoProxy, token.Tenant, token.JenkinsIdler) {
 		log.Error(ctx, nil, "unauthorized access to cluster info")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("unauthorized access to cluster info"))
 	}

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -32,6 +32,7 @@ func (rest *TestClustersREST) TestShowForServiceAccountsOK() {
 	require.True(rest.T(), len(rest.Config.GetOSOClusters()) > 0)
 	rest.checkShowForServiceAccount("fabric8-oso-proxy")
 	rest.checkShowForServiceAccount("fabric8-tenant")
+	rest.checkShowForServiceAccount("fabric8-jenkins-idler")
 }
 
 func (rest *TestClustersREST) checkShowForServiceAccount(saName string) {

--- a/controller/token.go
+++ b/controller/token.go
@@ -243,8 +243,8 @@ func (c *TokenController) retrieveToken(ctx context.Context, forResource string,
 	}
 
 	osConfig, ok := providerConfig.(link.OpenShiftIdentityProviderConfig)
-	if ok && token.IsSpecificServiceAccount(ctx, token.OsoProxy, token.Tenant) {
-		// This is a request from OSO proxy or tenant service to obtain a cluster wide token
+	if ok && token.IsSpecificServiceAccount(ctx, token.OsoProxy, token.Tenant, token.JenkinsIdler) {
+		// This is a request from OSO proxy, tenant, or Jenkins Idler service to obtain a cluster wide token
 		return c.retrieveClusterToken(ctx, forResource, forcePull, osConfig)
 	}
 

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -90,6 +90,7 @@ func (rest *TestTokenStorageREST) SecuredControllerWithServiceAccountAndDummyPro
 func (rest *TestTokenStorageREST) TestRetrieveOSOServiceAccountTokenOK() {
 	rest.checkRetrieveOSOServiceAccountToken("fabric8-oso-proxy")
 	rest.checkRetrieveOSOServiceAccountToken("fabric8-tenant")
+	rest.checkRetrieveOSOServiceAccountToken("fabric8-jenkins-idler")
 }
 
 func (rest *TestTokenStorageREST) checkRetrieveOSOServiceAccountToken(saName string) {

--- a/token/token.go
+++ b/token/token.go
@@ -40,6 +40,7 @@ const (
 	OsoProxy           = "fabric8-oso-proxy"
 	Tenant             = "fabric8-tenant"
 	Notification       = "fabric8-notification"
+	JenkinsIdler       = "fabric8-jenkins-idler"
 	OnlineRegistration = "online-registration"
 )
 


### PR DESCRIPTION
So, Jenkins Idler can access cluster configuration and cluster tokens.