### PR TITLE
ISSUE-408 fixed failing tests in role_mapping_blackbox_test, fixed cl…

### DIFF
--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -31,10 +31,10 @@ func (s *roleMappingBlackBoxTest) SetupTest() {
 
 func (s *roleMappingBlackBoxTest) TestOKToDelete() {
 
-	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "employee", authorization.IdentityResourceTypeTeam, "member")
+	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "role_mapping_test_role_employee", authorization.IdentityResourceTypeTeam, "role_mapping_test_role_member")
 	require.NoError(s.T(), err)
 
-	_, err = s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "manager", authorization.IdentityResourceTypeGroup, "admin")
+	_, err = s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "role_mapping_test_role_manager", authorization.IdentityResourceTypeGroup, "role_mapping_test_role_admin")
 	require.NoError(s.T(), err)
 
 	mappings, err := s.repo.List(s.Ctx)
@@ -98,7 +98,7 @@ func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName str
 }
 
 func (s *roleMappingBlackBoxTest) TestOKToLoad() {
-	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "employee", authorization.IdentityResourceTypeTeam, "member")
+	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "role_mapping_test_role_personnel", authorization.IdentityResourceTypeTeam, "role_mapping_test_role_member")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rm1)
 
@@ -107,7 +107,7 @@ func (s *roleMappingBlackBoxTest) TestOKToLoad() {
 }
 
 func (s *roleMappingBlackBoxTest) TestExistsRoleMapping() {
-	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "employee", authorization.IdentityResourceTypeTeam, "member")
+	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "role_mapping_test_role_staff", authorization.IdentityResourceTypeTeam, "role_mapping_test_role_someOtherRoleName")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rm1)
 
@@ -116,13 +116,13 @@ func (s *roleMappingBlackBoxTest) TestExistsRoleMapping() {
 }
 
 func (s *roleMappingBlackBoxTest) TestOKToSave() {
-	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "contributor", authorization.IdentityResourceTypeTeam, "committer")
-	require.NoError(s.T(), err)
-	require.NotNil(s.T(), rm1)
-
 	otherResource, err := testsupport.CreateTestResourceWithDefaultType(s.Ctx, s.DB, "other-resource")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), otherResource)
+
+	rm1, err := s.createTestRoleMapping(authorization.IdentityResourceTypeOrganization, "role_mapping_test_role_contributor", authorization.IdentityResourceTypeTeam, "role_mapping_test_role_committer")
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), rm1)
 
 	rm1.ResourceID = otherResource.ResourceID
 	err = s.repo.Save(s.Ctx, &rm1)

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"fmt"
 	"testing"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
@@ -378,6 +379,9 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByNewResourceType() {
 		require.NotNil(s.T(), rs)
 
 		createdRoleScopes = append(createdRoleScopes, *rs)
+
+		s.T().Log(fmt.Sprintf("Created rolescope with role ID %s and scope ID %s", rs.RoleID.String(), rs.ResourceTypeScopeID.String()))
+
 	}
 
 	someOtherResourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -380,8 +380,6 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByNewResourceType() {
 
 		createdRoleScopes = append(createdRoleScopes, *rs)
 
-		s.T().Log(fmt.Sprintf("Created rolescope with role ID %s and scope ID %s", rs.RoleID.String(), rs.ResourceTypeScopeID.String()))
-
 	}
 
 	someOtherResourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -1,7 +1,6 @@
 package service_test
 
 import (
-	"fmt"
 	"testing"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -211,18 +211,23 @@ func (c *ResourceController) Update(ctx *app.UpdateResourceContext) error {
 
 		// If a parent resource ID has been passed in, update the parent resource
 		if ctx.Payload.ParentResourceID != nil {
-			// Lookup the parent resource
-			parentResource, err := appl.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"err":                err,
-					"parent_resource_id": *ctx.Payload.ParentResourceID,
-				}, "Parent resource could not be found.")
+			if *ctx.Payload.ParentResourceID != "" {
+				// If a parent ID has been specified, lookup the parent resource
+				parentResource, err := appl.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{
+						"err":                err,
+						"parent_resource_id": *ctx.Payload.ParentResourceID,
+					}, "Parent resource could not be found.")
 
-				return errors.NewBadParameterError("invalid parent resource ID specified", err)
+					return errors.NewBadParameterError("invalid parent resource ID specified", err)
+				}
+
+				res.ParentResourceID = &parentResource.ResourceID
+			} else {
+				res.ParentResourceID = nil
 			}
 
-			res.ParentResourceID = &parentResource.ResourceID
 		}
 
 		return appl.ResourceRepository().Save(ctx, res)

--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -276,6 +276,21 @@ func (rest *TestResourceREST) TestUpdateResource() {
 	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
 
 	require.EqualValues(rest.T(), *parentCreated.ID, *readResource.ParentResourceID)
+
+	emptyParentResourceID := ""
+
+	// Now test clearing the original resource's parent to nil
+	updatePayload = &app.UpdateResourcePayload{
+		ParentResourceID: &emptyParentResourceID,
+	}
+
+	// Update the original resource
+	_, updated = test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID, updatePayload)
+
+	// Read the resource again, and check the parent resource has been cleared
+	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+
+	require.Nil(rest.T(), readResource.ParentResourceID)
 }
 
 func (rest *TestResourceREST) TestDeleteResource() {


### PR DESCRIPTION
Fixes #408 

Just a small PR, this fixes the problems when running subsequent iterations of `role_mapping_blackbox_test.go`.  The problem was due to an issue with the automatic db cleanup routine, which attempts to delete all records created during testing.  A referential integrity issue was introduced when the `TestOKToSave` test updated a role_mapping entity to point to a resource created after the role_mapping was created.  Fixed by changing the create order so that the resource is created first.

Another issue was identified in `controller/resource_blackbox_test.go` - The `TestUpdateResource` test was likewise updating a resource with a reference to a parent resource, thereby preventing it from being deleted also due to a constraint violation.  Fixed by adding another test where the child resource is updated yet again to clear the parent resource (this required fixing the resource controller also, as this feature wasn't previously supported).