### PR TITLE
Don't return private emails in user search result

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
 
+	"fmt"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -208,5 +209,12 @@ func UserFilterByID(userID uuid.UUID) func(db *gorm.DB) *gorm.DB {
 func UserFilterByEmail(email string) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("email = ?", email)
+	}
+}
+
+// UserFilterByEmailPrivacy is to be used to filter only public or only private emails
+func UserFilterByEmailPrivacy(privateEmails bool) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where(fmt.Sprintf("email_private IS %v", privateEmails))
 	}
 }

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"errors"
 	"strings"
 
@@ -16,7 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 // CollaboratorsController implements the collaborators resource.
@@ -30,11 +29,6 @@ type CollaboratorsController struct {
 type collaboratorsConfiguration interface {
 	GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error)
 	GetCacheControlCollaborators() string
-}
-
-type collaboratorContext interface {
-	context.Context
-	jsonapi.InternalServerError
 }
 
 // NewCollaboratorsController creates a collaborators controller.
@@ -161,7 +155,7 @@ func (c *CollaboratorsController) RemoveMany(ctx *app.RemoveManyCollaboratorsCon
 	return ctx.OK([]byte{})
 }
 
-func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID uuid.UUID, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
+func (c *CollaboratorsController) updatePolicy(ctx jsonapi.InternalServerError, req *goa.RequestData, spaceID uuid.UUID, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
 	// Authorize current user
 	authorized, err := authz.Authorize(ctx, spaceID.String())
 	if err != nil {
@@ -253,7 +247,7 @@ func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa
 	return nil
 }
 
-func (c *CollaboratorsController) getPolicy(ctx collaboratorContext, req *goa.RequestData, spaceID uuid.UUID) (*auth.KeycloakPolicy, *string, error) {
+func (c *CollaboratorsController) getPolicy(ctx jsonapi.InternalServerError, req *goa.RequestData, spaceID uuid.UUID) (*auth.KeycloakPolicy, *string, error) {
 	var policyID string
 	err := application.Transactional(c.db, func(appl application.Application) error {
 		// Load associated space resource

--- a/controller/search.go
+++ b/controller/search.go
@@ -1,12 +1,12 @@
 package controller
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/fabric8-services/fabric8-auth/account"
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 
@@ -35,7 +35,7 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 
 	q := ctx.Q
 	if len(q) == 0 {
-		return ctx.BadRequest(goa.ErrBadRequest(fmt.Errorf("search query should be longer")))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("", "search query should be longer"))
 	}
 
 	var result []account.Identity

--- a/controller/users.go
+++ b/controller/users.go
@@ -1058,16 +1058,13 @@ func filterUsers(appl application.Application, ctx *app.ListUsersContext) ([]acc
 		/*** Start filtering on Users table ****/
 		if ctx.FilterEmail != nil {
 			userFilters = append(userFilters, account.UserFilterByEmail(*ctx.FilterEmail))
+			userFilters = append(userFilters, account.UserFilterByEmailPrivacy(false)) // Ignore users with private emails
 		}
 		// .. Add other filters in future when needed into the userFilters slice in the above manner.
 		if len(userFilters) != 0 {
 			filteredUsers, err = appl.Users().Query(userFilters...)
 			if err != nil {
 				return nil, nil, errs.Wrap(err, "error fetching users")
-			}
-			// Should be zero or the only user in the result. If the user's email is private then ignore the user
-			if len(filteredUsers) > 0 && filteredUsers[0].EmailPrivate {
-				filteredUsers = []account.User{}
 			}
 		} else {
 			// Soft-kill the API for listing all Users /api/users

--- a/controller/users.go
+++ b/controller/users.go
@@ -1038,7 +1038,8 @@ func filterUsers(appl application.Application, ctx *app.ListUsersContext) ([]acc
 		// cumulatively filter out those not matching the user-based filters.
 		for _, identity := range filteredIdentities {
 			// this is where you keep trying all other filters one by one for 'user' fields like email.
-			if ctx.FilterEmail == nil || identity.User.Email == *ctx.FilterEmail {
+			// If email filter is present then ignore private emails
+			if ctx.FilterEmail == nil || (identity.User.Email == *ctx.FilterEmail && !identity.User.EmailPrivate) {
 				resultUsers = append(resultUsers, identity.User)
 				resultIdentities = append(resultIdentities, identity)
 			}
@@ -1052,6 +1053,13 @@ func filterUsers(appl application.Application, ctx *app.ListUsersContext) ([]acc
 		// .. Add other filters in future when needed into the userFilters slice in the above manner.
 		if len(userFilters) != 0 {
 			filteredUsers, err = appl.Users().Query(userFilters...)
+			if err != nil {
+				return nil, nil, errs.Wrap(err, "error fetching users")
+			}
+			// Should be zero or the only user in the result. If the user's email is private then ignore the user
+			if len(filteredUsers) > 0 && filteredUsers[0].EmailPrivate {
+				filteredUsers = []account.User{}
+			}
 		} else {
 			// Soft-kill the API for listing all Users /api/users
 			resultUsers = []account.User{}
@@ -1061,7 +1069,7 @@ func filterUsers(appl application.Application, ctx *app.ListUsersContext) ([]acc
 		if err != nil {
 			return nil, nil, errs.Wrap(err, "error fetching users")
 		}
-		resultUsers, resultIdentities, err = LoadKeyCloakIdentities(appl, filteredUsers)
+		resultUsers, resultIdentities, err = loadKeyCloakIdentities(appl, filteredUsers)
 		if err != nil {
 			return nil, nil, errs.Wrap(err, "error fetching keycloak identities")
 		}
@@ -1069,9 +1077,9 @@ func filterUsers(appl application.Application, ctx *app.ListUsersContext) ([]acc
 	return resultUsers, resultIdentities, nil
 }
 
-// LoadKeyCloakIdentities loads keycloak identities for the users and returns the valid users along with their KC identities
+// loadKeyCloakIdentities loads keycloak identities for the users and returns the valid users along with their KC identities
 // (if a user is missing his/her KC identity, he/she is filtered out of the result array)
-func LoadKeyCloakIdentities(appl application.Application, users []account.User) ([]account.User, []account.Identity, error) {
+func loadKeyCloakIdentities(appl application.Application, users []account.User) ([]account.User, []account.Identity, error) {
 	var resultUsers []account.User
 	var resultIdentities []account.Identity
 	for _, user := range users {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -637,10 +637,9 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// But when you try to access the same with an API which doesn't respect auth,
 			// it wouldn't be visible.
 			_, result = test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
-			returnedUserResult := result.Data[0]
-			require.Equal(s.T(), "", *returnedUserResult.Attributes.Email)
+			require.Empty(s.T(), result.Data)
 
-			// the /api/users/<ID> endpoint should hide out the email.
+			// the /api/users/<ID> endpoint should also hide out the email.
 			_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
 			require.NotEqual(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
 			require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)

--- a/design/account.go
+++ b/design/account.go
@@ -162,6 +162,7 @@ var _ = a.Resource("users", func() {
 		})
 		a.Description("Verify if the new email updated by the user is a valid email")
 		a.Response(d.TemporaryRedirect)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 	a.Action("sendEmailVerificationCode", func() {
 		a.Security("jwt")

--- a/design/search.go
+++ b/design/search.go
@@ -22,11 +22,7 @@ var _ = a.Resource("search", func() {
 		a.Response(d.OK, func() {
 			a.Media(userList)
 		})
-
-		a.Response(d.BadRequest, func() {
-			a.Media(d.ErrorMedia)
-		})
-
-		a.Response(d.InternalServerError)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 })

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -65,7 +65,7 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 		}
 		for i := len(entities) - 1; i >= 0; i-- {
 			entity := entities[i]
-			log.Info(nil, map[string]interface{}{
+			log.Debug(nil, map[string]interface{}{
 				"table":     entity.table,
 				"keys":      entity.keys,
 				"hook_name": hookName,


### PR DESCRIPTION
`/api/users?filter[email]=<email>` and `/api/search/users?q=<email>` look up public emails only.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/387
