### PR TITLE
Set resource limits on Container level

### DIFF
--- a/openshift/auth.app.yaml
+++ b/openshift/auth.app.yaml
@@ -14,9 +14,6 @@ objects:
     selector:
       service: auth
     strategy:
-      resources:
-        limits:
-          memory: 1.5Gi
       rollingParams:
         intervalSeconds: 1
         maxSurge: 25%
@@ -162,6 +159,9 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1.5Gi            
           terminationMessagePath: /dev/termination-log
           volumeMounts:
           - mountPath: /etc/fabric8/


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685
