### PR TITLE
Use unique resource type for role tests

### DIFF
--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -91,11 +91,14 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOK() {
 
 	var createdRoleScopes []rolerepo.RoleScope
 
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	resourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())
+	require.NoError(s.T(), err)
+
+	role, err := testsupport.CreateTestRoleWithSpecifiedType(s.Ctx, s.DB, uuid.NewV4().String(), resourceType.Name)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
-	scope, err := testsupport.CreateTestScopeWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *resourceType, uuid.NewV4().String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), scope)
 
@@ -105,17 +108,13 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOK() {
 
 	createdRoleScopes = append(createdRoleScopes, *rs)
 
-	areaResourceType, err := s.resourcetypeRepo.Lookup(s.Ctx, "openshift.io/resource/area")
-	require.NoError(s.T(), err)
-	require.NotNil(s.T(), areaResourceType)
-
-	roleScopesRetrieved, err := s.repo.ListAvailableRolesByResourceType(s.Ctx, "openshift.io/resource/area")
+	roleScopesRetrieved, err := s.repo.ListAvailableRolesByResourceType(s.Ctx, resourceType.Name)
 	require.NoError(s.T(), err)
 
 	// there might be other 'RoleScopes' returned too.
 	// That wouldn't be considered to be a failure, rather we are gonna check whether they all
 	// belong to the same resource type.
-	s.checkRoleBelongsToResourceType(s.DB, roleScopesRetrieved, *areaResourceType)
+	s.checkRoleBelongsToResourceType(s.DB, roleScopesRetrieved, *resourceType)
 
 	// Then let's check if the ones we created are there.
 	s.checkIfCreatedRoleScopesAreReturned(s.DB, roleScopesRetrieved, createdRoleScopes)

--- a/test/authorization.go
+++ b/test/authorization.go
@@ -228,6 +228,23 @@ func CreateTestRoleWithDefaultType(ctx context.Context, db *gorm.DB, name string
 	return &roleRef, err
 }
 
+func CreateTestRoleWithSpecifiedType(ctx context.Context, db *gorm.DB, name string, resourceTypeName string) (*role.Role, error) {
+	resourceTypeRepo := resourcetype.NewResourceTypeRepository(db)
+	resourceType, err := resourceTypeRepo.Lookup(ctx, resourceTypeName)
+
+	if err != nil {
+		return nil, err
+	}
+	roleRef := role.Role{
+		ResourceType:   *resourceType,
+		ResourceTypeID: resourceType.ResourceTypeID,
+		Name:           name,
+	}
+	roleRepository := role.NewRoleRepository(db)
+	err = roleRepository.Create(ctx, &roleRef)
+	return &roleRef, err
+}
+
 func CreateRandomIdentityRole(ctx context.Context, db *gorm.DB) (*role.IdentityRole, error) {
 	resourceTypeRepo := resourcetype.NewResourceTypeRepository(db)
 	resourceType, err := resourceTypeRepo.Lookup(ctx, "openshift.io/resource/area")


### PR DESCRIPTION
Fixes #463 (hopefully for good this time)

I believe that because we were using the `openshift.io/resource/area` resource type for this test, that roles created for the same resource type by other tests were getting picked up by the `ListAvailableRolesByResourceType()` method before the db cleanup had a chance to run.

Then, sometime after this method but before the `roleRepo.Load()` call (which happens when the same test calls `checkRoleBelongsToResourceType()` with the list of the roles it had found) the db cleanup gets run.  This means that the `roleRepo.Load()` will then fail when it tries to load one of the roles that got cleaned up.

I've addressed this by creating a unique resource type just for the purpose of this test, which should ensure that db cleanup of other roles for the area resource type have no effect.