### PR TITLE
Get role assignments for a specific resource & role name

### DIFF
--- a/authorization/role/model/role_management_model_service.go
+++ b/authorization/role/model/role_management_model_service.go
@@ -18,6 +18,7 @@ import (
 // RoleManagementModelService defines the service contract for managing role assignments
 type RoleManagementModelService interface {
 	ListByResource(ctx context.Context, resourceID string) ([]identityrole.IdentityRole, error)
+	ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]identityrole.IdentityRole, error)
 }
 
 // NewRoleManagementModelService creates a new service to manage role assignments
@@ -32,6 +33,121 @@ func NewRoleManagementModelService(db *gorm.DB, repo repository.Repositories) *G
 type GormRoleManagementModelService struct {
 	db         *gorm.DB
 	repository repository.Repositories
+}
+
+// ListByResourceAndRoleName lists role assignments of a specific resource.
+func (r *GormRoleManagementModelService) ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]identityrole.IdentityRole, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "identity_role", "list"}, time.Now())
+	var identityRoles []identityrole.IdentityRole
+
+	r.db = r.db.Debug()
+	db := r.db.Raw(`WITH RECURSIVE q AS ( 
+		SELECT 
+		  resource_id, parent_resource_id 
+		FROM 
+		  resource 
+		WHERE 
+		  resource_id = ?
+		UNION ALL
+		SELECT 
+		  p.resource_id, p.parent_resource_id
+		FROM 
+		  resource p
+		JOIN q ON 
+		  q.parent_resource_id = p.resource_id)
+	  SELECT 
+		q.parent_resource_id,q.resource_id, ir.identity_role_id, ir.identity_id, r.role_id, r.name 
+	  FROM 
+		identity_role ir, q, role r
+	  WHERE 
+		ir.resource_id = q.resource_id 
+		and ir.role_id = r.role_id
+		and r.name = ?`, resourceID, roleName)
+
+	rows, err := db.Rows()
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": resourceID,
+			"err":         err,
+		}, "error running custom sql to get identity roles")
+		return identityRoles, err
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	columnValues := make([]interface{}, len(columns))
+
+	var ignore interface{}
+	for index := range columnValues {
+		columnValues[index] = &ignore
+	}
+
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": resourceID,
+			"err":         err,
+		}, "error getting columns")
+		return identityRoles, errors.NewInternalError(ctx, err)
+	}
+
+	for rows.Next() {
+		var parentResourceID *string
+		var returnedResourceID string
+		var identityRoleID string
+		var identityID string
+		var roleID string
+		var roleName string
+
+		columnValues[0] = &parentResourceID
+		columnValues[1] = &returnedResourceID
+		columnValues[2] = &identityRoleID
+		columnValues[3] = &identityID
+		columnValues[4] = &roleID
+		columnValues[5] = &roleName
+
+		if err = rows.Scan(columnValues...); err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"resource_id": resourceID,
+				"err":         err,
+			}, "error getting rows")
+			return identityRoles, errors.NewInternalError(ctx, err)
+		}
+
+		identityRoleIDAsUUID, err := uuid.FromString(identityRoleID)
+		if err != nil {
+			return identityRoles, errors.NewInternalError(ctx, err)
+		}
+
+		identityIDAsUUID, err := uuid.FromString(identityID)
+		if err != nil {
+			return identityRoles, errors.NewInternalError(ctx, err)
+		}
+
+		roleIDAsUUID, err := uuid.FromString(roleID)
+		if err != nil {
+			return identityRoles, errors.NewInternalError(ctx, err)
+		}
+
+		ir := identityrole.IdentityRole{
+			IdentityRoleID: identityRoleIDAsUUID,
+			Identity: account.Identity{
+				ID: identityIDAsUUID,
+			},
+			Resource: resource.Resource{
+				ResourceID:       resourceID,
+				ParentResourceID: parentResourceID,
+			},
+			Role: role.Role{
+				RoleID: roleIDAsUUID,
+				Name:   roleName,
+			},
+		}
+		if parentResourceID != nil {
+			ir.Resource.ParentResourceID = parentResourceID
+		}
+		identityRoles = append(identityRoles, ir)
+	}
+	return identityRoles, nil
 }
 
 // ListByResource lists role assignments of a specific resource.

