### PR TITLE
Fix golang image path for RHEL Docker file

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM registry.devshift.net/osio-prod/base/golang:latest
+FROM prod.registry.devshift.net/osio-prod/base/golang:latest
 
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"


### PR DESCRIPTION
This should have been part of https://github.com/fabric8-services/fabric8-auth/pull/450 ;)
