### PR TITLE
Enforce unique organization names in database

### DIFF
--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -163,7 +163,7 @@ func (s *identityBlackBoxTest) TestFindIdentityMemberships() {
 	// Create an identity
 	identity := createAndLoad(s)
 
-	orgName := "Acme Corporation - identityBlackBoxTest"
+	orgName := "Acme Corporation - identityBlackBoxTest.TestFindIdentityMemberships"
 	// Create an organization
 	orgID, err := s.Application.OrganizationService().CreateOrganization(s.Ctx, identity.ID, orgName)
 	require.NoError(s.T(), err)

--- a/authorization/organization/service/organization_service_blackbox_test.go
+++ b/authorization/organization/service/organization_service_blackbox_test.go
@@ -88,7 +88,7 @@ func (s *organizationServiceBlackBoxTest) TestListOrganization() {
 	require.Nil(s.T(), err, "Could not create organization")
 
 	// Org created by the second user
-	_, err = s.orgService.CreateOrganization(s.Ctx, identityAnother.ID, "One More Test Organization MMMYYY")
+	_, err = s.orgService.CreateOrganization(s.Ctx, identityAnother.ID, "Yet One More Test Organization")
 	require.Nil(s.T(), err, "Could not create organization")
 
 	// Load orgs where the first user is a member

--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -135,6 +135,15 @@ func (m *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 
 	err := m.db.Create(resource).Error
 	if err != nil {
+		// Organization names must be unique
+		if gormsupport.IsUniqueViolation(err, "unique_organization_names") {
+			log.Error(ctx, map[string]interface{}{
+				"err":  err,
+				"name": resource.Name,
+			}, "unable to create organization resource as an organization with the same name already exists")
+			return errors.NewDataConflictError(fmt.Sprintf("organization with same name already exists, '%s'", resource.Name))
+		}
+
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resource.ResourceID,
 			"err":         err,

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -81,7 +82,7 @@ func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName str
 		return rm, err
 	}
 
-	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *fromResourceType, "Test-Role-Mapped-Resource", nil)
+	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *fromResourceType, "Test-Role-Mapped-Resource"+uuid.NewV4().String(), nil)
 	if err != nil {
 		return rm, err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -191,6 +191,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 27
 	m = append(m, steps{ExecuteSQLFile("027-invitations.sql")})
 
+	// Version 28
+	m = append(m, steps{ExecuteSQLFile("028-make-organization-names-unique.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -355,34 +355,37 @@ func testMigration27(t *testing.T) {
 func testMigration28(t *testing.T) {
 	migrateToVersion(sqlDB, migrations[:(28)], (28))
 
-	resourceID := uuid.NewV4()
-	// Let's create two organization resources with the same name
-	_, err := sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name, created_at) VALUES (?, '66659ea9-aa0a-4737-96e2-e96e615dc280', 'Acme Corporation', now())", resourceID)
+	var orgResourceTypeID string
+	err := sqlDB.QueryRow("SELECT resource_type_id FROM resource_type WHERE name = 'identity/organization'").Scan(&orgResourceTypeID)
 	require.NoError(t, err)
 
-	otherResourceID := uuid.NewV4()
-	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name, created_at) VALUES (?, '66659ea9-aa0a-4737-96e2-e96e615dc280', 'Acme Corporation', now())", otherResourceID)
+	// Let's create two organization resources with the same name
+	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name, created_at) VALUES ('ca9dfe76-d5f2-4f0c-b887-ad722e745cd5', $1, 'Acme Corporation', now())", orgResourceTypeID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name, created_at) VALUES ('3ac75b8a-e794-403b-bf1b-e0516af99a93', $1, 'Acme Corporation', now())", orgResourceTypeID)
 	require.NoError(t, err)
 
 	migrateToVersion(sqlDB, migrations[:(29)], (29))
 
 	// Let's check the name of our first resource, it should be the same
-	result, err := sqlDB.Exec("SELECT name FROM resource WHERE resource_id = ?", resourceID)
+	var resourceName string
+	err = sqlDB.QueryRow("SELECT name FROM resource WHERE resource_id = 'ca9dfe76-d5f2-4f0c-b887-ad722e745cd5'").Scan(&resourceName)
 	require.NoError(t, err)
-	require.Equal(t, "Acme Corporation", result)
+	require.Equal(t, "Acme Corporation", resourceName)
 
 	// Our other resource should have been renamed though
-	result, err = sqlDB.Exec("SELECT name FROM resource WHERE resource_id = ?", otherResourceID)
+	err = sqlDB.QueryRow("SELECT name FROM resource WHERE resource_id = '3ac75b8a-e794-403b-bf1b-e0516af99a93'").Scan(&resourceName)
 	require.NoError(t, err)
-	require.Equal(t, "Acme Corporation (1)", result)
+	require.Equal(t, "Acme Corporation (1)", resourceName)
 
 	// After update 28 it should be impossible to create organizations with duplicate names
 	orgName := "Acme" + uuid.NewV4().String()
-	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name) VALUES (uuid_generate_v4(), '66659ea9-aa0a-4737-96e2-e96e615dc280', ?)", orgName)
+	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name) VALUES (uuid_generate_v4(), '66659ea9-aa0a-4737-96e2-e96e615dc280', $1)", orgName)
 	require.NoError(t, err)
 
 	// This one should fail