--- a/authorization/role/model/role_management_model_service.go
+++ b/authorization/role/model/role_management_model_service.go
@@ -75,13 +75,6 @@ func (r *GormRoleManagementModelService) ListByResourceAndRoleName(ctx context.C
 	defer rows.Close()
 
 	columns, err := rows.Columns()
-	columnValues := make([]interface{}, len(columns))
-
-	var ignore interface{}
-	for index := range columnValues {
-		columnValues[index] = &ignore
-	}
-
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resourceID,
@@ -89,6 +82,8 @@ func (r *GormRoleManagementModelService) ListByResourceAndRoleName(ctx context.C
 		}, "error getting columns")
 		return identityRoles, errors.NewInternalError(ctx, err)
 	}
+
+	columnValues := make([]interface{}, len(columns))
 
 	for rows.Next() {
 		var parentResourceID *string
@@ -189,13 +184,6 @@ func (r *GormRoleManagementModelService) ListByResource(ctx context.Context, res
 	defer rows.Close()
 
 	columns, err := rows.Columns()
-	columnValues := make([]interface{}, len(columns))
-
-	var ignore interface{}
-	for index := range columnValues {
-		columnValues[index] = &ignore
-	}
-
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resourceID,
@@ -203,6 +191,8 @@ func (r *GormRoleManagementModelService) ListByResource(ctx context.Context, res
 		}, "error getting columns")
 		return identityRoles, errors.NewInternalError(ctx, err)
 	}
+
+	columnValues := make([]interface{}, len(columns))
 
 	for rows.Next() {
 		var parentResourceID *string

--- a/authorization/role/model/role_management_model_service_backbox_test.go
+++ b/authorization/role/model/role_management_model_service_backbox_test.go
@@ -45,6 +45,27 @@ func (s *roleManagementModelServiceBlackboxTest) TestGetIdentityRoleByResource()
 	require.Equal(t, identityRole.Role.RoleID, identityRoles[0].Role.RoleID)
 }
 
+func (s *roleManagementModelServiceBlackboxTest) TestGetIdentityRoleByResourceAndRoleName() {
+	t := s.T()
+	identityRole, err := testsupport.CreateRandomIdentityRole(s.Ctx, s.DB)
+	require.NoError(t, err)
+	require.NotNil(t, identityRole)
+
+	// something that we don't want to be returned
+	for i := 0; i < 10; i++ {
+		identityRoleUnrelated, err := testsupport.CreateRandomIdentityRole(s.Ctx, s.DB)
+		require.NoError(t, err)
+		require.NotNil(t, identityRoleUnrelated)
+	}
+
+	identityRoles, err := s.repo.ListByResourceAndRoleName(s.Ctx, identityRole.Resource.ResourceID, identityRole.Role.Name)
+	require.NoError(t, err)
+	require.Len(t, identityRoles, 1)
+	require.Equal(t, identityRole.Resource.ResourceID, identityRoles[0].Resource.ResourceID)
+	require.Equal(t, identityRole.Identity.ID, identityRoles[0].Identity.ID)
+	require.Equal(t, identityRole.Role.RoleID, identityRoles[0].Role.RoleID)
+}
+
 func (s *roleManagementModelServiceBlackboxTest) TestGetIdentityRoleByResourceNotFound() {
 	t := s.T()
 	identityRole, err := testsupport.CreateRandomIdentityRole(s.Ctx, s.DB)
@@ -52,6 +73,17 @@ func (s *roleManagementModelServiceBlackboxTest) TestGetIdentityRoleByResourceNo
 	require.NotNil(t, identityRole)
 
 	identityRoles, err := s.repo.ListByResource(s.Ctx, uuid.NewV4().String())
+	require.NoError(t, err)
+	require.Equal(t, 0, len(identityRoles))
+}
+
+func (s *roleManagementModelServiceBlackboxTest) TestGetIdentityRoleByResourceAndRoleNameNotFound() {
+	t := s.T()
+	identityRole, err := testsupport.CreateRandomIdentityRole(s.Ctx, s.DB)
+	require.NoError(t, err)
+	require.NotNil(t, identityRole)
+
+	identityRoles, err := s.repo.ListByResourceAndRoleName(s.Ctx, uuid.NewV4().String(), uuid.NewV4().String())
 	require.NoError(t, err)
 	require.Equal(t, 0, len(identityRoles))
 }

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -12,6 +12,7 @@ import (
 // RoleManagementService defines the contract for managing roles assigments to a resource
 type RoleManagementService interface {
 	ListByResource(ctx context.Context, resourceID string) ([]identityrole.IdentityRole, error)
+	ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]identityrole.IdentityRole, error)
 }
 
 // RoleManagementServiceImpl implements the RoleManagementService for managing role assignments.
