### PR TITLE
Flattened /authorization/resource_type directory structure

### DIFF
--- a/application/repository/repositories.go
+++ b/application/repository/repositories.go
@@ -6,7 +6,6 @@ import (
 	invitation "github.com/fabric8-services/fabric8-auth/authorization/invitation/repository"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/space"
 	"github.com/fabric8-services/fabric8-auth/token/provider"
@@ -23,7 +22,7 @@ type Repositories interface {
 	InvitationRepository() invitation.InvitationRepository
 	ResourceRepository() resource.ResourceRepository
 	ResourceTypeRepository() resourcetype.ResourceTypeRepository
-	ResourceTypeScopeRepository() scope.ResourceTypeScopeRepository
+	ResourceTypeScopeRepository() resourcetype.ResourceTypeScopeRepository
 	IdentityRoleRepository() role.IdentityRoleRepository
 	RoleRepository() role.RoleRepository
 }

--- a/authorization/permission/service/permission_service_blackbox_test.go
+++ b/authorization/permission/service/permission_service_blackbox_test.go
@@ -7,7 +7,6 @@ import (
 	permissionmodel "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	resourcetypescope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	roleRepo "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/fabric8-services/fabric8-auth/test"
@@ -33,7 +32,7 @@ type permissionServiceBlackBoxTest struct {
 	identityRoleRepo        roleRepo.IdentityRoleRepository
 	resourceRepo            resource.ResourceRepository
 	resourceTypeRepo        resourcetype.ResourceTypeRepository
-	resourceTypeScopeRepo   resourcetypescope.ResourceTypeScopeRepository
+	resourceTypeScopeRepo   resourcetype.ResourceTypeScopeRepository
 	roleRepo                roleRepo.RoleRepository
 	roleMappingRepo         roleRepo.RoleMappingRepository
 	permissionService       permissionmodel.PermissionService
@@ -53,7 +52,7 @@ func (s *permissionServiceBlackBoxTest) SetupSuite() {
 	s.identityRoleRepo = roleRepo.NewIdentityRoleRepository(s.DB)
 	s.resourceRepo = resource.NewResourceRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
-	s.resourceTypeScopeRepo = resourcetypescope.NewResourceTypeScopeRepository(s.DB)
+	s.resourceTypeScopeRepo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.roleRepo = roleRepo.NewRoleRepository(s.DB)
 	s.roleMappingRepo = roleRepo.NewRoleMappingRepository(s.DB)
 	s.permissionService = permissionmodel.NewPermissionService(s.Application)
@@ -84,7 +83,7 @@ func (s *permissionServiceBlackBoxTest) setupResourceType(resourceTypeName strin
 	require.NoError(s.T(), err, "Could not lookup resource type")
 
 	// Create a test scope
-	err = s.resourceTypeScopeRepo.Create(s.Ctx, &resourcetypescope.ResourceTypeScope{
+	err = s.resourceTypeScopeRepo.Create(s.Ctx, &resourcetype.ResourceTypeScope{
 		Name:           scopeName,
 		ResourceTypeID: resourceType.ResourceTypeID,
 	})

--- a/authorization/resourcetype/repository/resource_type_scope.go
+++ b/authorization/resourcetype/repository/resource_type_scope.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
@@ -22,7 +21,7 @@ type ResourceTypeScope struct {
 	// This is the primary key value
 	ResourceTypeScopeID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:resource_type_scope_id"`
 	// The resource type that this scope belongs to
-	ResourceType resourcetype.ResourceType `gorm:"ForeignKey:ResourceTypeID;AssociationForeignKey:ResourceTypeID"`
+	ResourceType ResourceType `gorm:"ForeignKey:ResourceTypeID;AssociationForeignKey:ResourceTypeID"`
 	// The foreign key value for ResourceType
 	ResourceTypeID uuid.UUID
 	// The name of this scope
@@ -58,7 +57,7 @@ type ResourceTypeScopeRepository interface {
 	Delete(ctx context.Context, ID uuid.UUID) error
 	Load(ctx context.Context, ID uuid.UUID) (*ResourceTypeScope, error)
 	LookupForType(ctx context.Context, resourceTypeID uuid.UUID) ([]ResourceTypeScope, error)
-	List(ctx context.Context, resourceType *resourcetype.ResourceType) ([]ResourceTypeScope, error)
+	List(ctx context.Context, resourceType *ResourceType) ([]ResourceTypeScope, error)
 	LookupByResourceTypeAndScope(ctx context.Context, resourceTypeID uuid.UUID, scopeName string) (*ResourceTypeScope, error)
 }
 
@@ -184,7 +183,7 @@ func (m *GormResourceTypeScopeRepository) Delete(ctx context.Context, id uuid.UU
 }
 
 // List return all resource type scopes
-func (m *GormResourceTypeScopeRepository) List(ctx context.Context, resourceType *resourcetype.ResourceType) ([]ResourceTypeScope, error) {
+func (m *GormResourceTypeScopeRepository) List(ctx context.Context, resourceType *ResourceType) ([]ResourceTypeScope, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "resource_type_scope", "list"}, time.Now())
 	var rows []ResourceTypeScope
 

--- a/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
+++ b/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
 
@@ -15,7 +14,7 @@ import (
 
 type resourceTypeScopeBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo             scope.ResourceTypeScopeRepository
+	repo             resourcetype.ResourceTypeScopeRepository
 	resourceTypeRepo resourcetype.ResourceTypeRepository
 }
 
@@ -26,7 +25,7 @@ func TestRunResourceTypeScopeBlackBoxTest(t *testing.T) {
 func (s *resourceTypeScopeBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.DB.LogMode(true)
-	s.repo = scope.NewResourceTypeScopeRepository(s.DB)
+	s.repo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
 }
 

--- a/authorization/resourcetype/scope/repository/doc.go
+++ b/authorization/resourcetype/scope/repository/doc.go
@@ -1,2 +1,0 @@
-// Package repository provides the APIs for making 'resource_type_scope' related database interactions.
-package repository

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/account"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
@@ -24,7 +23,7 @@ type identityRoleBlackBoxTest struct {
 	identityRepo          account.IdentityRepository
 	resourceRepo          resource.ResourceRepository
 	resourceTypeRepo      resourcetype.ResourceTypeRepository
-	resourceTypeScopeRepo scope.ResourceTypeScopeRepository
+	resourceTypeScopeRepo resourcetype.ResourceTypeScopeRepository
 	roleRepo              role.RoleRepository
 }
 
@@ -38,7 +37,7 @@ func (s *identityRoleBlackBoxTest) SetupTest() {
 	s.repo = role.NewIdentityRoleRepository(s.DB)
 	s.identityRepo = account.NewIdentityRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
-	s.resourceTypeScopeRepo = scope.NewResourceTypeScopeRepository(s.DB)
+	s.resourceTypeScopeRepo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.roleRepo = role.NewRoleRepository(s.DB)
 }
 

--- a/authorization/role/repository/role.go
+++ b/authorization/role/repository/role.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
@@ -52,8 +51,8 @@ type RoleRepository interface {
 	Delete(ctx context.Context, ID uuid.UUID) error
 
 	Lookup(ctx context.Context, name string, resourceType string) (*Role, error)
-	ListScopes(ctx context.Context, u *Role) ([]scope.ResourceTypeScope, error)
-	AddScope(ctx context.Context, u *Role, s *scope.ResourceTypeScope) error
+	ListScopes(ctx context.Context, u *Role) ([]resourcetype.ResourceTypeScope, error)
+	AddScope(ctx context.Context, u *Role, s *resourcetype.ResourceTypeScope) error
 
 	FindRolesByResourceType(ctx context.Context, resourceType string) ([]role.RoleDescriptor, error)
 }
@@ -214,7 +213,7 @@ func (m *GormRoleRepository) Lookup(ctx context.Context, name string, resourceTy
 	return &native, errs.WithStack(err)
 }
 
-func (m *GormRoleRepository) ListScopes(ctx context.Context, u *Role) ([]scope.ResourceTypeScope, error) {
+func (m *GormRoleRepository) ListScopes(ctx context.Context, u *Role) ([]resourcetype.ResourceTypeScope, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "role", "listscopes"}, time.Now())
 
 	var scopes []RoleScope
@@ -224,7 +223,7 @@ func (m *GormRoleRepository) ListScopes(ctx context.Context, u *Role) ([]scope.R
 		return nil, errs.WithStack(err)
 	}
 
-	results := make([]scope.ResourceTypeScope, len(scopes))
+	results := make([]resourcetype.ResourceTypeScope, len(scopes))
 	for index := 0; index < len(scopes); index++ {
 		results[index] = scopes[index].ResourceTypeScope
 	}
@@ -232,7 +231,7 @@ func (m *GormRoleRepository) ListScopes(ctx context.Context, u *Role) ([]scope.R
 	return results, nil
 }
 
-func (m *GormRoleRepository) AddScope(ctx context.Context, u *Role, s *scope.ResourceTypeScope) error {
+func (m *GormRoleRepository) AddScope(ctx context.Context, u *Role, s *resourcetype.ResourceTypeScope) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role", "addscope"}, time.Now())
 
 	roleScope := &RoleScope{

--- a/authorization/role/repository/role_scope.go
+++ b/authorization/role/repository/role_scope.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
+	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
 

--- a/authorization/role/repository/role_scope_blackbox_test.go
+++ b/authorization/role/repository/role_scope_blackbox_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	rolescope "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
@@ -17,7 +16,7 @@ import (
 type roleScopeBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
 	repo                  rolescope.RoleScopeRepository
-	resourceTypeScopeRepo scope.ResourceTypeScopeRepository
+	resourceTypeScopeRepo resourcetype.ResourceTypeScopeRepository
 	resourceTypeRepo      resourcetype.ResourceTypeRepository
 }
 
@@ -29,7 +28,7 @@ func (s *roleScopeBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.DB.LogMode(true)
 	s.repo = rolescope.NewRoleScopeRepository(s.DB)
-	s.resourceTypeScopeRepo = scope.NewResourceTypeScopeRepository(s.DB)
+	s.resourceTypeScopeRepo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
 }
 
@@ -88,7 +87,7 @@ func (s *roleScopeBlackBoxTest) TestListRoleScopeByScopeOK() {
 	require.NotNil(s.T(), rt)
 
 	// TODO: move to test/authorization.go
-	rts := scope.ResourceTypeScope{
+	rts := resourcetype.ResourceTypeScope{
 		ResourceTypeScopeID: uuid.NewV4(),
 		ResourceTypeID:      rt.ResourceTypeID,
 		Name:                uuid.NewV4().String(),

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	"github.com/fabric8-services/fabric8-auth/authorization/role"
 	rolerepo "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	rolescope "github.com/fabric8-services/fabric8-auth/authorization/role/service"
@@ -22,7 +21,7 @@ type roleManagementServiceBlackboxTest struct {
 	repo              rolescope.RoleManagementService
 	roleRepo          rolerepo.RoleRepository
 	resourcetypeRepo  resourcetype.ResourceTypeRepository
-	resourceTypeScope scope.ResourceTypeScopeRepository
+	resourceTypeScope resourcetype.ResourceTypeScopeRepository
 }
 
 func TestRunRoleManagementServiceBlackboxTest(t *testing.T) {
@@ -34,7 +33,7 @@ func (s *roleManagementServiceBlackboxTest) SetupTest() {
 	s.repo = rolescope.NewRoleManagementService(s.Application)
 	s.roleRepo = rolerepo.NewRoleRepository(s.DB)
 	s.resourcetypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
-	s.resourceTypeScope = scope.NewResourceTypeScopeRepository(s.DB)
+	s.resourceTypeScope = resourcetype.NewResourceTypeScopeRepository(s.DB)
 }
 
 func (s *roleManagementServiceBlackboxTest) TestGetIdentityRoleByResource() {

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -4,7 +4,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
+	resourceType "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
@@ -62,7 +62,7 @@ func (c *ResourceController) Read(ctx *app.ReadResourceContext) error {
 	}
 
 	var res *resource.Resource
-	var scopes []scope.ResourceTypeScope
+	var scopes []resourceType.ResourceTypeScope
 
 	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
 

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -12,7 +12,6 @@ import (
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
 	"github.com/fabric8-services/fabric8-auth/space"
@@ -112,8 +111,8 @@ func (g *GormBase) ResourceTypeRepository() resourcetype.ResourceTypeRepository 
 	return resourcetype.NewResourceTypeRepository(g.db)
 }
 
-func (g *GormBase) ResourceTypeScopeRepository() scope.ResourceTypeScopeRepository {
-	return scope.NewResourceTypeScopeRepository(g.db)
+func (g *GormBase) ResourceTypeScopeRepository() resourcetype.ResourceTypeScopeRepository {
+	return resourcetype.NewResourceTypeScopeRepository(g.db)
 }
 
 func (g *GormBase) RoleRepository() role.RoleRepository {

--- a/test/authorization.go
+++ b/test/authorization.go
@@ -8,7 +8,6 @@ import (
 	organizationservice "github.com/fabric8-services/fabric8-auth/authorization/organization/service"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
-	scope "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/scope/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 
 	"github.com/jinzhu/gorm"
@@ -134,7 +133,7 @@ func CreateTestRoleMapping(ctx context.Context, db *gorm.DB, app application.App
 	return err
 }
 
-func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name string) (*scope.ResourceTypeScope, error) {
+func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name string) (*resourcetype.ResourceTypeScope, error) {
 	resourceTypeRepo := resourcetype.NewResourceTypeRepository(db)
 	resourceType, err := resourceTypeRepo.Lookup(ctx, "openshift.io/resource/area")
 
@@ -142,13 +141,13 @@ func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name strin
 		return nil, err
 	}
 
-	rts := scope.ResourceTypeScope{
+	rts := resourcetype.ResourceTypeScope{
 		ResourceTypeScopeID: uuid.NewV4(),
 		ResourceTypeID:      resourceType.ResourceTypeID,
 		Name:                uuid.NewV4().String(),
 	}
 
-	resourceTypeScopeRepo := scope.NewResourceTypeScopeRepository(db)
+	resourceTypeScopeRepo := resourcetype.NewResourceTypeScopeRepository(db)
 	err = resourceTypeScopeRepo.Create(ctx, &rts)
 	if err != nil {
 		return nil, err
@@ -156,15 +155,15 @@ func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name strin
 	return &rts, nil
 }
 
-func CreateTestScope(ctx context.Context, db *gorm.DB, resourceType resourcetype.ResourceType, name string) (*scope.ResourceTypeScope, error) {
+func CreateTestScope(ctx context.Context, db *gorm.DB, resourceType resourcetype.ResourceType, name string) (*resourcetype.ResourceTypeScope, error) {
 
-	rts := scope.ResourceTypeScope{
+	rts := resourcetype.ResourceTypeScope{
 		ResourceTypeScopeID: uuid.NewV4(),
 		ResourceTypeID:      resourceType.ResourceTypeID,
 		Name:                name,
 	}
 
-	resourceTypeScopeRepo := scope.NewResourceTypeScopeRepository(db)
+	resourceTypeScopeRepo := resourcetype.NewResourceTypeScopeRepository(db)
 	err := resourceTypeScopeRepo.Create(ctx, &rts)
 	if err != nil {
 		return nil, err
@@ -172,7 +171,7 @@ func CreateTestScope(ctx context.Context, db *gorm.DB, resourceType resourcetype
 	return &rts, nil
 }
 
-func CreateTestRoleScope(ctx context.Context, db *gorm.DB, s scope.ResourceTypeScope, r role.Role) (*role.RoleScope, error) {
+func CreateTestRoleScope(ctx context.Context, db *gorm.DB, s resourcetype.ResourceTypeScope, r role.Role) (*role.RoleScope, error) {
 	roleScopeRepo := role.NewRoleScopeRepository(db)
 
 	rs := role.RoleScope{


### PR DESCRIPTION
This PR merges the `/authorization/resource_type/scope` directory into `/authorization/resource_type`.

Fixes #462