### PR TITLE
Fix intermittent failure of role management service test

### DIFF
--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -163,7 +163,7 @@ func (s *identityBlackBoxTest) TestFindIdentityMemberships() {
 	// Create an identity
 	identity := createAndLoad(s)
 
-	orgName := "Acme Corporation - identityBlackBoxTest.TestFindIdentityMemberships"
+	orgName := "Acme Corporation - identityBlackBoxTest.TestFindIdentityMemberships" + uuid.NewV4().String()
 	// Create an organization
 	orgID, err := s.Application.OrganizationService().CreateOrganization(s.Ctx, identity.ID, orgName)
 	require.NoError(s.T(), err)

--- a/authorization/role/repository/role.go
+++ b/authorization/role/repository/role.go
@@ -270,7 +270,9 @@ func (m *GormRoleRepository) FindRolesByResourceType(ctx context.Context, resour
 			resource_type rt
 		WHERE  
 			rt.resource_type_id = r.resource_type_id 
+      AND r.deleted_at IS NULL
 			AND rt.NAME = ?
+      AND rt.deleted_at IS NULL
 		GROUP BY 
 		  r.role_id, 
 		  r.name`, resourceType)


### PR DESCRIPTION
Fixes #463

This PR adds a `deleted_at IS NULL` condition for both the `role` and `resource_type` tables in the SQL for `RoleRepository.FindRolesByResourceType()`.  This should fix the error we sometimes see in the test.