### PR TITLE
Don't create preview OSO accounts in prod OSIO/Auth if they were provisioned for preview env

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -711,7 +711,8 @@ func (c *ConfigurationData) GetGitHubClientDefaultScopes() string {
 	return c.v.GetString(varGitHubClientDefaultScopes)
 }
 
-// GetOpenShiftClientApiUrl return the default OpenShift cluster client API URL used to link OpenShift accounts
+// GetOpenShiftClientApiUrl return the default OpenShift cluster client API URL.
+// If in a staging env a new user doesn't have the cluster set then this default cluster is used
 func (c *ConfigurationData) GetOpenShiftClientApiUrl() string {
 	return c.v.GetString(varOSOClientApiUrl)
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -94,6 +94,7 @@ const (
 	varNotificationServiceURL               = "notification.serviceurl"
 	varEmailVerifiedRedirectURL             = "email.verify.url"
 	varInternalUsersEmailAddressSuffix      = "internal.users.email.address.domain"
+	varIgnoreEmailInProd                    = "ignore.email.prod"
 
 	varTenantServiceURL = "tenant.serviceurl"
 
@@ -554,6 +555,9 @@ func (c *ConfigurationData) setConfigDefaults() {
 
 	// default email address suffix
 	c.v.SetDefault(varInternalUsersEmailAddressSuffix, "@redhat.com")
+
+	// Regex to be used to check if the user with such email should be ignored during account provisioning
+	c.v.SetDefault(varIgnoreEmailInProd, ".+\\+preview.*\\@redhat\\.com")
 }
 
 // GetEmailVerifiedRedirectURL returns the url where the user would be redirected to after clicking on email
@@ -1039,6 +1043,11 @@ func (c *ConfigurationData) GetValidRedirectURLs() string {
 // GetInternalUsersEmailAddressSuffix returns the email address suffix of employees who can opt-in for the 'internal' features.
 func (c *ConfigurationData) GetInternalUsersEmailAddressSuffix() string {
 	return c.v.GetString(varInternalUsersEmailAddressSuffix)
+}
+
+// GetIgnoreEmailInProd returns regex for checking if the user with such email should be ignored during account provisioning
+func (c *ConfigurationData) GetIgnoreEmailInProd() string {
+	return c.v.GetString(varIgnoreEmailInProd)
 }
 
 const (

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -1514,17 +1514,25 @@ func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountForExistingUser
 }
 
 func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountWithRequiredFieldsOnlyOK() {
-	user := testsupport.TestUser
-	identity := testsupport.TestIdentity
-	identity.User = user
-	identity.ProviderType = ""
-	user.FullName = ""
-	user.Cluster = "some cluster"
-	user.FeatureLevel = account.DefaultFeatureLevel // should be set by default
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("testuser%s@email.com", uuid.NewV4().String()))
+}
+
+func (s *UsersControllerTestSuite) checkCreateUserAsServiceAccountOK(email string) {
+	user := account.User{
+		ID:           uuid.NewV4(),
+		Email:        email,
+		Cluster:      "some cluster",
+		FeatureLevel: account.DefaultFeatureLevel,
+	}
+	identity := account.Identity{
+		ID:       uuid.NewV4(),
+		Username: "TestDeveloper" + uuid.NewV4().String(),
+		User:     user,
+	}
 
 	secureService, secureController := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
 
-	createUserPayload := newCreateUsersPayload(&user.Email, nil, nil, nil, nil, nil, &identity.Username, nil, user.ID.String(), &user.Cluster, nil, nil, nil)
+	createUserPayload := newCreateUsersPayload(&email, nil, nil, nil, nil, nil, &identity.Username, nil, user.ID.String(), &user.Cluster, nil, nil, nil)
 
 	// With only required fields should be OK
 	_, appUser := test.CreateUsersOK(s.T(), secureService.Context, secureService, secureController, createUserPayload)
@@ -1533,7 +1541,6 @@ func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountWithRequiredFie
 
 func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountWithMissingRequiredFieldsFails() {
 	user := testsupport.TestUser
-	// identity := testsupport.TestIdentity
 	cluster := "some cluster"
 
 	// Missing username
@@ -1575,6 +1582,30 @@ func (s *UsersControllerTestSuite) TestCreateUserAsNonServiceAccountUnauthorized
 	// then
 	createUserPayload := newCreateUsersPayload(&user.Email, &user.FullName, &user.Bio, &user.ImageURL, &user.URL, &user.Company, &identity.Username, nil, user.ID.String(), &user.Cluster, &identity.RegistrationCompleted, nil, user.ContextInformation)
 	test.CreateUsersUnauthorized(s.T(), secureService.Context, secureService, secureController, createUserPayload)
+}
+
+func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountForPreviewUserIgnored() {
+	// Ignored
+	s.checkCreateUserAsServiceAccountForPreviewUserIgnored(fmt.Sprintf("%s+preview%s@redhat.com", uuid.NewV4().String(), uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountForPreviewUserIgnored("someuser+preview@redhat.com")
+
+	// Not ignored
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s+preview@email.com", uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("preview%s@redhat.com", uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s@redhat.com", uuid.NewV4().String()))
+}
+
+func (s *UsersControllerTestSuite) checkCreateUserAsServiceAccountForPreviewUserIgnored(email string) {
+	secureService, secureController := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
+
+	username := "someuser"
+	cluster := "some.cluster"
+	createUserPayload := newCreateUsersPayload(&email, nil, nil, nil, nil, nil, &username, nil, uuid.NewV4().String(), &cluster, nil, nil, nil)
+
+	// With only required fields should be OK
+	_, appUser := test.CreateUsersOK(s.T(), secureService.Context, secureService, secureController, createUserPayload)
+	require.NotNil(s.T(), appUser)
+	assertCreatedUser(s.T(), appUser.Data, account.User{Cluster: cluster, Email: email}, account.Identity{Username: username})
 }
 
 func (s *UsersControllerTestSuite) TestCreateUserUnauthorized() {


### PR DESCRIPTION
When OSO reg app creates a user with email == `<username>+preview*@redhat.com` then Auth ignores such user.
Such accounts are supposed to be used only in Preview. So there will be no account sharing between prod and preview.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/377