### PR TITLE
fix: cleans up logging package

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -25,8 +25,6 @@ var (
 
 // InitializeLogger creates a default logger with the given ouput format and log level
 func InitializeLogger(logJSON bool, lvl string) {
-	logger = log.New()
-
 	logLevel, err := log.ParseLevel(lvl)
 	if err != nil {
 		log.Warnf("unable to parse log level configuration error: %q", err)
@@ -51,43 +49,6 @@ func InitializeLogger(logJSON bool, lvl string) {
 	}
 
 	logger.Out = os.Stdout
-}
-
-// NewCustomizedLogger creates a custom logger specifying the desired log level
-// and the log format flag. Returns the logger object and the error.
-func NewCustomizedLogger(level string, logJSON bool) (*log.Logger, error) {
-	logger := log.New()
-
-	lv, err := log.ParseLevel(level)
-	if err != nil {
-		return nil, err
-	}
-	logger.Level = lv
-
-	if logJSON {
-		customFormatter := new(log.JSONFormatter)
-		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-
-		log.SetFormatter(customFormatter)
-		customFormatter.DisableTimestamp = false
-
-		log.SetLevel(log.InfoLevel)
-		logger.Level = lv
-		logger.Formatter = customFormatter
-	} else {
-		customFormatter := new(log.TextFormatter)
-		customFormatter.FullTimestamp = true
-		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-		log.SetFormatter(customFormatter)
-
-		log.SetLevel(log.DebugLevel)
-		logger.Level = lv
-		logger.Formatter = customFormatter
-	}
-
-	logger.Out = os.Stdout
-
-	return logger, nil
 }
 
 // Logger returns the current logger object.
@@ -131,9 +92,9 @@ func Error(ctx context.Context, fields map[string]interface{}, format string, ar
 					for k, v := range req.Header {
 						// Hide sensitive information
 						if k == "Authorization" || k == "Cookie" {
-							headers[string(k)] = "*****"
+							headers[k] = "*****"
 						} else {
-							headers[string(k)] = v
+							headers[k] = v
 						}
 					}
 					entry = entry.WithField("req_headers", headers)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"context"
 )
 
 func LogAndAssertJSON(t *testing.T, log func(), assertions func(fields logrus.Fields)) {
@@ -38,7 +39,7 @@ func TestPointerToString(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Info(nil, nil, "test")
+		Info(context.Background(), nil, "test")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
@@ -48,7 +49,7 @@ func TestInfo(t *testing.T) {
 
 func TestInfoWithFields(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Info(nil, map[string]interface{}{"key": "value"}, "test")
+		Info(context.Background(), map[string]interface{}{"key": "value"}, "test")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
@@ -59,7 +60,7 @@ func TestInfoWithFields(t *testing.T) {
 
 func TestWarn(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Warn(nil, nil, "test")
+		Warn(context.Background(), nil, "test")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "warning")
@@ -68,7 +69,7 @@ func TestWarn(t *testing.T) {
 
 func TestDebug(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Debug(nil, nil, "test")
+		Debug(context.Background(), nil, "test")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "debug")
@@ -77,7 +78,7 @@ func TestDebug(t *testing.T) {
 
 func TestDebugMsgFieldHasPrefix(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Debug(nil, map[string]interface{}{"req": "PUT", "info": "hello"}, "msg with additional fields: %s", "value of my field")
+		Debug(context.Background() , map[string]interface{}{"req": "PUT", "info": "hello"}, "msg with additional fields: %s", "value of my field")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "msg with additional fields: value of my field")
 		assert.Equal(t, fields["req"], "PUT")
@@ -87,7 +88,7 @@ func TestDebugMsgFieldHasPrefix(t *testing.T) {
 
 func TestInfoMsgFieldHasPrefix(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Info(nil, map[string]interface{}{"req": "GET"}, "message with additional fields: %s", "value of my field")
+		Info(context.Background(), map[string]interface{}{"req": "GET"}, "message with additional fields: %s", "value of my field")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "message with additional fields: value of my field")
 		assert.Equal(t, fields["req"], "GET")

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/resource"
 
+	"context"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"context"
 )
 
 func LogAndAssertJSON(t *testing.T, log func(), assertions func(fields logrus.Fields)) {
@@ -78,7 +78,7 @@ func TestDebug(t *testing.T) {
 
 func TestDebugMsgFieldHasPrefix(t *testing.T) {
 	LogAndAssertJSON(t, func() {
-		Debug(context.Background() , map[string]interface{}{"req": "PUT", "info": "hello"}, "msg with additional fields: %s", "value of my field")
+		Debug(context.Background(), map[string]interface{}{"req": "PUT", "info": "hello"}, "msg with additional fields: %s", "value of my field")
 	}, func(fields logrus.Fields) {
 		assert.Equal(t, fields["msg"], "msg with additional fields: value of my field")
 		assert.Equal(t, fields["req"], "PUT")


### PR DESCRIPTION
#### Changes in this PR
 
  * removed dead code (`func NewCustomizedLogger`)
  * removed unnecessary and confusing double instantiation of `logger`
  * minor fixes hinted by [`gometalinter`](https://github.com/alecthomas/gometalinter)
