### PR TITLE
restructured user search query, recreated search indexes

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -185,6 +185,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 25
 	m = append(m, steps{ExecuteSQLFile("025-fix-feature-level.sql")})
 
+	// Version 26
+	m = append(m, steps{ExecuteSQLFile("026-identities-users-indexes.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/026-identities-users-indexes.sql
+++ b/migration/sql-files/026-identities-users-indexes.sql
@@ -1,0 +1,8 @@
+drop index idx_identities_username;
+drop index idx_user_email;
+drop index idx_user_full_name;
+
+CREATE EXTENSION pg_trgm;
+create index ix_users_email_gin on users using gin (lower(email) gin_trgm_ops);
+create index ix_users_full_name_gin on users using gin (lower(full_name) gin_trgm_ops);
+create index ix_identities_username_gin on identities using gin (username gin_trgm_ops);


### PR DESCRIPTION
Related to #388 

This PR for now addresses the user search DB performance spikes.  The btree indexes on identities.username, users.user_email and users.user_full_name have been dropped, and replaced with trigram indexes that support indexed searches on wildcard LIKE comparisons.  The user search query has been rewritten as a UNION SELECT query in order to take advantage of the new index types, which results in SQL that looks like this:

```
SELECT * FROM (
SELECT 
  identities.id AS identity_id,
  identities.username,  
  users.*
FROM 
  identities, users
WHERE 
  identities.user_id = users.id 
  AND identities.username LIKE '%337827a2-0946-4b11-91a2-b8db22dac9a3%'
  AND users.deprovisioned IS false
UNION SELECT
  identities.id AS identity_id,
  identities.username,
  users.*
FROM
  identities, users
WHERE  
  identities.user_id = users.id 
  AND users.deprovisioned IS false 
  AND (LOWER(users.full_name) LIKE '%337827a2-0946-4b11-91a2-b8db22dac9a3%'
  OR (LOWER(users.email) LIKE '%337827a2-0946-4b11-91a2-b8db22dac9a3%' AND users.email_private is false))) results LIMIT 1
```

Trigram indexes require the additional Postgres package `pg_trgm`, enabled by executing the following statement:

`CREATE EXTENSION pg_trgm;`

Confirmed that the pg_trgm extension is available in our minishift deployment.