@@ -41,6 +42,28 @@ func (r *RoleManagementServiceImpl) ListByResource(ctx context.Context, resource
 		}
 
 		roles, err = r.modelService.ListByResource(ctx, resourceID)
+		return err
+	})
+
+	return roles, err
+}
+
+// ListByResourceAndRoleName lists assignments made for a specific resource
+func (r *RoleManagementServiceImpl) ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]identityrole.IdentityRole, error) {
+
+	var roles []identityrole.IdentityRole
+	var err error
+	err = application.Transactional(r.db, func(appl application.Application) error {
+		err = appl.ResourceRepository().CheckExists(ctx, resourceID)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"resource_id": resourceID,
+				"err":         err,
+			}, "does not exist")
+			return errors.NewNotFoundError("resource_id", resourceID)
+		}
+
+		roles, err = r.modelService.ListByResourceAndRoleName(ctx, resourceID, roleName)
 		return err
 	})
 

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -94,6 +94,11 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesNotFound() {
 	test.ListAssignedResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String())
 }
 
+func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameNotFound() {
+	svc, ctrl := rest.SecuredControllerWithIdentity(testsupport.TestIdentity)
+	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String(), uuid.NewV4().String())
+}
+
 func (rest *TestResourceRolesRest) TestListAssignedRolesFromInheritedOK() {
 
 	// Create a resource of the inbuilt resource type
@@ -136,6 +141,74 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesFromInheritedOK() {
 	require.Len(rest.T(), returnedIdentityRoles.Data, 2)
 	require.True(rest.T(), rest.checkExists(*identityRoleRef, returnedIdentityRoles, true))
 	require.True(rest.T(), rest.checkExists(*identityRoleRef2, returnedIdentityRoles, true))
+}
+
+func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameFromInheritedOK() {
+
+	// Create a resource of the inbuilt resource type
+	// Create a child resource of the above resource
+	// Create a role for that resource type
+	// Create two assignments for that role
+	// Validate for 'Inherited' field's response
+
+	resourceOwner := testsupport.TestIdentity2
+	err := testsupport.CreateTestIdentityAndUserInDB(rest.DB, &resourceOwner)
+	require.NoError(rest.T(), err)
+
+	areaResourceType, err := rest.Application.ResourceTypeRepository().Lookup(rest.Ctx, "openshift.io/resource/area")
+	require.NoError(rest.T(), err)
+
+	parentResourceRef, err := testsupport.CreateTestResource(rest.Ctx, rest.DB, *areaResourceType, "SpaceR", nil)
+	require.NoError(rest.T(), err)
+	require.NotNil(rest.T(), parentResourceRef)
+
+	resourceRef, err := testsupport.CreateTestResource(rest.Ctx, rest.DB, *areaResourceType, "SpaceH", &parentResourceRef.ResourceID)
+	require.NoError(rest.T(), err)
+
+	roleRef, err := testsupport.CreateTestRole(rest.Ctx, rest.DB, *areaResourceType, "collab")
+	require.NoError(rest.T(), err)
+
+	roleRefGroup2, err := testsupport.CreateTestRole(rest.Ctx, rest.DB, *areaResourceType, "collab-x")
+	require.NoError(rest.T(), err)
+
+	var createdIdentityRoles []identityrole.IdentityRole
+	var createdIdentityRolesGroup2 []identityrole.IdentityRole
+
+	identityRoleRef, err := testsupport.CreateTestIdentityRole(rest.Ctx, rest.DB, *resourceRef, *roleRef)
+	require.NoError(rest.T(), err)
+	require.NotNil(rest.T(), identityRoleRef)
+	createdIdentityRoles = append(createdIdentityRoles, *identityRoleRef)
+
+	identityRoleRef2, err := testsupport.CreateTestIdentityRole(rest.Ctx, rest.DB, *resourceRef, *roleRef)
+	require.NoError(rest.T(), err)
+	require.NotNil(rest.T(), identityRoleRef2)
+	createdIdentityRoles = append(createdIdentityRoles, *identityRoleRef2)
+
+	// second role
+
+	identityRoleRef1InGroup2, err := testsupport.CreateTestIdentityRole(rest.Ctx, rest.DB, *resourceRef, *roleRefGroup2)
+	require.NoError(rest.T(), err)
+	require.NotNil(rest.T(), identityRoleRef1InGroup2)
+	createdIdentityRolesGroup2 = append(createdIdentityRolesGroup2, *identityRoleRef1InGroup2)
+
+	identityRoleRef2InGroup2, err := testsupport.CreateTestIdentityRole(rest.Ctx, rest.DB, *resourceRef, *roleRefGroup2)
+	require.NoError(rest.T(), err)
+	require.NotNil(rest.T(), identityRoleRef2InGroup2)
+	createdIdentityRolesGroup2 = append(createdIdentityRolesGroup2, *identityRoleRef2InGroup2)
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(testsupport.TestIdentity)
+	_, returnedIdentityRoles := test.ListAssignedByRoleNameResourceRolesOK(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, roleRef.Name)
+	require.Len(rest.T(), returnedIdentityRoles.Data, 2)
+	require.True(rest.T(), rest.checkExists(*identityRoleRef, returnedIdentityRoles, true))
+	require.True(rest.T(), rest.checkExists(*identityRoleRef2, returnedIdentityRoles, true))
+
+	_, returnedIdentityRoles = test.ListAssignedByRoleNameResourceRolesOK(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, roleRefGroup2.Name)
+	require.Len(rest.T(), returnedIdentityRoles.Data, 2)
+	require.True(rest.T(), rest.checkExists(*identityRoleRef1InGroup2, returnedIdentityRoles, true))
+	require.True(rest.T(), rest.checkExists(*identityRoleRef2InGroup2, returnedIdentityRoles, true))
+
+	// include these as a side-test
+	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, uuid.NewV4().String())
 }
 
 func (rest *TestResourceRolesRest) checkExists(createdRole identityrole.IdentityRole, pool *app.Identityroles, isInherited bool) bool {

--- a/design/role.go
+++ b/design/role.go
@@ -18,6 +18,16 @@ var _ = a.Resource("resource_roles", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
+	a.Action("listAssignedByRoleName", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/:resourceID/roles/:roleName/assigned"),
+		)
+		a.Description("List assigned roles for a specific role name, for a specific resource")
+		a.Response(d.OK, identityRolesMedia)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
 })
 
 // ResourceMedia represents a protected resource

