### PR TITLE
Ask for less GitHub permissions when linking OSIO and GitHub

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -530,7 +530,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
 	c.v.SetDefault(varGitHubClientID, "c6a3a6280e9650ba27d8")
 	c.v.SetDefault(varGitHubClientSecret, defaultGitHubClientSecret)
-	c.v.SetDefault(varGitHubClientDefaultScopes, "admin:repo_hook read:org repo user gist")
+	c.v.SetDefault(varGitHubClientDefaultScopes, "admin:repo_hook read:org public_repo read:user")
 	c.v.SetDefault(varOSOClientApiUrl, "https://api.starter-us-east-2.openshift.com")
 	c.v.SetDefault(varTLSInsecureSkipVerify, false) // Do not set to true in production! True can be used only for testing.
 

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -740,7 +740,7 @@ func (client mockKeycloakExternalTokenServiceClient) Delete(ctx context.Context,
 func positiveKCResponseGithub() *keycloak.KeycloakExternalTokenResponse {
 	return &keycloak.KeycloakExternalTokenResponse{
 		AccessToken: "1234-github",
-		Scope:       "admin:repo_hook read:org repo user gist",
+		Scope:       "admin:repo_hook read:org public_repo read:user",
 		TokenType:   "bearer",
 	}
 }


### PR DESCRIPTION
Instead of `admin:repo_hook read:org repo user gist`
We will now ask for `admin:repo_hook read:org public_repo read:user`

Part of https://github.com/openshiftio/openshift.io/issues/259
