### PR TITLE
Add missing deleted_at conditions to raw queries

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -384,8 +384,9 @@ FROM
 WHERE 
   identities.user_id = users.id 
   AND identities.username LIKE ?
+  AND identities.deleted_at IS NULL
   AND users.deprovisioned IS false
-  AND users.deleted_at IS null
+  AND users.deleted_at IS NULL
 UNION SELECT
   identities.id AS identity_id,
   identities.username,
@@ -394,6 +395,8 @@ FROM
   identities, users
 WHERE  
   identities.user_id = users.id 
+  AND identities.deleted_at IS NULL
+  AND users.deleted_at IS NULL
   AND users.deprovisioned IS false 
   AND (LOWER(users.full_name) LIKE ?
   OR (LOWER(users.email) LIKE ? AND users.email_private is false))) users LIMIT ?`


### PR DESCRIPTION
This PR adds `deleted_at` conditions to both the identity search, and identity_role find permissions queries which both use raw SQL.

Fixes #466