### PR TITLE
Fix gorm tags

### DIFF
--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jinzhu/gorm"
 
 	"fmt"
+
 	"github.com/fabric8-services/fabric8-auth/application/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	"github.com/goadesign/goa"
@@ -21,7 +22,7 @@ type Resource struct {
 	gormsupport.Lifecycle
 
 	// This is the primary key value
-	ResourceID string `sql:"type:string" gorm:"primary_key" gorm:"column:resource_id"`
+	ResourceID string `sql:"type:string" gorm:"primary_key;column:resource_id"`
 	// The parent resource ID
 	ParentResourceID *string
 	// The resource type

--- a/authorization/resourcetype/repository/resource_type.go
+++ b/authorization/resourcetype/repository/resource_type.go
@@ -2,13 +2,14 @@ package repository
 
 import (
 	"context"
+	"time"
+
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	"github.com/satori/go.uuid"
-	"time"
 
 	errs "github.com/pkg/errors"
 )
@@ -16,7 +17,7 @@ import (
 type ResourceType struct {
 	gormsupport.Lifecycle
 
-	ResourceTypeID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key" gorm:"column:resource_type_id"`
+	ResourceTypeID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:resource_type_id"`
 	// The resource type name
 	Name string
 }

--- a/authorization/resourcetype/scope/repository/resource_type_scope.go
+++ b/authorization/resourcetype/scope/repository/resource_type_scope.go
@@ -14,6 +14,7 @@ import (
 	"github.com/satori/go.uuid"
 
 	"fmt"
+
 	errs "github.com/pkg/errors"
 )
 
@@ -21,7 +22,7 @@ type ResourceTypeScope struct {
 	gormsupport.Lifecycle
 
 	// This is the primary key value
-	ResourceTypeScopeID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key" gorm:"column:resource_type_scope_id"`
+	ResourceTypeScopeID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:resource_type_scope_id"`
 	// The resource type that this scope belongs to
 	ResourceType resourcetype.ResourceType `gorm:"ForeignKey:ResourceTypeID;AssociationForeignKey:ResourceTypeID"`
 	// The foreign key value for ResourceType

--- a/authorization/role/repository/identity_role.go
+++ b/authorization/role/repository/identity_role.go
@@ -23,7 +23,7 @@ type IdentityRole struct {
 	gormsupport.Lifecycle
 
 	// This is the primary key value
-	IdentityRoleID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key" gorm:"column:identity_role_id"`
+	IdentityRoleID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:identity_role_id"`
 	// The identity to which the role is assigned
 	IdentityID uuid.UUID
 	Identity   account.Identity

--- a/authorization/role/repository/role.go
+++ b/authorization/role/repository/role.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jinzhu/gorm"
 
 	"fmt"
+
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
@@ -21,7 +22,7 @@ type Role struct {
 	gormsupport.Lifecycle
 
 	// This is the primary key value
-	RoleID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key" gorm:"column:role_id"`
+	RoleID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:role_id"`
 	// The resource type that this role applies to
 	ResourceType resourcetype.ResourceType `gorm:"ForeignKey:ResourceTypeID;AssociationForeignKey:ResourceTypeID"`
 	// The foreign key value for ResourceType

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/log"
 
 	"fmt"
+
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -20,7 +21,7 @@ type RoleMapping struct {
 	gormsupport.Lifecycle
 
 	// This is the primary key value
-	RoleMappingID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key" gorm:"column:role_mapping_id"`
+	RoleMappingID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:role_mapping_id"`
 	// The resource that this role mapping applies to
 	Resource resource.Resource `gorm:"ForeignKey:ResourceID;AssociationForeignKey:ResourceID"`
 	// The foreign key value for Resource


### PR DESCRIPTION
This is maybe the reason of our failing tests.

Go tags are in key:value format. Declaring multiple keys with the same name you always set only one key value. Not sure which one (maybe it's even random).
If we need to set multiple values then we should use `;`
For example: `gorm:"primary_key;column:invitation_id"`