### PR TITLE
Remove https://golang.org/x/lint depenency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,12 +363,6 @@
   revision = "81e90905daefcd6fd217b62423c0908922eadb30"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/lint"
-  packages = ["."]
-  revision = "85993ffd0a6cd043291f3f63d45d656d97b165bd"
-
-[[projects]]
   name = "golang.org/x/net"
   packages = [
     "context",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ goTemplate{
           dockerOrganisation = 'fabric8'
           project = 'fabric8-auth'
           dockerBuildOptions = '--file Dockerfile.deploy'
-          makeTarget = 'build check-go-format analyze-go-code test-unit-junit'
+          makeTarget = 'build check-go-format test-unit-junit'
         }
       } else if (utils.isCD()){
         def v = goRelease{
@@ -22,7 +22,7 @@ goTemplate{
           dockerOrganisation = 'fabric8'
           project = 'fabric8-auth'
           dockerBuildOptions = '--file Dockerfile.deploy'
-          makeTarget = 'build check-go-format analyze-go-code test-unit-junit'
+          makeTarget = 'build check-go-format test-unit-junit'
         }
 
         initServiceGitHash = sh(script: 'git rev-parse HEAD', returnStdout: true).toString().trim()

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ clean-git-hooks:
 	|| true
 
 .PHONY: release
-release: prebuild-check deps generate build check-go-format analyze-go-code test-unit-junit
+release: prebuild-check deps generate build check-go-format test-unit-junit
 
 .PHONY: analyze-go-code
 ## Run a complete static code analysis using the following tools: golint, gocyclo and go-vet.

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -46,7 +46,6 @@ function prepare() {
   make docker-start
   make docker-check-go-format
   make docker-deps
-  make docker-analyze-go-code
   make docker-generate
   make docker-build
   echo 'CICO: Preparation complete'


### PR DESCRIPTION
This dependency was added by `dep init` during our migration from Glide to Go Dep and it's currently used only by `analyze-go-code`. We don't really use this lint analyze outputs in our CI builds, so I'm removing it from our ci/cd builds. It also will make our CI build a bit faster.

Currently https://golang.org/x/lint is down and it blocks our build.