-	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name) VALUES (uuid_generate_v4(), '66659ea9-aa0a-4737-96e2-e96e615dc280', ?)", orgName)
+	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name) VALUES (uuid_generate_v4(), '66659ea9-aa0a-4737-96e2-e96e615dc280', $1)", orgName)
 	require.Error(t, err)
 }
 

--- a/migration/sql-files/028-make-organization-names-unique.sql
+++ b/migration/sql-files/028-make-organization-names-unique.sql
@@ -1,0 +1,16 @@
+UPDATE resource_type SET name = 'organization_remove' WHERE name = 'identity/organization';
+INSERT INTO resource_type (resource_type_id, name) VALUES ('66659ea9-aa0a-4737-96e2-e96e615dc280', 'identity/organization');
+
+UPDATE resource SET resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280' WHERE resource_type_id = (SELECT resource_type_id FROM resource_type WHERE name = 'organization_remove');
+UPDATE resource_type_scope SET resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280' WHERE resource_type_id = (SELECT resource_type_id FROM resource_type WHERE name = 'organization_remove');
+
+UPDATE resource ur set name = rs.updated_name
+FROM (SELECT resource_id, name || ' (' || ROW_NUMBER() OVER (PARTITION BY (name) ORDER BY (created_at)) || ')' updated_name FROM resource WHERE resource_id NOT IN (
+  SELECT resource_id FROM (SELECT resource_id, ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at) nth FROM resource WHERE resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280') numbered WHERE nth = 1)) rs
+WHERE ur.resource_id = rs.resource_id AND ur.resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280';
+
+CREATE UNIQUE INDEX unique_organization_names
+ON resource (name)
+WHERE resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280';
+
+DELETE resource_type WHERE name = 'organization_remove'; 

--- a/migration/sql-files/028-make-organization-names-unique.sql
+++ b/migration/sql-files/028-make-organization-names-unique.sql
@@ -3,14 +3,12 @@ INSERT INTO resource_type (resource_type_id, name) VALUES ('66659ea9-aa0a-4737-9
 
 UPDATE resource SET resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280' WHERE resource_type_id = (SELECT resource_type_id FROM resource_type WHERE name = 'organization_remove');
 UPDATE resource_type_scope SET resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280' WHERE resource_type_id = (SELECT resource_type_id FROM resource_type WHERE name = 'organization_remove');
+UPDATE role SET resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280' WHERE resource_type_id = (SELECT resource_type_id FROM resource_type WHERE name = 'organization_remove');
 
-UPDATE resource ur set name = rs.updated_name
-FROM (SELECT resource_id, name || ' (' || ROW_NUMBER() OVER (PARTITION BY (name) ORDER BY (created_at)) || ')' updated_name FROM resource WHERE resource_id NOT IN (
-  SELECT resource_id FROM (SELECT resource_id, ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at) nth FROM resource WHERE resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280') numbered WHERE nth = 1)) rs
-WHERE ur.resource_id = rs.resource_id AND ur.resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280';
+UPDATE resource ur set name = rs.updated_name FROM (SELECT resource_id, name || ' (' || ROW_NUMBER() OVER (PARTITION BY (name) ORDER BY (created_at)) || ')' updated_name FROM resource WHERE resource_id NOT IN (SELECT resource_id FROM (SELECT resource_id, ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at) nth FROM resource WHERE resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280') numbered WHERE nth = 1)) rs WHERE ur.resource_id = rs.resource_id AND ur.resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280';
 
 CREATE UNIQUE INDEX unique_organization_names
 ON resource (name)
 WHERE resource_type_id = '66659ea9-aa0a-4737-96e2-e96e615dc280';
 
-DELETE resource_type WHERE name = 'organization_remove'; 
+DELETE FROM resource_type WHERE name = 'organization_remove'; 


### PR DESCRIPTION
This PR includes a migration script and tests for updating the database constraints to prevent duplicate organization names.  The migration script will check for any existing duplicate organization names, and update them on a "first created, first served" basis.  I.e. for organization name "Acme", the record with the earliest created_at value will remain unchanged, while subsequent organizations with duplicate names will have their names updated to "Acme (1)", "Acme (2)", etc.

Fixes #358
