### PR TITLE
Fix PK for role_scope table

### DIFF
--- a/authorization/role/repository/role_scope.go
+++ b/authorization/role/repository/role_scope.go
@@ -23,13 +23,13 @@ type RoleScope struct {
 	ResourceTypeScope resourceTypeScope.ResourceTypeScope `gorm:"ForeignKey:ResourceTypeScopeID"`
 
 	// The foreign key value for ResourceTypeScopeID
-	ResourceTypeScopeID uuid.UUID `sql:"type:uuid" gorm:"column:scope_id"`
+	ResourceTypeScopeID uuid.UUID `gorm:"primary_key;column:scope_id" sql:"type:uuid"`
 
 	// The associated role
 	Role Role `gorm:"ForeignKey:RoleID"`
 
 	// The foreign key value for RoleID
-	RoleID uuid.UUID `sql:"type:uuid" gorm:"column:role_id"`
+	RoleID uuid.UUID `gorm:"primary_key;column:role_id" sql:"type:uuid"`
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -70,6 +70,12 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 				"keys":      entity.keys,
 				"hook_name": hookName,
 			}, "Deleting entities from '%s' table with keys %v", entity.table, entity.keys)
+			if len(entity.keys) == 0 {
+				log.Panic(nil, map[string]interface{}{
+					"table":     entity.table,
+					"hook_name": hookName,
+				}, "no primary keys found!!!")
+			}
 			tx.Table(entity.table).Where(entity.keys).Delete("")
 		}
 


### PR DESCRIPTION
We missed `gorm:"primary_key"` tag for role_scope table, so, GORM didn't set PKs for that table. It resulted to "DELETE FROM role_table" in our db clean func.
