### PR TITLE
return external tokens in descending order of created_at timestamp

### DIFF
--- a/token/provider/external_provider_token.go
+++ b/token/provider/external_provider_token.go
@@ -167,7 +167,8 @@ func (m *GormExternalTokenRepository) Delete(ctx context.Context, id uuid.UUID) 
 func (m *GormExternalTokenRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]ExternalToken, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "ExternalToken", "query"}, time.Now())
 	var externalProviderTokens []ExternalToken
-	err := m.db.Scopes(funcs...).Table(m.TableName()).Find(&externalProviderTokens).Error
+	// if a query is returning multiple tokens, always return the latest token first
+	err := m.db.Scopes(funcs...).Table(m.TableName()).Order("created_at desc").Find(&externalProviderTokens).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, errs.WithStack(err)
 	}


### PR DESCRIPTION
If a user has multiple github or OSO tokens in the token storage, then return the tokens in the descending order of `created_at` because the most relevant token would always be the most recent one. 