--- a/design/role.go
+++ b/design/role.go
@@ -11,7 +11,7 @@ var _ = a.Resource("resource_roles", func() {
 	a.Action("listAssigned", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.GET("/:resourceID/roles/assigned"),
+			a.GET("/:resourceID/roles"),
 		)
 		a.Description("List assigned roles by resource")
 		a.Response(d.OK, identityRolesMedia)
@@ -22,7 +22,7 @@ var _ = a.Resource("resource_roles", func() {
 	a.Action("listAssignedByRoleName", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.GET("/:resourceID/roles/:roleName/assigned"),
+			a.GET("/:resourceID/roles/:roleName"),
 		)
 		a.Description("List assigned roles for a specific role name, for a specific resource")
 		a.Response(d.OK, identityRolesMedia)

--- a/design/role.go
+++ b/design/role.go
@@ -17,6 +17,7 @@ var _ = a.Resource("resource_roles", func() {
 		a.Response(d.OK, identityRolesMedia)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 	a.Action("listAssignedByRoleName", func() {
 		a.Security("jwt")
@@ -27,6 +28,7 @@ var _ = a.Resource("resource_roles", func() {
 		a.Response(d.OK, identityRolesMedia)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })
 


### PR DESCRIPTION
This API returns all assignees to a specific role, for a specific resource.

Request:
```
GET /api/resources/:resourceID/roles/:roleName
Authorization: Bearer <User OpenShift.io token>
```

A 200OK Response would look like :
```
{
  data: [
    {
      assignee_id: "cb567f71-b09c-4784-a692-9270a6679af8",
      assignee_type: "user",
      inherited: false,
      role_name: "collab"
    },
    {
      assignee_id: "bb577f71-b09c-4784-a692-9270a6679af8",
      assignee_type: "user",
      inherited: false,
      role_name: "collab"
    },
    {
      assignee_id: "af567f71-b09c-4784-a692-9270a6679af8",
      assignee_type: "user",
      inherited: false,
      role_name: "collab"
    }
  ]
}
```
fixes #375  
