### PR TITLE
[WIP] refactor(uuid): parity patch for UUID API upgrade in f8-wit

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,8 +298,7 @@
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
+  revision = "master"
 
 [[projects]]
   name = "github.com/sergi/go-diff"
@@ -452,6 +451,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3d3c8ec306c48a083bd43e5bfe65b0e54387072ed18b926a4fd2102a96e425c9"
+  inputs-digest = "2028ae07bad4813cf87dbdcccb3e916aacd3ae14ff2dfe17c2ccbe5fb5576b7d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,7 +73,7 @@ required = [
 
 [[constraint]]
   name = "github.com/satori/go.uuid"
-  version = "1.2.0"
+  revision = "master"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/account/email/verification_service.go
+++ b/account/email/verification_service.go
@@ -40,7 +40,7 @@ func NewEmailVerificationClient(app application.Application, notificationChannel
 // SendVerificationCode generates and sends out an email with verification code.
 func (c *EmailVerificationClient) SendVerificationCode(ctx context.Context, req *goa.RequestData, identity account.Identity) (*account.VerificationCode, error) {
 
-	generatedCode := uuid.NewV4().String()
+	generatedCode := uuid.Must(uuid.NewV4()).String()
 	newVerificationCode := account.VerificationCode{
 		User: identity.User,
 		Code: generatedCode,

--- a/account/email/verification_service_blackbox_test.go
+++ b/account/email/verification_service_blackbox_test.go
@@ -33,7 +33,7 @@ func (s *verificationServiceBlackboxTest) SetupTest() {
 }
 
 func (s *verificationServiceBlackboxTest) TestSendVerificationCodeOK() {
-	identity, err := test.CreateTestIdentity(s.DB, uuid.NewV4().String(), "kc")
+	identity, err := test.CreateTestIdentity(s.DB, uuid.Must(uuid.NewV4()).String(), "kc")
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), identity.ProviderType, "kc")
 
@@ -52,11 +52,11 @@ func (s *verificationServiceBlackboxTest) TestSendVerificationCodeOK() {
 }
 
 func (s *verificationServiceBlackboxTest) TestVerifyCodeOK() {
-	identity, err := test.CreateTestIdentity(s.DB, uuid.NewV4().String(), "kc")
+	identity, err := test.CreateTestIdentity(s.DB, uuid.Must(uuid.NewV4()).String(), "kc")
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), identity.ProviderType, "kc")
 
-	generatedCode := uuid.NewV4().String()
+	generatedCode := uuid.Must(uuid.NewV4()).String()
 	newVerificationCode := account.VerificationCode{
 		User: identity.User,
 		Code: generatedCode,
@@ -74,11 +74,11 @@ func (s *verificationServiceBlackboxTest) TestVerifyCodeOK() {
 }
 
 func (s *verificationServiceBlackboxTest) TestVerifyCodeFails() {
-	identity, err := test.CreateTestIdentity(s.DB, uuid.NewV4().String(), "kc")
+	identity, err := test.CreateTestIdentity(s.DB, uuid.Must(uuid.NewV4()).String(), "kc")
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), identity.ProviderType, "kc")
 
-	generatedCode := uuid.NewV4().String()
+	generatedCode := uuid.Must(uuid.NewV4()).String()
 	newVerificationCode := account.VerificationCode{
 		User: identity.User,
 		Code: generatedCode,

--- a/account/identity.go
+++ b/account/identity.go
@@ -179,7 +179,7 @@ func (m *GormIdentityRepository) CheckExists(ctx context.Context, id string) err
 func (m *GormIdentityRepository) Create(ctx context.Context, model *Identity) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity", "create"}, time.Now())
 	if model.ID == uuid.Nil {
-		model.ID = uuid.NewV4()
+		model.ID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(model).Error
 	if err != nil {

--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -29,12 +29,12 @@ func (s *identityBlackBoxTest) SetupTest() {
 func (s *identityBlackBoxTest) TestOKToDelete() {
 	// given
 	identity := &account.Identity{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Username:     "someuserTestIdentity",
 		ProviderType: account.KeycloakIDP}
 
 	identity2 := &account.Identity{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Username:     "onemoreuserTestIdentity",
 		ProviderType: account.KeycloakIDP}
 
@@ -74,7 +74,7 @@ func (s *identityBlackBoxTest) TestExistsIdentity() {
 
 	t.Run("identity doesn't exist", func(t *testing.T) {
 		//t.Parallel()
-		err := s.Application.Identities().CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.Application.Identities().CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
@@ -99,7 +99,7 @@ func (s *identityBlackBoxTest) TestLoadIdentityAndUserFailsIfUserOrIdentityDoNot
 	assert.Equal(s.T(), errors.NewNotFoundError("user for identity", identity.ID.String()).Error(), err.Error())
 
 	// Identity does not exist
-	id := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 	_, err = s.Application.Identities().LoadWithUser(s.Ctx, id)
 	require.NotNil(s.T(), err)
 	assert.Equal(s.T(), errors.NewNotFoundError("identity", id.String()).Error(), err.Error())
@@ -108,13 +108,13 @@ func (s *identityBlackBoxTest) TestLoadIdentityAndUserFailsIfUserOrIdentityDoNot
 func (s *identityBlackBoxTest) TestLoadIdentityAndUserOK() {
 	// Create test user & identity
 	testUser := &account.User{
-		ID:       uuid.NewV4(),
-		Email:    uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    uuid.Must(uuid.NewV4()).String(),
 		FullName: "TestLoadIdentityAndUserOK Developer",
 		Cluster:  "https://api.starter-us-east-2a.openshift.com",
 	}
 	testIdentity := &account.Identity{
-		Username:     "TestLoadIdentityAndUserOK" + uuid.NewV4().String(),
+		Username:     "TestLoadIdentityAndUserOK" + uuid.Must(uuid.NewV4()).String(),
 		ProviderType: account.KeycloakIDP,
 		User:         *testUser,
 	}
@@ -138,13 +138,13 @@ func (s *identityBlackBoxTest) TestLoadIdentityAndUserOK() {
 func (s *identityBlackBoxTest) TestUserIdentityIsUser() {
 	// Create test user & identity
 	testUser := &account.User{
-		ID:       uuid.NewV4(),
-		Email:    uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    uuid.Must(uuid.NewV4()).String(),
 		FullName: "TestUserIdentityIsUser Developer",
 		Cluster:  "https://api.starter-us-east-2a.openshift.com",
 	}
 	testIdentity := &account.Identity{
-		Username:     "TestUserIdentityIsUser" + uuid.NewV4().String(),
+		Username:     "TestUserIdentityIsUser" + uuid.Must(uuid.NewV4()).String(),
 		ProviderType: account.KeycloakIDP,
 		User:         *testUser,
 	}
@@ -163,7 +163,7 @@ func (s *identityBlackBoxTest) TestFindIdentityMemberships() {
 	// Create an identity
 	identity := createAndLoad(s)
 
-	orgName := "Acme Corporation - identityBlackBoxTest.TestFindIdentityMemberships" + uuid.NewV4().String()
+	orgName := "Acme Corporation - identityBlackBoxTest.TestFindIdentityMemberships" + uuid.Must(uuid.NewV4()).String()
 	// Create an organization
 	orgID, err := s.Application.OrganizationService().CreateOrganization(s.Ctx, identity.ID, orgName)
 	require.NoError(s.T(), err)
@@ -185,7 +185,7 @@ func (s *identityBlackBoxTest) TestFindIdentityMemberships() {
 
 func createAndLoad(s *identityBlackBoxTest) *account.Identity {
 	identity := &account.Identity{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Username:     "someuserTestIdentity2",
 		ProviderType: account.KeycloakIDP}
 

--- a/account/user.go
+++ b/account/user.go
@@ -115,7 +115,7 @@ func (m *GormUserRepository) CheckExists(ctx context.Context, id string) error {
 func (m *GormUserRepository) Create(ctx context.Context, u *User) error {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "create"}, time.Now())
 	if u.ID == uuid.Nil {
-		u.ID = uuid.NewV4()
+		u.ID = uuid.Must(uuid.NewV4())
 	}
 
 	err := m.db.Create(u).Error

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -67,7 +67,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 	t.Run("user doesn't exist", func(t *testing.T) {
 		//t.Parallel()
 		// Check not existing
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(s.T(), errors.NotFoundError{}, err)
 	})
@@ -77,7 +77,7 @@ func (s *userBlackBoxTest) TestOKToSave() {
 	user := createAndLoadUser(s, false)
 
 	user.FullName = "newusernameTestUser"
-	user.Cluster = "NewCluster" + uuid.NewV4().String()
+	user.Cluster = "NewCluster" + uuid.Must(uuid.NewV4()).String()
 	err := s.repo.Save(s.Ctx, user)
 	require.Nil(s.T(), err, "Could not update user")
 
@@ -94,14 +94,14 @@ func (s *userBlackBoxTest) TestOKToSave() {
 func (s *userBlackBoxTest) TestCreateUserWithoutClusterFails() {
 	t := s.T()
 	user := &account.User{
-		ID:       uuid.NewV4(),
-		Email:    "noclustersomeuser@TestUser" + uuid.NewV4().String(),
-		FullName: "someuserTestUser" + uuid.NewV4().String(),
-		ImageURL: "someImageUrl" + uuid.NewV4().String(),
-		Bio:      "somebio" + uuid.NewV4().String(),
-		URL:      "someurl" + uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    "noclustersomeuser@TestUser" + uuid.Must(uuid.NewV4()).String(),
+		FullName: "someuserTestUser" + uuid.Must(uuid.NewV4()).String(),
+		ImageURL: "someImageUrl" + uuid.Must(uuid.NewV4()).String(),
+		Bio:      "somebio" + uuid.Must(uuid.NewV4()).String(),
+		URL:      "someurl" + uuid.Must(uuid.NewV4()).String(),
 		ContextInformation: account.ContextInformation{
-			"space":        uuid.NewV4(),
+			"space":        uuid.Must(uuid.NewV4()),
 			"last_visited": "http://www.google.com",
 			"myid":         "71f343e3-2bfa-4ec6-86d4-79b91476acfc",
 		},
@@ -221,16 +221,16 @@ func (s *userBlackBoxTest) checkPrivateEmailFilter(privateEmails bool, expectedE
 
 func createAndLoadUser(s *userBlackBoxTest, emailPrivate bool) *account.User {
 	user := &account.User{
-		ID:           uuid.NewV4(),
-		Email:        "someuser@TestUser" + uuid.NewV4().String(),
+		ID:           uuid.Must(uuid.NewV4()),
+		Email:        "someuser@TestUser" + uuid.Must(uuid.NewV4()).String(),
 		EmailPrivate: emailPrivate,
-		FullName:     "someuserTestUser" + uuid.NewV4().String(),
-		ImageURL:     "someImageUrl" + uuid.NewV4().String(),
-		Bio:          "somebio" + uuid.NewV4().String(),
-		URL:          "someurl" + uuid.NewV4().String(),
-		Cluster:      "somecluster" + uuid.NewV4().String(),
+		FullName:     "someuserTestUser" + uuid.Must(uuid.NewV4()).String(),
+		ImageURL:     "someImageUrl" + uuid.Must(uuid.NewV4()).String(),
+		Bio:          "somebio" + uuid.Must(uuid.NewV4()).String(),
+		URL:          "someurl" + uuid.Must(uuid.NewV4()).String(),
+		Cluster:      "somecluster" + uuid.Must(uuid.NewV4()).String(),
 		ContextInformation: account.ContextInformation{
-			"space":        uuid.NewV4(),
+			"space":        uuid.Must(uuid.NewV4()),
 			"last_visited": "http://www.google.com",
 			"myid":         "71f343e3-2bfa-4ec6-86d4-79b91476acfc",
 		},

--- a/account/userinfo/service_blackbox_test.go
+++ b/account/userinfo/service_blackbox_test.go
@@ -61,8 +61,8 @@ func (s *serviceBlackBoxTest) TestShowUserInfoUnauthorized() {
 	require.Equal(s.T(), err.Error(), fmt.Sprintf("bad token"))
 
 	// Generate Token with an identity that doesn't exist in the database
-	sub := uuid.NewV4().String()
-	ctx, err := testtoken.EmbedTokenInContext(sub, uuid.NewV4().String())
+	sub := uuid.Must(uuid.NewV4()).String()
+	ctx, err := testtoken.EmbedTokenInContext(sub, uuid.Must(uuid.NewV4()).String())
 	require.Nil(s.T(), err)
 
 	_, _, err = s.userInfoProvider.UserInfo(ctx)

--- a/account/verification_code.go
+++ b/account/verification_code.go
@@ -89,7 +89,7 @@ func (m *GormVerificationCodeRepository) CheckExists(ctx context.Context, id str
 func (m *GormVerificationCodeRepository) Create(ctx context.Context, model *VerificationCode) error {
 	defer goa.MeasureSince([]string{"goa", "db", "VerificationCode", "create"}, time.Now())
 	if model.ID == uuid.Nil {
-		model.ID = uuid.NewV4()
+		model.ID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(model).Error
 	if err != nil {

--- a/account/verification_code_blackbox_test.go
+++ b/account/verification_code_blackbox_test.go
@@ -56,13 +56,13 @@ func (s *verificationCodeBlackboxTest) TestVerificationCodeOKToDelete() {
 
 func createAndLoadVerificationCode(s *verificationCodeBlackboxTest) *account.VerificationCode {
 
-	identity, err := test.CreateTestIdentityAndUser(s.DB, uuid.NewV4().String(), "kc")
+	identity, err := test.CreateTestIdentityAndUser(s.DB, uuid.Must(uuid.NewV4()).String(), "kc")
 
 	require.NoError(s.T(), err)
 
 	verificationCode := account.VerificationCode{
-		ID:     uuid.NewV4(),
-		Code:   uuid.NewV4().String(),
+		ID:     uuid.Must(uuid.NewV4()),
+		Code:   uuid.Must(uuid.NewV4()).String(),
 		UserID: identity.User.ID,
 		User:   identity.User,
 	}

--- a/application/application_db_calls_bench_test.go
+++ b/application/application_db_calls_bench_test.go
@@ -63,7 +63,7 @@ func (s *BenchDbOperations) SetupBenchmark() {
 	s.appDB = gormapplication.NewGormDB(s.DB)
 
 	s.identity = &account.Identity{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Username:     "BenchmarkTestIdentity",
 		ProviderType: account.KeycloakIDP}
 

--- a/application/transaction/transaction_bench_test.go
+++ b/application/transaction/transaction_bench_test.go
@@ -47,7 +47,7 @@ func (s *BenchTransactional) SetupBenchmark() {
 	s.app = gormapplication.NewGormDB(s.DB)
 
 	s.identity = &account.Identity{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Username:     "BenchmarkTransactionalTestIdentity",
 		ProviderType: account.KeycloakIDP}
 

--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -80,7 +80,7 @@ func (s *TestAuthSuite) TestDeleteNonexistingResourceFails() {
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(s.T(), err)
 	pat := getProtectedAPITokenOK(s.T())
-	err = auth.DeleteResource(ctx, uuid.NewV4().String(), authzEndpoint, pat)
+	err = auth.DeleteResource(ctx, uuid.Must(uuid.NewV4()).String(), authzEndpoint, pat)
 	require.NotNil(s.T(), err)
 }
 
@@ -133,7 +133,7 @@ func (s *TestAuthSuite) TestCreateAndDeletePermissionOK() {
 	defer deletePolicy(s.T(), ctx, clientsEndpoint, clientId, policyID, pat)
 
 	permission := auth.KeycloakPermission{
-		Name:             "test-" + uuid.NewV4().String(),
+		Name:             "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PermissionTypeResource,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,
@@ -161,10 +161,10 @@ func (s *TestAuthSuite) TestDeleteNonexistingPolicyAndPermissionFails() {
 	require.Nil(s.T(), err)
 	pat := getProtectedAPITokenOK(s.T())
 	clientId, _ := getClientIDAndEndpoint(s.T())
-	err = auth.DeletePolicy(ctx, clientsEndpoint, clientId, uuid.NewV4().String(), pat)
+	err = auth.DeletePolicy(ctx, clientsEndpoint, clientId, uuid.Must(uuid.NewV4()).String(), pat)
 	assert.NotNil(s.T(), err)
 
-	err = auth.DeletePermission(ctx, clientsEndpoint, clientId, uuid.NewV4().String(), pat)
+	err = auth.DeletePermission(ctx, clientsEndpoint, clientId, uuid.Must(uuid.NewV4()).String(), pat)
 	assert.NotNil(s.T(), err)
 }
 
@@ -185,7 +185,7 @@ func (s *TestAuthSuite) TestGetEntitlement() {
 	defer deletePolicy(s.T(), ctx, clientsEndpoint, clientId, policyID, pat)
 
 	permission := auth.KeycloakPermission{
-		Name:             "test-" + uuid.NewV4().String(),
+		Name:             "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PermissionTypeResource,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,
@@ -259,14 +259,14 @@ func (s *TestAuthSuite) TestReadTokenOK() {
 
 func (s *TestAuthSuite) TestUpdateUserToPolicyOK() {
 	policy := auth.KeycloakPolicy{
-		Name:             "test-" + uuid.NewV4().String(),
+		Name:             "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PolicyTypeUser,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,
 	}
-	userID1 := uuid.NewV4().String()
-	userID2 := uuid.NewV4().String()
-	userID3 := uuid.NewV4().String()
+	userID1 := uuid.Must(uuid.NewV4()).String()
+	userID2 := uuid.Must(uuid.NewV4()).String()
+	userID3 := uuid.Must(uuid.NewV4()).String()
 	assert.True(s.T(), policy.AddUserToPolicy(userID1))
 	//"users":"[\"<ID>\",\"<ID>\"]"
 	assert.Equal(s.T(), fmt.Sprintf("[\"%s\"]", userID1), policy.Config.UserIDs)
@@ -276,7 +276,7 @@ func (s *TestAuthSuite) TestUpdateUserToPolicyOK() {
 	assert.Equal(s.T(), fmt.Sprintf("[\"%s\",\"%s\"]", userID1, userID2), policy.Config.UserIDs)
 	assert.True(s.T(), policy.AddUserToPolicy(userID3))
 	assert.Equal(s.T(), fmt.Sprintf("[\"%s\",\"%s\",\"%s\"]", userID1, userID2, userID3), policy.Config.UserIDs)
-	assert.False(s.T(), policy.RemoveUserFromPolicy(uuid.NewV4().String()))
+	assert.False(s.T(), policy.RemoveUserFromPolicy(uuid.Must(uuid.NewV4()).String()))
 	assert.Equal(s.T(), fmt.Sprintf("[\"%s\",\"%s\",\"%s\"]", userID1, userID2, userID3), policy.Config.UserIDs)
 	assert.True(s.T(), policy.RemoveUserFromPolicy(userID2))
 	assert.Equal(s.T(), fmt.Sprintf("[\"%s\",\"%s\"]", userID1, userID3), policy.Config.UserIDs)
@@ -357,7 +357,7 @@ func createResource(t *testing.T, ctx context.Context, pat string) (string, stri
 	}
 	uri := "testResourceURI"
 	kcResource := auth.KeycloakResource{
-		Name:   "test-" + uuid.NewV4().String(),
+		Name:   "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:   "testResource",
 		URI:    &uri,
 		Scopes: &scopes,
@@ -375,7 +375,7 @@ func createPolicy(t *testing.T, ctx context.Context, pat string) (string, auth.K
 	firstTestUserID := getUserID(t, configuration.GetKeycloakTestUserName(), configuration.GetKeycloakTestUserSecret())
 	secondTestUserID := getUserID(t, configuration.GetKeycloakTestUser2Name(), configuration.GetKeycloakTestUser2Secret())
 	policy := auth.KeycloakPolicy{
-		Name:             "test-" + uuid.NewV4().String(),
+		Name:             "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PolicyTypeUser,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,

--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -88,7 +88,7 @@ func createPermissionWithPolicy(s *TestPolicySuite) (*auth.KeycloakPolicy, strin
 	require.NotNil(s.T(), policy)
 
 	permission := auth.KeycloakPermission{
-		Name:             "test-" + uuid.NewV4().String(),
+		Name:             "test-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PermissionTypeResource,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -92,7 +92,7 @@ func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *g
 	// Create policy
 	userIDs := "[\"" + userID + "\"]"
 	policy := KeycloakPolicy{
-		Name:             fmt.Sprintf("%s-%s", name, uuid.NewV4().String()),
+		Name:             fmt.Sprintf("%s-%s", name, uuid.Must(uuid.NewV4()).String()),
 		Type:             PolicyTypeUser,
 		Logic:            PolicyLogicPossitive,
 		DecisionStrategy: PolicyDecisionStrategyUnanimous,
@@ -107,7 +107,7 @@ func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *g
 
 	// Create permission
 	permission := KeycloakPermission{
-		Name:             fmt.Sprintf("%s-%s", name, uuid.NewV4().String()),
+		Name:             fmt.Sprintf("%s-%s", name, uuid.Must(uuid.NewV4()).String()),
 		Type:             PermissionTypeResource,
 		Logic:            PolicyLogicPossitive,
 		DecisionStrategy: PolicyDecisionStrategyUnanimous,

--- a/auth/state.go
+++ b/auth/state.go
@@ -109,7 +109,7 @@ func (r *GormOauthStateReferenceRepository) Delete(ctx context.Context, ID uuid.
 // returns InternalError
 func (r *GormOauthStateReferenceRepository) Create(ctx context.Context, reference *OauthStateReference) (*OauthStateReference, error) {
 	if reference.ID == uuid.Nil {
-		reference.ID = uuid.NewV4()
+		reference.ID = uuid.Must(uuid.NewV4())
 	}
 
 	tx := r.db.Create(reference)

--- a/auth/state_blackbox_test.go
+++ b/auth/state_blackbox_test.go
@@ -30,13 +30,13 @@ func (s *stateBlackBoxTest) SetupTest() {
 func (s *stateBlackBoxTest) TestCreateDeleteLoad() {
 	// given
 	state := &auth.OauthStateReference{
-		State:    uuid.NewV4().String(),
+		State:    uuid.Must(uuid.NewV4()).String(),
 		Referrer: "domain.org",
 	}
 
 	responseMode := "fragment"
 	state2 := &auth.OauthStateReference{
-		State:        uuid.NewV4().String(),
+		State:        uuid.Must(uuid.NewV4()).String(),
 		Referrer:     "anotherdomain.com",
 		ResponseMode: &responseMode,
 	}

--- a/authorization/authorization_blackbox_test.go
+++ b/authorization/authorization_blackbox_test.go
@@ -27,8 +27,8 @@ func (s *authorizationBlackBoxTest) TestCanHaveMembers() {
 }
 
 func (s *authorizationBlackBoxTest) TestAppendAssociation() {
-	aID := uuid.NewV4()
-	bID := uuid.NewV4()
+	aID := uuid.Must(uuid.NewV4())
+	bID := uuid.Must(uuid.NewV4())
 
 	associations := []authorization.IdentityAssociation{}
 
@@ -92,8 +92,8 @@ func (s *authorizationBlackBoxTest) TestAppendAssociation() {
 }
 
 func (s *authorizationBlackBoxTest) TestMergeAssociations() {
-	cID := uuid.NewV4()
-	dID := uuid.NewV4()
+	cID := uuid.Must(uuid.NewV4())
+	dID := uuid.Must(uuid.NewV4())
 
 	c := authorization.IdentityAssociation{
 		IdentityID:   &cID,

--- a/authorization/invitation/repository/invitation.go
+++ b/authorization/invitation/repository/invitation.go
@@ -119,7 +119,7 @@ func (m *GormInvitationRepository) Load(ctx context.Context, id uuid.UUID) (*Inv
 func (m *GormInvitationRepository) Create(ctx context.Context, i *Invitation) error {
 	defer goa.MeasureSince([]string{"goa", "db", "invitation", "create"}, time.Now())
 	if i.InvitationID == uuid.Nil {
-		i.InvitationID = uuid.NewV4()
+		i.InvitationID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(i).Error
 	if err != nil {

--- a/authorization/invitation/repository/invitation_blackbox_test.go
+++ b/authorization/invitation/repository/invitation_blackbox_test.go
@@ -63,7 +63,7 @@ func (s *invitationBlackBoxTest) TestExistsInvitation() {
 }
 
 func (s *invitationBlackBoxTest) TestNotExistsInvitationFails() {
-	exists, err := s.repo.CheckExists(s.Ctx, uuid.NewV4())
+	exists, err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()))
 	require.Error(s.T(), err)
 	require.False(s.T(), exists)
 }
@@ -140,7 +140,7 @@ func (s *invitationBlackBoxTest) TestAddRoleFailsForInvalidRoleID() {
 	invitation, err := s.CreateTestInvitation()
 	require.NoError(s.T(), err)
 
-	err = s.repo.AddRole(s.Ctx, invitation.InvitationID, uuid.NewV4())
+	err = s.repo.AddRole(s.Ctx, invitation.InvitationID, uuid.Must(uuid.NewV4()))
 	require.Error(s.T(), err, "add role should return error for nonexistent role")
 
 	roles, err := s.repo.ListRoles(s.Ctx, invitation.InvitationID)

--- a/authorization/invitation/service/invitation_service_blackbox_test.go
+++ b/authorization/invitation/service/invitation_service_blackbox_test.go
@@ -83,7 +83,7 @@ func (s *invitationServiceBlackBoxTest) TestIssueInvitationFailsForInvalidID() {
 		},
 	}
 
-	err = s.invService.Issue(s.Ctx, identity.ID, uuid.NewV4().String(), invitations)
+	err = s.invService.Issue(s.Ctx, identity.ID, uuid.Must(uuid.NewV4()).String(), invitations)
 	require.Error(s.T(), err)
 
 	err = s.invService.Issue(s.Ctx, identity.ID, "foo", invitations)
@@ -266,7 +266,7 @@ func (s *invitationServiceBlackBoxTest) TestIssueInvitationFailsForUnknownUser()
 	orgId, err := s.orgService.CreateOrganization(s.Ctx, identity.ID, "Test Organization ZZZZZZ")
 	require.Nil(s.T(), err, "Could not create organization")
 
-	invalidIdentityID := uuid.NewV4()
+	invalidIdentityID := uuid.Must(uuid.NewV4())
 
 	invitations := []invitation.Invitation{
 		{
@@ -332,20 +332,20 @@ func (s *invitationServiceBlackBoxTest) TestIssueMultipleInvitations() {
 	require.NoError(s.T(), err, "Could not create organization")
 
 	// Create another test user - we will invite this one to join the organization
-	invitee, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "invitationServiceBlackBoxTest-TestInviteeUser-"+uuid.NewV4().String())
+	invitee, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "invitationServiceBlackBoxTest-TestInviteeUser-"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "Could not create identity")
 
 	// Create another test user - we will invite this one to join the organization
 	invitee2User := account.User{
-		ID:       uuid.NewV4(),
-		Email:    "jsmith-invitationtest" + uuid.NewV4().String() + "@acmecorp.com",
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    "jsmith-invitationtest" + uuid.Must(uuid.NewV4()).String() + "@acmecorp.com",
 		FullName: "John Smith - Invitation Test",
 		Cluster:  "https://api.starter-us-east-2.openshift.com",
 	}
 
 	invitee2 := account.Identity{
-		ID:           uuid.NewV4(),
-		Username:     "TestInvitee" + uuid.NewV4().String(),
+		ID:           uuid.Must(uuid.NewV4()),
+		Username:     "TestInvitee" + uuid.Must(uuid.NewV4()).String(),
 		User:         invitee2User,
 		ProviderType: account.KeycloakIDP,
 	}
@@ -397,7 +397,7 @@ func (s *invitationServiceBlackBoxTest) TestIssueMultipleInvitations() {
 
 func (s *invitationServiceBlackBoxTest) TestIssueInvitationByIdentityIDForRole() {
 	// Create a test user - this will be the organization owner
-	identity, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "invitationServiceBlackBoxTest-TestIssuingUser"+uuid.NewV4().String())
+	identity, err := test.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "invitationServiceBlackBoxTest-TestIssuingUser"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(s.T(), err, "Could not create identity")
 
 	// Create an organization

--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -118,7 +118,7 @@ func (m *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 
 	// If no identifier has been specified for the new resource, then generate one
 	if resource.ResourceID == "" {
-		resource.ResourceID = uuid.NewV4().String()
+		resource.ResourceID = uuid.Must(uuid.NewV4()).String()
 	}
 
 	if resource.ResourceTypeID.String() == "" {

--- a/authorization/resource/repository/resource_blackbox_test.go
+++ b/authorization/resource/repository/resource_blackbox_test.go
@@ -70,7 +70,7 @@ func (s *resourceBlackBoxTest) TestExistsResource() {
 	t.Run("resource doesn't exist", func(t *testing.T) {
 		//t.Parallel()
 		// Check not existing
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(s.T(), errors.NotFoundError{}, err)
 	})
@@ -91,11 +91,11 @@ func (s *resourceBlackBoxTest) TestCannotCreateDuplicateOrganizationNames() {
 	resourceType, err := s.resourceTypeRepo.Lookup(s.Ctx, authorization.IdentityResourceTypeOrganization)
 	require.NoError(s.T(), err, "Could not find organization resource type")
 
-	orgName := "Acme Corporation" + uuid.NewV4().String()
+	orgName := "Acme Corporation" + uuid.Must(uuid.NewV4()).String()
 
 	// Create a new organization resource
 	res := &resource.Resource{
-		ResourceID:       uuid.NewV4().String(),
+		ResourceID:       uuid.Must(uuid.NewV4()).String(),
 		ParentResourceID: nil,
 		Name:             orgName,
 		ResourceType:     *resourceType,
@@ -107,7 +107,7 @@ func (s *resourceBlackBoxTest) TestCannotCreateDuplicateOrganizationNames() {
 
 	// Now try to create another organization resource with the same name
 	res = &resource.Resource{
-		ResourceID:       uuid.NewV4().String(),
+		ResourceID:       uuid.Must(uuid.NewV4()).String(),
 		ParentResourceID: nil,
 		Name:             orgName,
 		ResourceType:     *resourceType,
@@ -124,7 +124,7 @@ func createAndLoadResource(s *resourceBlackBoxTest) *resource.Resource {
 	require.Nil(s.T(), err, "Could not find resource type")
 
 	resource := &resource.Resource{
-		ResourceID:       uuid.NewV4().String(),
+		ResourceID:       uuid.Must(uuid.NewV4()).String(),
 		ParentResourceID: nil,
 		ResourceType:     *resourceType,
 		ResourceTypeID:   resourceType.ResourceTypeID,

--- a/authorization/resourcetype/repository/resource_type.go
+++ b/authorization/resourcetype/repository/resource_type.go
@@ -78,7 +78,7 @@ func (m *GormResourceTypeRepository) Lookup(ctx context.Context, name string) (*
 func (m *GormResourceTypeRepository) Create(ctx context.Context, u *ResourceType) error {
 	defer goa.MeasureSince([]string{"goa", "db", "resource_type", "create"}, time.Now())
 	if u.ResourceTypeID == uuid.Nil {
-		u.ResourceTypeID = uuid.NewV4()
+		u.ResourceTypeID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(u).Error
 	if err != nil {

--- a/authorization/resourcetype/repository/resource_type_blackbox_test.go
+++ b/authorization/resourcetype/repository/resource_type_blackbox_test.go
@@ -49,8 +49,8 @@ func (s *resourceTypeBlackBoxTest) TestDefaultResourceTypesExist() {
 func (s *resourceTypeBlackBoxTest) TestCreateResourceType() {
 	t := s.T()
 	resourceTypeRef := resourcetype.ResourceType{
-		ResourceTypeID: uuid.NewV4(),
-		Name:           uuid.NewV4().String(),
+		ResourceTypeID: uuid.Must(uuid.NewV4()),
+		Name:           uuid.Must(uuid.NewV4()).String(),
 	}
 	err := s.repo.Create(s.Ctx, &resourceTypeRef)
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func (s *resourceTypeBlackBoxTest) TestCreateResourceType() {
 func (s *resourceTypeBlackBoxTest) TestCreateResourceTypeWithoutID() {
 	t := s.T()
 	resourceTypeRef := resourcetype.ResourceType{
-		Name: uuid.NewV4().String(),
+		Name: uuid.Must(uuid.NewV4()).String(),
 	}
 	err := s.repo.Create(s.Ctx, &resourceTypeRef)
 	require.NoError(t, err)

--- a/authorization/resourcetype/repository/resource_type_scope.go
+++ b/authorization/resourcetype/repository/resource_type_scope.go
@@ -120,7 +120,7 @@ func (m *GormResourceTypeScopeRepository) LookupForType(ctx context.Context, res
 func (m *GormResourceTypeScopeRepository) Create(ctx context.Context, u *ResourceTypeScope) error {
 	defer goa.MeasureSince([]string{"goa", "db", "resource_type_scope", "create"}, time.Now())
 	if u.ResourceTypeScopeID == uuid.Nil {
-		u.ResourceTypeScopeID = uuid.NewV4()
+		u.ResourceTypeScopeID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(u).Error
 	if err != nil {

--- a/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
+++ b/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
@@ -30,11 +30,11 @@ func (s *resourceTypeScopeBlackBoxTest) SetupTest() {
 }
 
 func (s *resourceTypeScopeBlackBoxTest) TestLookupByResourceTypeAndScope() {
-	rtRef, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())
+	rtRef, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rtRef)
 
-	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rtRef, uuid.NewV4().String())
+	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rtRef, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rts)
 

--- a/authorization/role/repository/identity_role.go
+++ b/authorization/role/repository/identity_role.go
@@ -105,7 +105,7 @@ func (m *GormIdentityRoleRepository) CheckExists(ctx context.Context, id string)
 func (m *GormIdentityRoleRepository) Create(ctx context.Context, u *IdentityRole) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity_role", "create"}, time.Now())
 	if u.IdentityRoleID == uuid.Nil {
-		u.IdentityRoleID = uuid.NewV4()
+		u.IdentityRoleID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(u).Error
 	if err != nil {

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -78,7 +78,7 @@ func (s *identityRoleBlackBoxTest) TestExistsRole() {
 
 	t.Run("identity role doesn't exist", func(t *testing.T) {
 		// Check not existing
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
@@ -97,7 +97,7 @@ func (s *identityRoleBlackBoxTest) TestFindPermissions() {
 	require.NoError(s.T(), err)
 
 	// Create a new role
-	role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *resourceType, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *resourceType, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	// Assign the two scopes to the role
@@ -108,7 +108,7 @@ func (s *identityRoleBlackBoxTest) TestFindPermissions() {
 	require.NoError(s.T(), err)
 
 	// Create a test resource
-	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *resourceType, uuid.NewV4().String(), nil)
+	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *resourceType, uuid.Must(uuid.NewV4()).String(), nil)
 	require.NoError(s.T(), err)
 
 	// Assign the new role for our new resource to a user
@@ -153,7 +153,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceAndRoleName() 
 	createAndLoadIdentityRole(s)
 
 	// Create another identity role with the same resource as the first one, but a different role
-	roleName := uuid.NewV4().String()
+	roleName := uuid.Must(uuid.NewV4()).String()
 	otherRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, identityRole.Resource.ResourceType, roleName)
 	require.NoError(s.T(), err)
 

--- a/authorization/role/repository/role.go
+++ b/authorization/role/repository/role.go
@@ -110,7 +110,7 @@ func (m *GormRoleRepository) Load(ctx context.Context, id uuid.UUID) (*Role, err
 func (m *GormRoleRepository) Create(ctx context.Context, u *Role) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role", "create"}, time.Now())
 	if u.RoleID == uuid.Nil {
-		u.RoleID = uuid.NewV4()
+		u.RoleID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(u).Error
 	if err != nil {

--- a/authorization/role/repository/role_blackbox_test.go
+++ b/authorization/role/repository/role_blackbox_test.go
@@ -40,11 +40,11 @@ func (s *roleBlackBoxTest) SetupTest() {
 
 func (s *roleBlackBoxTest) TestOKToDelete() {
 	// create 2 roles, where the first one would be deleted.
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
-	_, err = testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	_, err = testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	err = s.repo.Delete(s.Ctx, role.RoleID)
@@ -63,7 +63,7 @@ func (s *roleBlackBoxTest) TestOKToDelete() {
 }
 
 func (s *roleBlackBoxTest) TestOKToLoad() {
-	r, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	r, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), r)
 
@@ -76,7 +76,7 @@ func (s *roleBlackBoxTest) TestExistsRole() {
 
 	t.Run("role exists", func(t *testing.T) {
 		//t.Parallel()
-		role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+		role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), role)
 		// when
@@ -88,14 +88,14 @@ func (s *roleBlackBoxTest) TestExistsRole() {
 	t.Run("role doesn't exist", func(t *testing.T) {
 		//t.Parallel()
 		// Check not existing
-		_, err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		_, err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(s.T(), errors.NotFoundError{}, err)
 	})
 }
 
 func (s *roleBlackBoxTest) TestOKToSave() {
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
@@ -109,7 +109,7 @@ func (s *roleBlackBoxTest) TestOKToSave() {
 }
 
 func (s *roleBlackBoxTest) TestOKToAddScopes() {
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
@@ -129,7 +129,7 @@ func (s *roleBlackBoxTest) TestOKToAddScopes() {
 }
 
 func (s *roleBlackBoxTest) TestSaveFailsForDeletedRole() {
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
@@ -142,11 +142,11 @@ func (s *roleBlackBoxTest) TestSaveFailsForDeletedRole() {
 }
 
 func (s *roleBlackBoxTest) TestSaveConflictError() {
-	role1, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role1, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role1)
 
-	role2, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role2, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role2)
 
@@ -157,7 +157,7 @@ func (s *roleBlackBoxTest) TestSaveConflictError() {
 }
 
 func (s *roleBlackBoxTest) TestCreateConflictError() {
-	role1, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role1, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role1)
 

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -110,7 +110,7 @@ func (m *GormRoleMappingRepository) Load(ctx context.Context, id uuid.UUID) (*Ro
 func (m *GormRoleMappingRepository) Create(ctx context.Context, u *RoleMapping) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role_mapping", "create"}, time.Now())
 	if u.RoleMappingID == uuid.Nil {
-		u.RoleMappingID = uuid.NewV4()
+		u.RoleMappingID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(u).Error
 	if err != nil {

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -82,7 +82,7 @@ func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName str
 		return rm, err
 	}
 
-	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *fromResourceType, "Test-Role-Mapped-Resource"+uuid.NewV4().String(), nil)
+	resource, err := testsupport.CreateTestResource(s.Ctx, s.DB, *fromResourceType, "Test-Role-Mapped-Resource"+uuid.Must(uuid.NewV4()).String(), nil)
 	if err != nil {
 		return rm, err
 	}

--- a/authorization/role/repository/role_scope_blackbox_test.go
+++ b/authorization/role/repository/role_scope_blackbox_test.go
@@ -37,11 +37,11 @@ func (s *roleScopeBlackBoxTest) TestCreateRoleScopeOK() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rt)
 
-	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rt, uuid.NewV4().String())
+	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rt, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rts)
 
-	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.NewV4().String())
+	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	rs := rolescope.RoleScope{
@@ -58,11 +58,11 @@ func (s *roleScopeBlackBoxTest) TestListRoleScopeByRoleOK() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rt)
 
-	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rt, uuid.NewV4().String())
+	rts, err := testsupport.CreateTestScope(s.Ctx, s.DB, *rt, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rts)
 
-	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.NewV4().String())
+	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	rs := rolescope.RoleScope{
@@ -88,14 +88,14 @@ func (s *roleScopeBlackBoxTest) TestListRoleScopeByScopeOK() {
 
 	// TODO: move to test/authorization.go
 	rts := resourcetype.ResourceTypeScope{
-		ResourceTypeScopeID: uuid.NewV4(),
+		ResourceTypeScopeID: uuid.Must(uuid.NewV4()),
 		ResourceTypeID:      rt.ResourceTypeID,
-		Name:                uuid.NewV4().String(),
+		Name:                uuid.Must(uuid.NewV4()).String(),
 	}
 
 	err = s.resourceTypeScopeRepo.Create(s.Ctx, &rts)
 
-	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.NewV4().String())
+	randomRole, err := testsupport.CreateTestRole(s.Ctx, s.DB, *rt, "collab-"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	rs := rolescope.RoleScope{

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -82,7 +82,7 @@ func (s *roleManagementServiceBlackboxTest) TestGetIdentityRoleByResourceNotFoun
 	require.NoError(t, err)
 	require.NotNil(t, identityRole)
 
-	identityRoles, err := s.repo.ListByResource(s.Ctx, uuid.NewV4().String())
+	identityRoles, err := s.repo.ListByResource(s.Ctx, uuid.Must(uuid.NewV4()).String())
 	require.NoError(t, err)
 	require.Equal(t, 0, len(identityRoles))
 }
@@ -91,14 +91,14 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOK() {
 
 	var createdRoleScopes []rolerepo.RoleScope
 
-	resourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())
+	resourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
-	role, err := testsupport.CreateTestRoleWithSpecifiedType(s.Ctx, s.DB, uuid.NewV4().String(), resourceType.Name)
+	role, err := testsupport.CreateTestRoleWithSpecifiedType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String(), resourceType.Name)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
-	scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *resourceType, uuid.NewV4().String())
+	scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *resourceType, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), scope)
 
@@ -123,11 +123,11 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOK() {
 func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOKEmpty() {
 
 	// create entities in the existing resource type
-	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), role)
 
-	scope, err := testsupport.CreateTestScopeWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
+	scope, err := testsupport.CreateTestScopeWithDefaultType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), scope)
 
@@ -136,7 +136,7 @@ func (s *roleManagementServiceBlackboxTest) TestGetRolesByResourceTypeOKEmpty() 
 	require.NotNil(s.T(), rs)
 
 	// create another resource type
-	newResourceTypeName := uuid.NewV4().String()
+	newResourceTypeName := uuid.Must(uuid.NewV4()).String()
 	_, err = testsupport.CreateTestResourceType(s.Ctx, s.DB, newResourceTypeName)
 	require.NoError(s.T(), err)
 
@@ -192,7 +192,7 @@ func (s *roleManagementServiceBlackboxTest) TestGetIdentityRoleByResourceAndRole
 	require.NoError(t, err)
 	require.NotNil(t, identityRole)
 
-	identityRoles, err := s.repo.ListByResourceAndRoleName(s.Ctx, uuid.NewV4().String(), uuid.NewV4().String())
+	identityRoles, err := s.repo.ListByResourceAndRoleName(s.Ctx, uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String())
 	require.NoError(t, err)
 	require.Equal(t, 0, len(identityRoles))
 }

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -558,7 +558,7 @@ func generateEnvKey(yamlKey string) string {
 }
 
 func checkGetKeycloakEndpointSetByEnvVariableOK(t *testing.T, envName string, getEndpoint func(req *goa.RequestData) (string, error)) {
-	envValue := uuid.NewV4().String()
+	envValue := uuid.Must(uuid.NewV4()).String()
 	env := os.Getenv(envName)
 	defer func() {
 		os.Setenv(envName, env)

--- a/controller/authorize_blackbox_test.go
+++ b/controller/authorize_blackbox_test.go
@@ -46,7 +46,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeOK() {
 	redirect := "https://openshift.io"
 	clientID := rest.Configuration.GetPublicOauthClientID()
 	responseType := "code"
-	state := uuid.NewV4().String()
+	state := uuid.Must(uuid.NewV4()).String()
 	responseMode := "query"
 
 	test.AuthorizeAuthorizeTemporaryRedirect(t, svc.Context, svc, ctrl, nil, clientID, redirect, &responseMode, responseType, nil, state)
@@ -54,11 +54,11 @@ func (rest *TestAuthorizeREST) TestAuthorizeOK() {
 	state = "not-uuid"
 	test.AuthorizeAuthorizeTemporaryRedirect(t, svc.Context, svc, ctrl, nil, clientID, redirect, &responseMode, responseType, nil, state)
 
-	state = uuid.NewV4().String()
+	state = uuid.Must(uuid.NewV4()).String()
 	responseMode = "fragment"
 	test.AuthorizeAuthorizeTemporaryRedirect(t, svc.Context, svc, ctrl, nil, clientID, redirect, &responseMode, responseType, nil, state)
 
-	state = uuid.NewV4().String()
+	state = uuid.Must(uuid.NewV4()).String()
 	test.AuthorizeAuthorizeTemporaryRedirect(t, svc.Context, svc, ctrl, nil, clientID, redirect, nil, responseType, nil, state)
 }
 
@@ -73,7 +73,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeBadRequest() {
 	prms.Add("response_type", "code")
 	prms.Add("redirect_uri", "https://openshift.io/somepath")
 	prms.Add("client_id", rest.Configuration.GetPublicOauthClientID())
-	prms.Add("state", uuid.NewV4().String())
+	prms.Add("state", uuid.Must(uuid.NewV4()).String())
 
 	rest.checkInvalidRequest("authorize", "response_type", prms, u, t)
 	rest.checkInvalidRequest("authorize", "redirect_uri", prms, u, t)
@@ -88,7 +88,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeUnauthorizedError() {
 	redirect := "https://openshift.io"
 	clientID := ""
 	responseType := "code"
-	state := uuid.NewV4().String()
+	state := uuid.Must(uuid.NewV4()).String()
 
 	test.AuthorizeAuthorizeUnauthorized(t, svc.Context, svc, ctrl, nil, clientID, redirect, nil, responseType, nil, state)
 }
@@ -117,7 +117,7 @@ func (rest *TestAuthorizeREST) checkAuthorizeCallbackOK(responseMode *string) {
 	prms.Add("response_type", "code")
 	prms.Add("redirect_uri", redirectURI)
 	prms.Add("client_id", rest.Configuration.GetPublicOauthClientID())
-	prms.Add("state", uuid.NewV4().String())
+	prms.Add("state", uuid.Must(uuid.NewV4()).String())
 	if responseMode != nil {
 		prms.Add("response_mode", *responseMode)
 	}
@@ -204,7 +204,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeCallbackBadRequest() {
 
 	prms := url.Values{}
 	prms.Add("code", "SOME_OAUTH2.0_CODE")
-	prms.Add("state", uuid.NewV4().String())
+	prms.Add("state", uuid.Must(uuid.NewV4()).String())
 
 	rest.checkInvalidRequest("authorizeCallback", "code", prms, u, t)
 	rest.checkInvalidRequest("authorizeCallback", "state", prms, u, t)
@@ -224,7 +224,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeCallbackUnauthorizedError() {
 	redirectURI := "https://openshift.io/somepath"
 	prms := url.Values{}
 
-	state := uuid.NewV4().String()
+	state := uuid.Must(uuid.NewV4()).String()
 	prms.Add("response_type", "code")
 	prms.Add("redirect_uri", redirectURI)
 	prms.Add("client_id", rest.Configuration.GetPublicOauthClientID())
@@ -257,7 +257,7 @@ func (rest *TestAuthorizeREST) TestAuthorizeCallbackUnauthorizedError() {
 	}
 
 	prms = url.Values{
-		"state": {uuid.NewV4().String()},
+		"state": {uuid.Must(uuid.NewV4()).String()},
 		"code":  {"SOME_OAUTH2.0_CODE"},
 	}
 

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -88,7 +88,7 @@ func TestRunCollaboratorsREST(t *testing.T) {
 func (rest *TestCollaboratorsREST) SetupTest() {
 	rest.DBTestSuite.SetupTest()
 	rest.policy = &auth.KeycloakPolicy{
-		Name:             "TestCollaborators-" + uuid.NewV4().String(),
+		Name:             "TestCollaborators-" + uuid.Must(uuid.NewV4()).String(),
 		Type:             auth.PolicyTypeUser,
 		Logic:            auth.PolicyLogicPossitive,
 		DecisionStrategy: auth.PolicyDecisionStrategyUnanimous,
@@ -98,10 +98,10 @@ func (rest *TestCollaboratorsREST) SetupTest() {
 	testIdentity, err := testsupport.CreateTestUser(rest.DB, &testsupport.TestUserPrivate)
 	require.Nil(rest.T(), err)
 	rest.testIdentity1 = testIdentity
-	testIdentity, err = testsupport.CreateTestIdentity(rest.DB, "TestCollaborators-"+uuid.NewV4().String(), "TestCollaborators")
+	testIdentity, err = testsupport.CreateTestIdentity(rest.DB, "TestCollaborators-"+uuid.Must(uuid.NewV4()).String(), "TestCollaborators")
 	require.Nil(rest.T(), err)
 	rest.testIdentity2 = testIdentity
-	testIdentity, err = testsupport.CreateTestIdentity(rest.DB, "TestCollaborators-"+uuid.NewV4().String(), "TestCollaborators")
+	testIdentity, err = testsupport.CreateTestIdentity(rest.DB, "TestCollaborators-"+uuid.Must(uuid.NewV4()).String(), "TestCollaborators")
 	require.Nil(rest.T(), err)
 	rest.testIdentity3 = testIdentity
 	rest.spaceID = rest.createSpace()
@@ -123,7 +123,7 @@ func (rest *TestCollaboratorsREST) UnSecuredController() (*goa.Service, *Collabo
 }
 
 func (rest *TestCollaboratorsREST) UnSecuredControllerDeprovisionedUser() (*goa.Service, *CollaboratorsController) {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(rest.T(), err)
 
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", identity, &DummySpaceAuthzService{rest})
@@ -133,7 +133,7 @@ func (rest *TestCollaboratorsREST) UnSecuredControllerDeprovisionedUser() (*goa.
 func (rest *TestCollaboratorsREST) TestListCollaboratorsWithRandomSpaceIDNotFound() {
 	// given
 	svc, ctrl := rest.UnSecuredController()
-	test.ListCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), nil, nil, nil, nil)
+	test.ListCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()), nil, nil, nil, nil)
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsOK() {
@@ -284,7 +284,7 @@ func (rest *TestCollaboratorsREST) TestAddCollaboratorsWithRandomSpaceIDNotFound
 	// given
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
-	test.AddCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), uuid.NewV4().String())
+	test.AddCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()).String())
 }
 
 func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsWithRandomSpaceIDNotFound() {
@@ -292,7 +292,7 @@ func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsWithRandomSpaceIDNotF
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
 	payload := &app.AddManyCollaboratorsPayload{Data: []*app.UpdateUserID{}}
-	test.AddManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), payload)
+	test.AddManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()), payload)
 }
 
 func (rest *TestCollaboratorsREST) TestAddCollaboratorsWithWrongUserIDFormatReturnsBadRequest() {
@@ -494,16 +494,16 @@ func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsWithRandomSpaceIDNotFo
 	// given
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
-	test.RemoveCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), uuid.NewV4().String())
+	test.RemoveCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()).String())
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsWithRandomSpaceIDNotFound() {
 	// given
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
-	payload := &app.RemoveManyCollaboratorsPayload{Data: []*app.UpdateUserID{{ID: uuid.NewV4().String(), Type: idnType}}}
+	payload := &app.RemoveManyCollaboratorsPayload{Data: []*app.UpdateUserID{{ID: uuid.Must(uuid.NewV4()).String(), Type: idnType}}}
 
-	test.RemoveManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), payload)
+	test.RemoveManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()), payload)
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsWithWrongUserIDFormatReturnsBadRequest() {
@@ -601,7 +601,7 @@ func (rest *TestCollaboratorsREST) createSpace() uuid.UUID {
 	spaceCtrl := NewSpaceController(svc, rest.Application, rest.Configuration, &DummyResourceManager{})
 	require.NotNil(rest.T(), spaceCtrl)
 
-	id := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 	test.CreateSpaceOK(rest.T(), svc.Context, svc, spaceCtrl, id)
 	return id
 }
@@ -641,7 +641,7 @@ type DummyResourceManager struct {
 
 func (m *DummyResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*auth.Resource, error) {
 	if m.ResourceID == nil {
-		return &auth.Resource{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}, nil
+		return &auth.Resource{ResourceID: uuid.Must(uuid.NewV4()).String(), PermissionID: uuid.Must(uuid.NewV4()).String(), PolicyID: uuid.Must(uuid.NewV4()).String()}, nil
 	}
 	return &auth.Resource{ResourceID: *m.ResourceID, PermissionID: *m.PermissionID, PolicyID: *m.PolicyID}, nil
 }

--- a/controller/invitation_blackbox_test.go
+++ b/controller/invitation_blackbox_test.go
@@ -35,7 +35,7 @@ func (s *TestInvitationREST) SetupSuite() {
 
 	var err error
 	s.testIdentity, err = testsupport.CreateTestIdentity(s.DB,
-		"InvitationCreatorUser-"+uuid.NewV4().String(),
+		"InvitationCreatorUser-"+uuid.Must(uuid.NewV4()).String(),
 		"TestInvitation")
 	require.Nil(s.T(), err)
 }
@@ -61,12 +61,12 @@ func TestRunInvitationREST(t *testing.T) {
 func (s *TestInvitationREST) TestCreateOrganizationMemberInvitationSuccess() {
 	var err error
 
-	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.NewV4().String())
+	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "could not create organization")
 
 	service, controller := s.SecuredController(s.testIdentity)
 
-	testUsername := "jsmith" + uuid.NewV4().String()
+	testUsername := "jsmith" + uuid.Must(uuid.NewV4()).String()
 	invitee, err := testsupport.CreateTestIdentityAndUser(s.DB, testUsername, "InvitationTest")
 	require.NoError(s.T(), err, "could not create invitee user")
 	inviteeID := invitee.ID.String()
@@ -98,12 +98,12 @@ func (s *TestInvitationREST) TestCreateOrganizationMemberInvitationSuccess() {
 func (s *TestInvitationREST) TestCreateOrganizationRoleInvitationSuccess() {
 	var err error
 
-	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.NewV4().String())
+	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "could not create organization")
 
 	service, controller := s.SecuredController(s.testIdentity)
 
-	testUsername := "jsmith" + uuid.NewV4().String()
+	testUsername := "jsmith" + uuid.Must(uuid.NewV4()).String()
 	invitee, err := testsupport.CreateTestIdentityAndUser(s.DB, testUsername, "InvitationTest")
 	require.NoError(s.T(), err, "could not create invitee user")
 	inviteeID := invitee.ID.String()
@@ -144,12 +144,12 @@ func (s *TestInvitationREST) TestCreateOrganizationRoleInvitationSuccess() {
 func (s *TestInvitationREST) TestCreateOrganizationMemberInvitationUnauthorized() {
 	var err error
 
-	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.NewV4().String())
+	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "could not create organization")
 
 	service, controller := s.UnsecuredController()
 
-	testUsername := "jsmith" + uuid.NewV4().String()
+	testUsername := "jsmith" + uuid.Must(uuid.NewV4()).String()
 	invitee, err := testsupport.CreateTestIdentityAndUser(s.DB, testUsername, "InvitationTest")
 	require.NoError(s.T(), err, "could not create invitee user")
 
@@ -180,12 +180,12 @@ func (s *TestInvitationREST) TestCreateOrganizationMemberInvitationUnauthorized(
 func (s *TestInvitationREST) TestCreateOrganizationInvalidRoleInvitation() {
 	var err error
 
-	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.NewV4().String())
+	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "could not create organization")
 
 	service, controller := s.SecuredController(s.testIdentity)
 
-	testUsername := "jsmith" + uuid.NewV4().String()
+	testUsername := "jsmith" + uuid.Must(uuid.NewV4()).String()
 	invitee, err := testsupport.CreateTestIdentityAndUser(s.DB, testUsername, "InvitationTest")
 	require.NoError(s.T(), err, "could not create invitee user")
 
@@ -217,7 +217,7 @@ func (s *TestInvitationREST) TestCreateOrganizationInvalidRoleInvitation() {
 func (s *TestInvitationREST) TestCreateOrganizationInvalidUserInvitation() {
 	var err error
 
-	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.NewV4().String())
+	orgIdentity, err := testsupport.CreateTestOrganization(s.Ctx, s.DB, s.Application, s.testIdentity.ID, "Acme Corporation"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err, "could not create organization")
 
 	service, controller := s.SecuredController(s.testIdentity)

--- a/controller/organization_blackbox_test.go
+++ b/controller/organization_blackbox_test.go
@@ -26,7 +26,7 @@ func (s *TestOrganizationREST) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 	var err error
 	s.testIdentity, err = testsupport.CreateTestIdentity(s.DB,
-		"OrganizationCreatorUser-"+uuid.NewV4().String(),
+		"OrganizationCreatorUser-"+uuid.Must(uuid.NewV4()).String(),
 		"TestOrganization")
 	require.Nil(s.T(), err)
 }

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -137,7 +137,7 @@ func (c *ResourceController) Register(ctx *app.RegisterResourceContext) error {
 		if ctx.Payload.ResourceID != nil {
 			resourceID = *ctx.Payload.ResourceID
 		} else {
-			resourceID = uuid.NewV4().String()
+			resourceID = uuid.Must(uuid.NewV4()).String()
 		}
 
 		var parentResourceID *string

--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -39,7 +39,7 @@ func TestRunResourceREST(t *testing.T) {
 func (rest *TestResourceREST) SecuredController(identity account.Identity) (*goa.Service, *ResourceController) {
 	var err error
 	rest.testIdentity, err = testsupport.CreateTestIdentity(rest.DB,
-		"TestRegisterResourceCreated-"+uuid.NewV4().String(),
+		"TestRegisterResourceCreated-"+uuid.Must(uuid.NewV4()).String(),
 		"TestRegisterResourceCreated")
 	require.Nil(rest.T(), err)
 
@@ -85,7 +85,7 @@ func (rest *TestResourceREST) TestFailRegisterResourceInvalidParentResource() {
 	resourceScopes := []string{}
 
 	resourceOwnerID := rest.testIdentity.ID
-	parentResourceID := uuid.NewV4().String()
+	parentResourceID := uuid.Must(uuid.NewV4()).String()
 
 	payload := &app.RegisterResourcePayload{
 		Name:             "My new resource",
@@ -120,7 +120,7 @@ func (rest *TestResourceREST) TestRegisterResourceCreated() {
 }
 
 func (rest *TestResourceREST) TestRegisterResourceWithResourceIDSetCreated() {
-	resourceID := uuid.NewV4().String()
+	resourceID := uuid.Must(uuid.NewV4()).String()
 	resourceScopes := []string{}
 	resourceOwnerID := rest.testIdentity.ID
 
@@ -145,7 +145,7 @@ func (rest *TestResourceREST) TestRegisterResourceWithResourceIDSetCreated() {
 }
 
 func (rest *TestResourceREST) TestRegisterResourceWithInvalidResourceType() {
-	resourceID := uuid.NewV4().String()
+	resourceID := uuid.Must(uuid.NewV4()).String()
 	resourceScopes := []string{}
 	resourceOwnerID := rest.testIdentity.ID
 

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -85,12 +85,12 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesOK() {
 
 func (rest *TestResourceRolesRest) TestListAssignedRolesNotFound() {
 	svc, ctrl := rest.SecuredControllerWithIdentity(testsupport.TestIdentity)
-	test.ListAssignedResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String())
+	test.ListAssignedResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.Must(uuid.NewV4()).String())
 }
 
 func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameNotFound() {
 	svc, ctrl := rest.SecuredControllerWithIdentity(testsupport.TestIdentity)
-	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String(), uuid.NewV4().String())
+	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String())
 }
 
 func (rest *TestResourceRolesRest) TestListAssignedRolesFromInheritedOK() {
@@ -202,7 +202,7 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameFromInheritedO
 	require.True(rest.T(), rest.checkExists(*identityRoleRef2InGroup2, returnedIdentityRoles, true))
 
 	// include these as a side-test
-	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, uuid.NewV4().String())
+	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, uuid.Must(uuid.NewV4()).String())
 }
 
 func (rest *TestResourceRolesRest) checkExists(createdRole role.IdentityRole, pool *app.Identityroles, isInherited bool) bool {

--- a/controller/roles_blackbox_test.go
+++ b/controller/roles_blackbox_test.go
@@ -35,20 +35,20 @@ func (s *TestRolesRest) TestListRolesByResourceTypeOK() {
 
 	var createdRoleScopes []role.RoleScope
 
-	newResourceTypeName := uuid.NewV4().String()
+	newResourceTypeName := uuid.Must(uuid.NewV4()).String()
 	testResourceTypeRef, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, newResourceTypeName)
 	require.NoError(s.T(), err)
 
 	// create 10 roles for the above resource type
 	for i := 0; i < 10; i++ {
-		role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *testResourceTypeRef, uuid.NewV4().String())
+		role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *testResourceTypeRef, uuid.Must(uuid.NewV4()).String())
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), role)
 
 		// associate 10 different scopes for each role.
 		for j := 0; j < 10; j++ {
 
-			scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *testResourceTypeRef, uuid.NewV4().String())
+			scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *testResourceTypeRef, uuid.Must(uuid.NewV4()).String())
 			require.NoError(s.T(), err)
 			require.NotNil(s.T(), scope)
 
@@ -60,17 +60,17 @@ func (s *TestRolesRest) TestListRolesByResourceTypeOK() {
 		}
 	}
 
-	someOtherResourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.NewV4().String())
+	someOtherResourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	// Add some noise to the data, and ensure non of these are returned.
 	for i := 0; i < 3; i++ {
-		role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *someOtherResourceType, uuid.NewV4().String())
+		role, err := testsupport.CreateTestRole(s.Ctx, s.DB, *someOtherResourceType, uuid.Must(uuid.NewV4()).String())
 
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), role)
 
-		scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *someOtherResourceType, uuid.NewV4().String())
+		scope, err := testsupport.CreateTestScope(s.Ctx, s.DB, *someOtherResourceType, uuid.Must(uuid.NewV4()).String())
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), scope)
 
@@ -97,7 +97,7 @@ func (s *TestRolesRest) TestListRolesByResourceTypeBadRequest() {
 
 func (s *TestRolesRest) TestListRolesByResourceTypeNotFound() {
 	svc, ctrl := s.SecuredRolesControllerWithIdentity(testsupport.TestIdentity)
-	unknownResourceType := uuid.NewV4().String()
+	unknownResourceType := uuid.Must(uuid.NewV4()).String()
 	test.ListRolesNotFound(s.T(), s.Ctx, svc, ctrl, &unknownResourceType)
 }
 

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -130,7 +130,7 @@ func (s *TestSearchUserSearch) createTestData() []account.Identity {
 
 			ident := account.Identity{
 				User:         user,
-				Username:     usernames[i] + uuid.NewV4().String(),
+				Username:     usernames[i] + uuid.Must(uuid.NewV4()).String(),
 				ProviderType: "kc",
 			}
 			err = tr.Identities().Create(context.Background(), &ident)
@@ -146,9 +146,9 @@ func (s *TestSearchUserSearch) createTestData() []account.Identity {
 
 func (s *TestSearchUserSearch) createDifferentTestData() account.Identity {
 	user := &account.User{
-		Email:   uuid.NewV4().String(),
+		Email:   uuid.Must(uuid.NewV4()).String(),
 		Cluster: "test cluster",
-		ID:      uuid.NewV4(),
+		ID:      uuid.Must(uuid.NewV4()),
 	}
 	result, err := testsupport.CreateTestUser(s.DB, user)
 	require.NoError(s.T(), err)
@@ -157,8 +157,8 @@ func (s *TestSearchUserSearch) createDifferentTestData() account.Identity {
 
 func (s *TestSearchUserSearch) TestEmailPrivateSearchOK() {
 
-	randomName := uuid.NewV4().String()
-	email := uuid.NewV4().String()
+	randomName := uuid.Must(uuid.NewV4()).String()
+	email := uuid.Must(uuid.NewV4()).String()
 	user := account.User{
 		EmailPrivate: true,
 		FullName:     randomName,
@@ -186,12 +186,12 @@ func (s *TestSearchUserSearch) TestEmailPrivateSearchOK() {
 
 func (s *TestSearchUserSearch) TestEmailNotPrivateSearchOK() {
 
-	randomName := uuid.NewV4().String()
+	randomName := uuid.Must(uuid.NewV4()).String()
 	user := account.User{
 		EmailPrivate: false,
 		FullName:     randomName,
 		ImageURL:     "http://example.org/" + randomName + ".png",
-		Email:        uuid.NewV4().String(),
+		Email:        uuid.Must(uuid.NewV4()).String(),
 		Cluster:      "default Cluster",
 	}
 	_, err := testsupport.CreateTestUser(s.DB, &user)
@@ -291,7 +291,7 @@ func (s *TestSearchUserSearch) UnSecuredController() (*goa.Service, *SearchContr
 }
 
 func (s *TestSearchUserSearch) UnsecuredControllerDeprovisionedUser() (*goa.Service, *SearchController) {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	svc := testsupport.ServiceAsUser("Search-Service", identity)
 	ctrl := NewSearchController(svc, s.Application, s.Configuration)
@@ -299,7 +299,7 @@ func (s *TestSearchUserSearch) UnsecuredControllerDeprovisionedUser() (*goa.Serv
 }
 
 func (s *TestSearchUserSearch) SecuredController() (*goa.Service, *SearchController) {
-	identity, err := testsupport.CreateTestIdentityAndUser(s.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentityAndUser(s.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.NoError(s.T(), err)
 	svc := testsupport.ServiceAsUser("Search-Service", identity)
 	ctrl := NewSearchController(svc, s.Application, s.Configuration)

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -30,13 +30,13 @@ func TestRunSpaceREST(t *testing.T) {
 
 func (rest *TestSpaceREST) SetupTest() {
 	rest.DBTestSuite.SetupTest()
-	rest.resourceID = uuid.NewV4().String()
-	rest.permissionID = uuid.NewV4().String()
-	rest.policyID = uuid.NewV4().String()
+	rest.resourceID = uuid.Must(uuid.NewV4()).String()
+	rest.permissionID = uuid.Must(uuid.NewV4()).String()
+	rest.policyID = uuid.Must(uuid.NewV4()).String()
 }
 
 func (rest *TestSpaceREST) SecuredController() (*goa.Service, *SpaceController) {
-	identity, err := testsupport.CreateTestIdentityAndUser(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentityAndUser(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.NoError(rest.T(), err)
 
 	svc := testsupport.ServiceAsUser("Space-Service", identity)
@@ -57,7 +57,7 @@ func (rest *TestSpaceREST) UnSecuredController() (*goa.Service, *SpaceController
 }
 
 func (rest *TestSpaceREST) UnSecuredControllerWithDeprovisionedIdentity() (*goa.Service, *SpaceController) {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, uuid.Must(uuid.NewV4()).String())
 	require.NoError(rest.T(), err)
 
 	svc := testsupport.ServiceAsUser("Space-Service", identity)
@@ -72,21 +72,21 @@ func (rest *TestSpaceREST) TestFailCreateSpaceUnauthorized() {
 	// given
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4())
+	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()))
 }
 
 func (rest *TestSpaceREST) TestCreateSpaceUnauthorizedDeprovisionedUser() {
 	// given
 	svc, ctrl := rest.UnSecuredControllerWithDeprovisionedIdentity()
 	// when/then
-	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4())
+	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()))
 }
 
 func (rest *TestSpaceREST) TestCreateSpaceOK() {
 	// given
 	svc, ctrl := rest.SecuredController()
 	// when
-	_, created := test.CreateSpaceOK(rest.T(), svc.Context, svc, ctrl, uuid.NewV4())
+	_, created := test.CreateSpaceOK(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()))
 	// then
 	require.NotNil(rest.T(), created.Data)
 	assert.Equal(rest.T(), rest.resourceID, created.Data.ResourceID)
@@ -98,20 +98,20 @@ func (rest *TestSpaceREST) TestFailDeleteSpaceUnauthorized() {
 	// given
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.DeleteSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4())
+	test.DeleteSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()))
 }
 
 func (rest *TestSpaceREST) TestDeleteSpaceUnauthorizedDeprovisionedUser() {
 	// given
 	svc, ctrl := rest.UnSecuredControllerWithDeprovisionedIdentity()
 	// when/then
-	test.DeleteSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4())
+	test.DeleteSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.Must(uuid.NewV4()))
 }
 
 func (rest *TestSpaceREST) TestDeleteSpaceOK() {
 	// given
 	svc, ctrl := rest.SecuredController()
-	id := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 	// when
 	test.CreateSpaceOK(rest.T(), svc.Context, svc, ctrl, id)
 	// then
@@ -122,7 +122,7 @@ func (rest *TestSpaceREST) TestDeleteSpaceIfUserIsNotSpaceOwnerForbidden() {
 	// given
 	svcOwner, ctrlOwner := rest.SecuredController()
 	svcNotOwner, ctrlNotOwner := rest.SecuredController()
-	id := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 	// when
 	test.CreateSpaceOK(rest.T(), svcOwner.Context, svcOwner, ctrlOwner, id)
 	// then

--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -87,7 +87,7 @@ func (rest *TestTokenREST) SecuredControllerWithNonExistentIdentity() (*goa.Serv
 }
 
 func (rest *TestTokenREST) SecuredController() (*goa.Service, *TokenController) {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 	return rest.SecuredControllerWithIdentity(identity)
 }

--- a/controller/token_storage_blackbox_test.go
+++ b/controller/token_storage_blackbox_test.go
@@ -45,7 +45,7 @@ func (rest *TestTokenStorageREST) SetupTest() {
 	rest.externalTokenRepository = provider.NewExternalTokenRepository(rest.DB)
 	rest.userRepository = account.NewUserRepository(rest.DB)
 	rest.providerConfigFactory = link.NewOauthProviderFactory(rest.Configuration, rest.Application)
-	rest.dummyProviderConfigFactory = &testsupport.DummyProviderFactory{Token: uuid.NewV4().String(), Config: rest.Configuration, App: rest.Application}
+	rest.dummyProviderConfigFactory = &testsupport.DummyProviderFactory{Token: uuid.Must(uuid.NewV4()).String(), Config: rest.Configuration, App: rest.Application}
 }
 
 func (rest *TestTokenStorageREST) UnSecuredController() (*goa.Service, *TokenController) {
@@ -180,7 +180,7 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenUnauthorized() {
 }
 
 func (rest *TestTokenStorageREST) checkRetrieveExternalTokenUnauthorized(for_ string, providerName string) {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 
 	service, controller := rest.SecuredControllerWithIdentity(identity)
@@ -219,7 +219,7 @@ func (rest *TestTokenStorageREST) checkRetrieveExternalTokenUnauthorized(for_ st
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenIdentityNotPresent() {
 	// using an Identity which does not exist in the database.
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
+		ID:       uuid.Must(uuid.NewV4()),
 		Username: "TestDeveloper",
 	}
 
@@ -237,7 +237,7 @@ func (rest *TestTokenStorageREST) TestRetrieveExternalTokenPresentInDB() {
 }
 
 func (rest *TestTokenStorageREST) retrieveExternalGitHubTokenFromDBSuccess() (account.Identity, provider.ExternalToken) {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
@@ -277,7 +277,7 @@ func (rest *TestTokenStorageREST) retrieveExternalGitHubTokenFromDBSuccess() (ac
 }
 
 func (rest *TestTokenStorageREST) retrieveExternalOSOTokenFromDBSuccess() (account.Identity, provider.ExternalToken) {
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
@@ -317,7 +317,7 @@ func (rest *TestTokenStorageREST) retrieveExternalOSOTokenFromDBSuccess() (accou
 }
 
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenForDeprovisionedUserUnauthorized() {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestRetrieveExternalTokenForDeprovisionedUserUnauthorized"+uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestRetrieveExternalTokenForDeprovisionedUserUnauthorized"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	service, controller := rest.SecuredControllerWithIdentityAndDummyProviderFactory(identity)
@@ -374,7 +374,7 @@ func (rest *TestTokenStorageREST) checkRetrieveExternalTokenInvalidOnForcePullIn
 // When the ForcePull option is passed, we determine that the token is invalid.
 
 func (rest *TestTokenStorageREST) TestRetrieveExternalTokenValidOnForcePullInternalError() {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 
 	rest.checkRetrieveExternalTokenValidOnForcePullInternalError(identity, "https://github.com/a/b")
@@ -464,7 +464,7 @@ func (rest *TestTokenStorageREST) TestStatusExternalTokenUnauthorized() {
 }
 
 func (rest *TestTokenStorageREST) checkStatusExternalTokenUnauthorized(for_ string, providerName string) {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 
 	service, controller := rest.SecuredControllerWithIdentity(identity)
@@ -525,7 +525,7 @@ func (rest *TestTokenStorageREST) checkStatusExternalTokenInvalidOnForcePullInte
 // This test demonstrates that the token status works successfully without the ForcePull option
 // When the ForcePull option is passed, we determine that the token is valid.
 func (rest *TestTokenStorageREST) TestStatusExternalTokenValidOnForcePullInternalError() {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "https://github.com/a/b", "https://github.com")
 	rest.checkStatusExternalTokenValidOnForcePullInternalError(identity, "github", "https://github.com")
@@ -595,7 +595,7 @@ func (rest *TestTokenStorageREST) deleteExternalTokenOK(forResource string) {
 }
 
 func (rest *TestTokenStorageREST) deleteExternalToken(forResource string, numberOfTokens int, scenario string) {
-	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.NewV4().String(), "KC")
+	identity, err := testsupport.CreateTestIdentity(rest.DB, uuid.Must(uuid.NewV4()).String(), "KC")
 	require.Nil(rest.T(), err)
 	service, controller := rest.SecuredControllerWithIdentity(identity)
 	r := &goa.RequestData{

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -71,7 +71,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedNonUUID() {
 func (rest *TestUserREST) TestCurrentAuthorizedMissingIdentity() {
 	// given
 	jwtToken := token.New(token.SigningMethodRS256)
-	jwtToken.Claims.(token.MapClaims)["sub"] = uuid.NewV4().String()
+	jwtToken.Claims.(token.MapClaims)["sub"] = uuid.Must(uuid.NewV4()).String()
 	ctx := jwt.WithJWT(context.Background(), jwtToken)
 	// when
 	svc, userCtrl := rest.UnsecuredController()
@@ -81,7 +81,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedMissingIdentity() {
 
 func (rest *TestUserREST) TestCurrentAuthorizedOK() {
 	// given
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	// when
@@ -93,7 +93,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedOK() {
 }
 
 func (rest *TestUserREST) TestShowDeprovisionedUserFails() {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestShowDeprovisionedUserFails"+uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestShowDeprovisionedUserFails"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(rest.T(), err)
 
 	svc, userCtrl := rest.SecuredController(identity)
@@ -105,7 +105,7 @@ func (rest *TestUserREST) TestShowDeprovisionedUserFails() {
 
 func (rest *TestUserREST) TestCurrentAuthorizedOKUsingExpiredIfModifiedSinceHeader() {
 	// given
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	// when
@@ -119,7 +119,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedOKUsingExpiredIfModifiedSinceHead
 
 func (rest *TestUserREST) TestCurrentAuthorizedOKUsingExpiredIfNoneMatchHeader() {
 	// given
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	// when
@@ -133,7 +133,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedOKUsingExpiredIfNoneMatchHeader()
 
 func (rest *TestUserREST) TestCurrentAuthorizedNotModifiedUsingIfModifiedSinceHeader() {
 	// given
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	// when
@@ -146,7 +146,7 @@ func (rest *TestUserREST) TestCurrentAuthorizedNotModifiedUsingIfModifiedSinceHe
 
 func (rest *TestUserREST) TestCurrentAuthorizedNotModifiedUsingIfNoneMatchHeader() {
 	// given
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestCurrentAuthorizedOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	// when
@@ -167,8 +167,8 @@ func (rest *TestUserREST) TestPrivateEmailVisibleIfPrivate() {
 
 func (rest *TestUserREST) checkPrivateEmailVisible(emailPrivate bool) {
 	testUser := account.User{
-		ID:           uuid.NewV4(),
-		Email:        uuid.NewV4().String(),
+		ID:           uuid.Must(uuid.NewV4()),
+		Email:        uuid.Must(uuid.NewV4()).String(),
 		FullName:     "Test Developer",
 		Cluster:      "Test Cluster",
 		EmailPrivate: emailPrivate,

--- a/controller/userinfo_test.go
+++ b/controller/userinfo_test.go
@@ -47,7 +47,7 @@ func (rest *TestUserInfoREST) UnsecuredController() (*goa.Service, *UserinfoCont
 }
 
 func (rest *TestUserInfoREST) TestShowUserInfoOK() {
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestShowUserInfoOK"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(rest.DB, "userTestShowUserInfoOK"+uuid.Must(uuid.NewV4()).String())
 	require.Nil(rest.T(), err)
 
 	svc, ctrl := rest.SecuredController(identity)
@@ -81,14 +81,14 @@ func (rest *TestUserInfoREST) TestShowUserInfoFailsWithInvalidToken() {
 	require.Equal(rest.T(), err.Errors[0].Detail, fmt.Sprintf("bad token"))
 
 	// We are adding subject, but subject is not matching any of the identities that we have
-	sub := uuid.NewV4().String()
+	sub := uuid.Must(uuid.NewV4()).String()
 	jwtToken.Claims.(jwtgo.MapClaims)["sub"] = sub
 	_, err = test.ShowUserinfoUnauthorized(rest.T(), ctx, svc, ctrl)
 	require.Equal(rest.T(), err.Errors[0].Detail, fmt.Sprintf("auth token contains id %s of unknown Identity\n", sub))
 }
 
 func (rest *TestUserInfoREST) TestShowUserinfoDeprovisionedUserFails() {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestShowUserinfoDeprovisionedUserFails"+uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(rest.DB, "TestShowUserinfoDeprovisionedUserFails"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(rest.T(), err)
 
 	svc, userCtrl := rest.SecuredController(identity)
@@ -100,8 +100,8 @@ func (rest *TestUserInfoREST) TestShowUserinfoDeprovisionedUserFails() {
 
 func (rest *TestUserInfoREST) checkPrivateEmailVisible(emailPrivate bool) {
 	testUser := account.User{
-		ID:           uuid.NewV4(),
-		Email:        uuid.NewV4().String(),
+		ID:           uuid.Must(uuid.NewV4()),
+		Email:        uuid.Must(uuid.NewV4()).String(),
 		FullName:     "Test Developer",
 		Cluster:      "Test Cluster",
 		EmailPrivate: emailPrivate,

--- a/controller/users.go
+++ b/controller/users.go
@@ -303,7 +303,7 @@ func (c *UsersController) createOrUpdateUserInKeycloak(ctx *app.CreateUsersConte
 
 func (c *UsersController) createUserInDB(ctx *app.CreateUsersContext, identityID uuid.UUID) (*account.Identity, *account.User, error) {
 	log.Debug(ctx, map[string]interface{}{"identity_id": identityID, "user attributes": ctx.Payload.Data.Attributes}, "creating a new user in DB...")
-	userID := uuid.NewV4()
+	userID := uuid.Must(uuid.NewV4())
 	var err error
 
 	var user *account.User

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -66,7 +66,7 @@ func (s *UsersControllerTestSuite) UnsecuredController() (*goa.Service, *UsersCo
 }
 
 func (s *UsersControllerTestSuite) UnsecuredControllerDeprovisionedUser() (*goa.Service, *UsersController) {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, uuid.Must(uuid.NewV4()).String())
 	require.Nil(s.T(), err)
 
 	svc := testsupport.ServiceAsUser("Users-Service", identity)
@@ -154,12 +154,12 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// given
 			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser")
 			// when
-			newEmail := "TestUpdateUserOK-" + uuid.NewV4().String() + "@email.com"
+			newEmail := "TestUpdateUserOK-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 			newFullName := "TestUpdateUserOK"
 			newImageURL := "http://new.image.io/imageurl"
 			newBio := "new bio"
 			newProfileURL := "http://new.profile.url/url"
-			newCompany := "updateCompany " + uuid.NewV4().String()
+			newCompany := "updateCompany " + uuid.Must(uuid.NewV4()).String()
 			newFeatureLevel := "beta"
 			secureService, secureController := s.SecuredController(identity)
 			contextInformation := map[string]interface{}{
@@ -228,7 +228,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			t.Run("internal level allowed", func(t *testing.T) {
 				t.Run("allowed", func(t *testing.T) {
 					// given
-					_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(uuid.NewV4().String()+"user@redhat.com"), WithEmailAddressVerified(true))
+					_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(uuid.Must(uuid.NewV4()).String()+"user@redhat.com"), WithEmailAddressVerified(true))
 					// when
 					newFeatureLevel := "internal"
 					secureService, secureController := s.SecuredController(identity)
@@ -244,7 +244,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 				})
 				t.Run("not allowed", func(t *testing.T) {
 					// given non internal user
-					_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(uuid.NewV4().String()+"user@foo.com"), WithEmailAddressVerified(true))
+					_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(uuid.Must(uuid.NewV4()).String()+"user@foo.com"), WithEmailAddressVerified(true))
 					// when
 					newFeatureLevel := "internal"
 					secureService, secureController := s.SecuredController(identity)
@@ -362,7 +362,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			_, result := test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
 			// then
 			require.False(t, *result.Data.Attributes.RegistrationCompleted)
-			newUsername := identity.Username + uuid.NewV4().String()
+			newUsername := identity.Username + uuid.Must(uuid.NewV4()).String()
 			updateUsersPayload = newUpdateUsersPayload(
 				WithUpdatedUsername(newUsername),
 				WithRegistrationCompleted(true),
@@ -375,7 +375,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// given
 			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser")
 			// when
-			newEmail := "updated-" + uuid.NewV4().String() + "@email.com"
+			newEmail := "updated-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 
 			// This is the special thing we are testing - everything else
 			// has been tested in other tests.
@@ -388,7 +388,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			newImageURL := "http://new.image.io/imageurl"
 			newBio := "new bio"
 			newProfileURL := "http://new.profile.url/url"
-			newCompany := "updateCompany " + uuid.NewV4().String()
+			newCompany := "updateCompany " + uuid.Must(uuid.NewV4()).String()
 
 			secureService, secureController := s.SecuredController(identity)
 
@@ -433,7 +433,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// given
 			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser")
 			// when
-			newEmail := "TestUpdateUserUnsetVariableInContextInfo-" + uuid.NewV4().String() + "@email.com"
+			newEmail := "TestUpdateUserUnsetVariableInContextInfo-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 			newFullName := "TestUpdateUserUnsetVariableInContextInfo"
 			newImageURL := "http://new.image.io/imageurl"
 			newBio := "new bio"
@@ -499,7 +499,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// given
 			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser")
 			// when
-			newEmail := "TestUpdateUserOKWithoutContextInfo-" + uuid.NewV4().String() + "@email.com"
+			newEmail := "TestUpdateUserOKWithoutContextInfo-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 			newFullName := "TestUpdateUserOKWithoutContextInfo"
 			newImageURL := "http://new.image.io/imageurl"
 			newBio := "new bio"
@@ -743,7 +743,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 
 		t.Run("username multiple times forbidden", func(t *testing.T) {
 			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser")
-			newUsername := identity.Username + uuid.NewV4().String()
+			newUsername := identity.Username + uuid.Must(uuid.NewV4()).String()
 			secureService, secureController := s.SecuredController(identity)
 			contextInformation := map[string]interface{}{
 				"last_visited": "yesterday",
@@ -765,7 +765,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
 
 			// next attempt should fail.
-			newUsername = identity.Username + uuid.NewV4().String()
+			newUsername = identity.Username + uuid.Must(uuid.NewV4()).String()
 			updateUsersPayload = newUpdateUsersPayload(
 				WithUpdatedUsername(newUsername),
 				WithUpdatedContextInformation(contextInformation))
@@ -774,7 +774,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 
 		t.Run("internal level for non-employee", func(t *testing.T) {
 			// given
-			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(fmt.Sprintf("%s@foo.com", uuid.NewV4())), WithEmailAddressVerified(true))
+			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(fmt.Sprintf("%s@foo.com", uuid.Must(uuid.NewV4()))), WithEmailAddressVerified(true))
 			// when/then
 			newFeatureLevel := "internal"
 			secureService, secureController := s.SecuredController(identity)
@@ -784,7 +784,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 
 		t.Run("internal level for non-verified employee", func(t *testing.T) {
 			// given
-			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(fmt.Sprintf("%s@redhat.com", uuid.NewV4())), WithEmailAddressVerified(false))
+			_, identity := s.createRandomUserIdentity(t, "TestUpdateUser", WithEmailAddress(fmt.Sprintf("%s@redhat.com", uuid.Must(uuid.NewV4()))), WithEmailAddressVerified(false))
 			// when/then
 			newFeatureLevel := "internal"
 			secureService, secureController := s.SecuredController(identity)
@@ -796,7 +796,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 	s.T().Run("unauthorized", func(t *testing.T) {
 		// given
 		s.createRandomUserIdentity(t, "TestUpdateUser")
-		newEmail := "TestUpdateUserUnauthorized-" + uuid.NewV4().String() + "@email.com"
+		newEmail := "TestUpdateUserUnauthorized-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 		newFullName := "TestUpdateUserUnauthorized"
 		newImageURL := "http://new.image.io/imageurl"
 		newBio := "new bio"
@@ -821,7 +821,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 	s.T().Run("deprovisioned user cannot update user", func(t *testing.T) {
 		// given
 		svc, ctrl := s.UnsecuredControllerDeprovisionedUser()
-		newEmail := "TestUpdateUserUnauthorized-" + uuid.NewV4().String() + "@email.com"
+		newEmail := "TestUpdateUserUnauthorized-" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 		newFullName := "TestUpdateUserUnauthorized"
 		newImageURL := "http://new.image.io/imageurl"
 		newBio := "new bio"
@@ -853,7 +853,7 @@ func (s *UsersControllerTestSuite) checkIfUserDeprovisioned(id uuid.UUID, expect
 }
 
 func (s *UsersControllerTestSuite) TestDeprovisionUser() {
-	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "TestDeprovisionUser"+uuid.NewV4().String())
+	identity, err := testsupport.CreateTestIdentityAndUserWithDefaultProviderType(s.DB, "TestDeprovisionUser"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	deprovisioned := true
@@ -873,10 +873,10 @@ func (s *UsersControllerTestSuite) TestDeprovisionUser() {
 	s.checkIfUserDeprovisioned(identity.ID, true)
 
 	// Fails if unknown identity
-	test.UpdateByServiceAccountUsersNotFound(s.T(), secureService.Context, secureService, secureController, uuid.NewV4().String(), updateUsersPayload)
+	test.UpdateByServiceAccountUsersNotFound(s.T(), secureService.Context, secureService, secureController, uuid.Must(uuid.NewV4()).String(), updateUsersPayload)
 
 	// Fails if identity is not associated with any user
-	lonelyIdentity, err := testsupport.CreateLonelyTestIdentity(s.DB, "TestDeprovisionUser"+uuid.NewV4().String())
+	lonelyIdentity, err := testsupport.CreateLonelyTestIdentity(s.DB, "TestDeprovisionUser"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 	test.UpdateByServiceAccountUsersNotFound(s.T(), secureService.Context, secureService, secureController, lonelyIdentity.ID.String(), updateUsersPayload)
 
@@ -940,12 +940,12 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 		// when
 		secureService, secureController := s.SecuredController(identity)
 		updateUsersPayload := newUpdateUsersPayload(
-			WithUpdatedEmail("TestUpdateUserOK-"+uuid.NewV4().String()+"@email.com"),
+			WithUpdatedEmail("TestUpdateUserOK-"+uuid.Must(uuid.NewV4()).String()+"@email.com"),
 			WithUpdatedFullName("TestUpdateUserOK"),
 			WithUpdatedBio("new bio"),
 			WithUpdatedImageURL("http://new.image.io/imageurl"),
 			WithUpdatedURL("http://new.profile.url/url"),
-			WithUpdatedCompany("updateCompany "+uuid.NewV4().String()),
+			WithUpdatedCompany("updateCompany "+uuid.Must(uuid.NewV4()).String()),
 			WithUpdatedContextInformation(map[string]interface{}{
 				"last_visited": "yesterday",
 				"space":        "3d6dab8d-f204-42e8-ab29-cdb1c93130ad",
@@ -990,7 +990,7 @@ func (s *UsersControllerTestSuite) TestShowUserOK() {
 }
 
 func (s *UsersControllerTestSuite) TestShowDeprovisionedUsersFails() {
-	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, "TestShowDeprovisionedUsersFails"+uuid.NewV4().String())
+	identity, err := testsupport.CreateDeprovisionedTestIdentityAndUser(s.DB, "TestShowDeprovisionedUsersFails"+uuid.Must(uuid.NewV4()).String())
 	require.NoError(s.T(), err)
 
 	// User returned if no token present
@@ -1056,7 +1056,7 @@ func (s *UsersControllerTestSuite) TestShowUserNotFound() {
 	// given user
 	s.createRandomUserIdentity(s.T(), "TestShowUserNotFound")
 	// when/then
-	test.ShowUsersNotFound(s.T(), nil, nil, s.controller, uuid.NewV4().String(), nil, nil)
+	test.ShowUsersNotFound(s.T(), nil, nil, s.controller, uuid.Must(uuid.NewV4()).String(), nil, nil)
 }
 
 func (s *UsersControllerTestSuite) TestShowUserBadRequest() {
@@ -1244,11 +1244,11 @@ func WithEmailAddressVerified(verified bool) CreateUserOption {
 
 func (s *UsersControllerTestSuite) createRandomUserIdentity(t *testing.T, fullname string, options ...CreateUserOption) (account.User, account.Identity) {
 	user := account.User{
-		Email:        uuid.NewV4().String() + "primaryForUpdat7e@example.com",
+		Email:        uuid.Must(uuid.NewV4()).String() + "primaryForUpdat7e@example.com",
 		FullName:     fullname,
 		ImageURL:     "someURLForUpdate",
-		ID:           uuid.NewV4(),
-		Company:      uuid.NewV4().String() + "company",
+		ID:           uuid.Must(uuid.NewV4()),
+		Company:      uuid.Must(uuid.NewV4()).String() + "company",
 		Cluster:      "https://api.openshift.com",
 		EmailPrivate: false,                       // being explicit
 		FeatureLevel: account.DefaultFeatureLevel, // being explicit
@@ -1473,7 +1473,7 @@ func (d *dummyUserProfileService) Get(ctx context.Context, accessToken string, k
 }
 
 func (d *dummyUserProfileService) CreateOrUpdate(ctx context.Context, keycloakUserProfile *login.KeytcloakUserRequest, accessToken string, keycloakProfileURL string) (*string, bool, error) {
-	url := "https://someurl/pathinkeycloakurl/" + uuid.NewV4().String()
+	url := "https://someurl/pathinkeycloakurl/" + uuid.Must(uuid.NewV4()).String()
 	return &url, true, nil
 }
 
@@ -1544,31 +1544,31 @@ func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountForExistingUser
 	// Another call with the same email and username should fail
 	test.CreateUsersConflict(s.T(), secureService.Context, secureService, secureController, createUserPayload)
 
-	newEmail := uuid.NewV4().String() + user.Email
+	newEmail := uuid.Must(uuid.NewV4()).String() + user.Email
 	payloadWithSameUsername := newCreateUsersPayload(&newEmail, nil, nil, nil, nil, nil, &identity.Username, nil, user.ID.String(), &user.Cluster, nil, nil, nil)
 	// Another call with the same username should fail
 	test.CreateUsersConflict(s.T(), secureService.Context, secureService, secureController, payloadWithSameUsername)
 
-	newUsername := uuid.NewV4().String() + identity.Username
+	newUsername := uuid.Must(uuid.NewV4()).String() + identity.Username
 	payloadWithSameEmail := newCreateUsersPayload(&user.Email, nil, nil, nil, nil, nil, &newUsername, nil, user.ID.String(), &user.Cluster, nil, nil, nil)
 	// Another call with the same email should fail
 	test.CreateUsersConflict(s.T(), secureService.Context, secureService, secureController, payloadWithSameEmail)
 }
 
 func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountWithRequiredFieldsOnlyOK() {
-	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("testuser%s@email.com", uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("testuser%s@email.com", uuid.Must(uuid.NewV4()).String()))
 }
 
 func (s *UsersControllerTestSuite) checkCreateUserAsServiceAccountOK(email string) {
 	user := account.User{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		Email:        email,
 		Cluster:      "some cluster",
 		FeatureLevel: account.DefaultFeatureLevel,
 	}
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
-		Username: "TestDeveloper" + uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Username: "TestDeveloper" + uuid.Must(uuid.NewV4()).String(),
 		User:     user,
 	}
 
@@ -1628,13 +1628,13 @@ func (s *UsersControllerTestSuite) TestCreateUserAsNonServiceAccountUnauthorized
 
 func (s *UsersControllerTestSuite) TestCreateUserAsServiceAccountForPreviewUserIgnored() {
 	// Ignored
-	s.checkCreateUserAsServiceAccountForPreviewUserIgnored(fmt.Sprintf("%s+preview%s@redhat.com", uuid.NewV4().String(), uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountForPreviewUserIgnored(fmt.Sprintf("%s+preview%s@redhat.com", uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()))
 	s.checkCreateUserAsServiceAccountForPreviewUserIgnored("someuser+preview@redhat.com")
 
 	// Not ignored
-	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s+preview@email.com", uuid.NewV4().String()))
-	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("preview%s@redhat.com", uuid.NewV4().String()))
-	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s@redhat.com", uuid.NewV4().String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s+preview@email.com", uuid.Must(uuid.NewV4()).String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("preview%s@redhat.com", uuid.Must(uuid.NewV4()).String()))
+	s.checkCreateUserAsServiceAccountOK(fmt.Sprintf("%s@redhat.com", uuid.Must(uuid.NewV4()).String()))
 }
 
 func (s *UsersControllerTestSuite) checkCreateUserAsServiceAccountForPreviewUserIgnored(email string) {
@@ -1642,7 +1642,7 @@ func (s *UsersControllerTestSuite) checkCreateUserAsServiceAccountForPreviewUser
 
 	username := "someuser"
 	cluster := "some.cluster"
-	createUserPayload := newCreateUsersPayload(&email, nil, nil, nil, nil, nil, &username, nil, uuid.NewV4().String(), &cluster, nil, nil, nil)
+	createUserPayload := newCreateUsersPayload(&email, nil, nil, nil, nil, nil, &username, nil, uuid.Must(uuid.NewV4()).String(), &cluster, nil, nil, nil)
 
 	// With only required fields should be OK
 	_, appUser := test.CreateUsersOK(s.T(), secureService.Context, secureService, secureController, createUserPayload)

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -44,7 +44,7 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 	var entities []entity
 	hookRegistered := db.Callback().Create().Get(hookName) != nil
 	if hookRegistered {
-		hookName += "-" + uuid.NewV4().String()
+		hookName += "-" + uuid.Must(uuid.NewV4()).String()
 	}
 	db.Callback().Create().After("gorm:create").Register(hookName, func(scope *gorm.Scope) {
 		fields := scope.PrimaryFields()

--- a/login/oso_reg_app_blackbox_test.go
+++ b/login/oso_reg_app_blackbox_test.go
@@ -57,7 +57,7 @@ func (s *TestOSORegistrationAppSuite) TestInvalidTokeFails() {
 }
 
 func (s *TestOSORegistrationAppSuite) TestClientResponse() {
-	accessToken, err := token.GenerateToken(uuid.NewV4().String(), "test-oso-registration-app-user")
+	accessToken, err := token.GenerateToken(uuid.Must(uuid.NewV4()).String(), "test-oso-registration-app-user")
 	require.NoError(s.T(), err)
 
 	// Should return an error if the client failed

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -114,12 +114,12 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 
 	// UPDATE the user profile
 
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
-	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
+	testEmail := "updatedEmail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
 	testUserName := "testuserupdated"
 
 	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{

--- a/login/profile_user_blackbox_test.go
+++ b/login/profile_user_blackbox_test.go
@@ -80,13 +80,13 @@ func (s *ProfileUserBlackBoxTest) TestPATGenerated() {
 func (s *ProfileUserBlackBoxTest) TestKeycloakAddUser() {
 	// UPDATE the user profile
 
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
-	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "sbosetestusercreate" + uuid.NewV4().String()
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
+	testEmail := "updatedEmail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
+	testUserName := "sbosetestusercreate" + uuid.Must(uuid.NewV4()).String()
 	testEnabled := true
 	testEmailVerified := true
 
@@ -135,13 +135,13 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakAddUser() {
 func (s *ProfileUserBlackBoxTest) TestKeycloakUpdateExistingUser() {
 	// UPDATE the user profile
 
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
-	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "sbosetestusercreate" + uuid.NewV4().String()
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
+	testEmail := "updatedEmail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
+	testUserName := "sbosetestusercreate" + uuid.Must(uuid.NewV4()).String()
 	testEnabled := true
 	testEmailVerified := true
 
@@ -168,13 +168,13 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakUpdateExistingUser() {
 
 func (s *ProfileUserBlackBoxTest) TestCreateKeycloakUserWithDefaults() {
 
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
-	testEmail := "updatedEmail" + uuid.NewV4().String() + "@email.com"
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "sev1testsbosetestusercreate" + uuid.NewV4().String()
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
+	testEmail := "updatedEmail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
+	testUserName := "sev1testsbosetestusercreate" + uuid.Must(uuid.NewV4()).String()
 
 	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{
 		login.ImageURLAttributeName: []string{testImageURL},
@@ -197,14 +197,14 @@ func (s *ProfileUserBlackBoxTest) TestCreateKeycloakUserWithDefaults() {
 func (s *ProfileUserBlackBoxTest) TestKeycloakCreateNewUserWithExistingEmail() {
 	// UPDATE the user profile
 
-	emailToBeUpdatedFor409 := "unitestupdatedmail" + uuid.NewV4().String() + "@email.com"
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
+	emailToBeUpdatedFor409 := "unitestupdatedmail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
 	testEmail := emailToBeUpdatedFor409
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "unittestsbosetestusercreate" + uuid.NewV4().String()
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
+	testUserName := "unittestsbosetestusercreate" + uuid.Must(uuid.NewV4()).String()
 	testEnabled := true
 	testEmailVerified := true
 
@@ -228,8 +228,8 @@ func (s *ProfileUserBlackBoxTest) TestKeycloakCreateNewUserWithExistingEmail() {
 
 	// Create second user
 
-	*(testKeycloakUserData).Email = "unittestupdatedemail" + uuid.NewV4().String() + "@email.com"
-	*(testKeycloakUserData).Username = "unitestupdatedusername" + uuid.NewV4().String() + "@email.com"
+	*(testKeycloakUserData).Email = "unittestupdatedemail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	*(testKeycloakUserData).Username = "unitestupdatedusername" + uuid.Must(uuid.NewV4()).String() + "@email.com"
 
 	s.createUser(&testKeycloakUserData)
 

--- a/login/profile_user_whitebox_test.go
+++ b/login/profile_user_whitebox_test.go
@@ -76,13 +76,13 @@ func (s *ProfileUserWhiteboxTest) TestPATGenerated() {
 
 func (s *ProfileUserWhiteboxTest) TestKeycloakLoadUser() {
 
-	testFirstName := "updatedFirstNameAgainNew" + uuid.NewV4().String()
-	testLastName := "updatedLastNameNew" + uuid.NewV4().String()
-	testEmail := "updatedemail" + uuid.NewV4().String() + "@email.com"
-	testBio := "updatedBioNew" + uuid.NewV4().String()
-	testURL := "updatedURLNew" + uuid.NewV4().String()
-	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "sbosetestusercreate" + uuid.NewV4().String()
+	testFirstName := "updatedFirstNameAgainNew" + uuid.Must(uuid.NewV4()).String()
+	testLastName := "updatedLastNameNew" + uuid.Must(uuid.NewV4()).String()
+	testEmail := "updatedemail" + uuid.Must(uuid.NewV4()).String() + "@email.com"
+	testBio := "updatedBioNew" + uuid.Must(uuid.NewV4()).String()
+	testURL := "updatedURLNew" + uuid.Must(uuid.NewV4()).String()
+	testImageURL := "updatedBio" + uuid.Must(uuid.NewV4()).String()
+	testUserName := "sbosetestusercreate" + uuid.Must(uuid.NewV4()).String()
 	testEnabled := true
 	testEmailVerified := true
 

--- a/login/service.go
+++ b/login/service.go
@@ -141,7 +141,7 @@ func (keycloak *KeycloakOAuthProvider) Login(ctx *app.LoginLoginContext, config 
 	}
 
 	// First time access, redirect to oauth provider
-	generatedState := uuid.NewV4().String()
+	generatedState := uuid.Must(uuid.NewV4()).String()
 	redirectURL, err := keycloak.AuthCodeURL(ctx, ctx.Redirect, ctx.APIClient, &generatedState, nil, ctx.RequestData, config, serviceConfig)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -230,7 +230,7 @@ func (d *dummyUserProfileService) Get(ctx context.Context, accessToken string, k
 }
 
 func (d *dummyUserProfileService) CreateOrUpdate(ctx context.Context, keycloakUserProfile *KeytcloakUserRequest, accessToken string, keycloakProfileURL string) (*string, bool, error) {
-	url := "https://someurl/pathinkeycloakurl/" + uuid.NewV4().String()
+	url := "https://someurl/pathinkeycloakurl/" + uuid.Must(uuid.NewV4()).String()
 	return &url, true, nil
 }
 

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -414,7 +414,7 @@ func testMigration28(t *testing.T) {
 	require.Equal(t, "Acme Corporation (1)", resourceName)
 
 	// After update 28 it should be impossible to create organizations with duplicate names
-	orgName := "Acme" + uuid.NewV4().String()
+	orgName := "Acme" + uuid.Must(uuid.NewV4()).String()
 	_, err = sqlDB.Exec("INSERT INTO resource (resource_id, resource_type_id, name) VALUES (uuid_generate_v4(), '66659ea9-aa0a-4737-96e2-e96e615dc280', $1)", orgName)
 	require.NoError(t, err)
 

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -39,7 +39,7 @@ func (m Message) String() string {
 // that would be sent out.
 func NewUserEmailUpdated(userID string, custom map[string]interface{}) Message {
 	return Message{
-		MessageID:   uuid.NewV4(),
+		MessageID:   uuid.Must(uuid.NewV4()),
 		MessageType: "user.email.update",
 		TargetID:    userID,
 		UserID:      &userID, // in future if service accounts are allowed to update, this will be handy.

--- a/sentry/sentry_whitebox_test.go
+++ b/sentry/sentry_whitebox_test.go
@@ -51,8 +51,8 @@ func validToken(t *testing.T, identity account.Identity) context.Context {
 
 func (s *TestWhiteboxSentry) TestExtractUserInfo() {
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
-		Username: uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Username: uuid.Must(uuid.NewV4()).String(),
 	}
 
 	tests := []struct {
@@ -118,8 +118,8 @@ func (s *TestWhiteboxSentry) TestInitialize() {
 	require.NotNil(s.T(), haltSentry)
 
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
-		Username: uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Username: uuid.Must(uuid.NewV4()).String(),
 	}
 	ctx := validToken(s.T(), identity)
 

--- a/space/space_resource.go
+++ b/space/space_resource.go
@@ -165,7 +165,7 @@ func (r *GormResourceRepository) Save(ctx context.Context, p *Resource) (*Resour
 func (r *GormResourceRepository) Create(ctx context.Context, resource *Resource) (*Resource, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "spaceresource", "create"}, time.Now())
 	if resource.ID == uuid.Nil {
-		resource.ID = uuid.NewV4()
+		resource.ID = uuid.Must(uuid.NewV4())
 	}
 
 	tx := r.db.Create(resource)

--- a/space/space_resource_test.go
+++ b/space/space_resource_test.go
@@ -17,12 +17,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var testResourceID string = uuid.NewV4().String()
-var testPolicyID string = uuid.NewV4().String()
-var testPermissionID string = uuid.NewV4().String()
-var testResource2ID string = uuid.NewV4().String()
-var testPolicyID2 string = uuid.NewV4().String()
-var testPermissionID2 string = uuid.NewV4().String()
+var testResourceID string = uuid.Must(uuid.NewV4()).String()
+var testPolicyID string = uuid.Must(uuid.NewV4()).String()
+var testPermissionID string = uuid.Must(uuid.NewV4()).String()
+var testResource2ID string = uuid.Must(uuid.NewV4()).String()
+var testPolicyID2 string = uuid.Must(uuid.NewV4()).String()
+var testPermissionID2 string = uuid.Must(uuid.NewV4()).String()
 
 func TestRunResourceRepoBBTest(t *testing.T) {
 	suite.Run(t, &resourceRepoBBTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
@@ -47,7 +47,7 @@ func (test *resourceRepoBBTest) TestCreate() {
 }
 
 func (test *resourceRepoBBTest) TestLoad() {
-	expectResource(test.load(uuid.NewV4()), test.assertNotFound())
+	expectResource(test.load(uuid.Must(uuid.NewV4())), test.assertNotFound())
 	res, _ := expectResource(test.create(testResourceID, testPolicyID, testPermissionID), test.requireOk)
 
 	res2, _ := expectResource(test.load(res.ID), test.requireOk)
@@ -60,7 +60,7 @@ func (test *resourceRepoBBTest) TestExistsSpaceResource() {
 
 	t.Run("space resource exists", func(t *testing.T) {
 		// given
-		expectResource(test.load(uuid.NewV4()), test.assertNotFound())
+		expectResource(test.load(uuid.Must(uuid.NewV4())), test.assertNotFound())
 		res, _ := expectResource(test.create(testResourceID, testPolicyID, testPermissionID), test.requireOk)
 
 		err := test.repo.CheckExists(context.Background(), res.ID.String())
@@ -68,7 +68,7 @@ func (test *resourceRepoBBTest) TestExistsSpaceResource() {
 	})
 
 	t.Run("space resource doesn't exist", func(t *testing.T) {
-		err := test.repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := test.repo.CheckExists(context.Background(), uuid.Must(uuid.NewV4()).String())
 
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
@@ -77,9 +77,9 @@ func (test *resourceRepoBBTest) TestExistsSpaceResource() {
 func (test *resourceRepoBBTest) TestSaveOk() {
 	res, _ := expectResource(test.create(testResourceID, testPolicyID, testPermissionID), test.requireOk)
 
-	newResourceID := uuid.NewV4().String()
-	newPermissionID := uuid.NewV4().String()
-	newPolicyID := uuid.NewV4().String()
+	newResourceID := uuid.Must(uuid.NewV4()).String()
+	newPermissionID := uuid.Must(uuid.NewV4()).String()
+	newPolicyID := uuid.Must(uuid.NewV4()).String()
 	res.PermissionID = newPermissionID
 	res.PolicyID = newPolicyID
 	res.ResourceID = newResourceID
@@ -91,7 +91,7 @@ func (test *resourceRepoBBTest) TestSaveOk() {
 
 func (test *resourceRepoBBTest) TestSaveNew() {
 	p := space.Resource{
-		ID:           uuid.NewV4(),
+		ID:           uuid.Must(uuid.NewV4()),
 		ResourceID:   testResourceID,
 		PolicyID:     testPolicyID,
 		PermissionID: testPermissionID,
@@ -105,12 +105,12 @@ func (test *resourceRepoBBTest) TestDelete() {
 	expectResource(test.load(res.ID), test.requireOk)
 	expectResource(test.delete(res.ID), func(p *space.Resource, err error) { require.Nil(test.T(), err) })
 	expectResource(test.load(res.ID), test.assertNotFound())
-	expectResource(test.delete(uuid.NewV4()), test.assertNotFound())
+	expectResource(test.delete(uuid.Must(uuid.NewV4())), test.assertNotFound())
 	expectResource(test.delete(uuid.Nil), test.assertNotFound())
 }
 
 func (test *resourceRepoBBTest) TestLoadBySpace() {
-	expectResource(test.load(uuid.NewV4()), test.assertNotFound())
+	expectResource(test.load(uuid.Must(uuid.NewV4())), test.assertNotFound())
 	res, _ := expectResource(test.create(testResourceID, testPolicyID, testPermissionID), test.requireOk)
 
 	res2, _ := expectResource(test.loadBySpace(res.SpaceID), test.requireOk)
@@ -120,7 +120,7 @@ func (test *resourceRepoBBTest) TestLoadBySpace() {
 func (test *resourceRepoBBTest) TestLoadByDifferentSpaceFails() {
 	test.create(testResourceID, testPolicyID, testPermissionID)
 
-	_, err := expectResource(test.loadBySpace(uuid.NewV4()), test.requireErrorType(errors.NotFoundError{}))
+	_, err := expectResource(test.loadBySpace(uuid.Must(uuid.NewV4())), test.requireErrorType(errors.NotFoundError{}))
 	assert.NotNil(test.T(), err)
 }
 
@@ -160,7 +160,7 @@ func (test *resourceRepoBBTest) create(resourceID string, policyID string, permi
 		ResourceID:   resourceID,
 		PolicyID:     policyID,
 		PermissionID: permissionID,
-		SpaceID:      uuid.NewV4(),
+		SpaceID:      uuid.Must(uuid.NewV4()),
 	}
 	return func() (*space.Resource, error) {
 		r, err := test.repo.Create(context.Background(), &newResource)

--- a/test/account.go
+++ b/test/account.go
@@ -17,8 +17,8 @@ import (
 
 // TestUser only creates in memory obj for testing purposes
 var TestUser = account.User{
-	ID:       uuid.NewV4(),
-	Email:    "testdeveloper@testalm.io" + uuid.NewV4().String(),
+	ID:       uuid.Must(uuid.NewV4()),
+	Email:    "testdeveloper@testalm.io" + uuid.Must(uuid.NewV4()).String(),
 	FullName: "Test Developer",
 	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
@@ -27,24 +27,24 @@ var TestUser = account.User{
 // This TestUser2 can be used to verify that some entity created by TestUser
 // can be later updated or deleted (or not) by another user.
 var TestUser2 = account.User{
-	ID:       uuid.NewV4(),
-	Email:    "testdeveloper2@testalm.io" + uuid.NewV4().String(),
+	ID:       uuid.Must(uuid.NewV4()),
+	Email:    "testdeveloper2@testalm.io" + uuid.Must(uuid.NewV4()).String(),
 	FullName: "Test Developer 2",
 	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
 
 // TestUser only creates in memory obj for testing purposes
 var TestUser3 = account.User{
-	ID:       uuid.NewV4(),
-	Email:    uuid.NewV4().String(),
+	ID:       uuid.Must(uuid.NewV4()),
+	Email:    uuid.Must(uuid.NewV4()).String(),
 	FullName: "Test Developer",
 	Cluster:  "https://api.starter-us-east-2.openshift.com",
 }
 
 // TestUserPrivate only creates in memory obj for testing purposes
 var TestUserPrivate = account.User{
-	ID:           uuid.NewV4(),
-	Email:        uuid.NewV4().String(),
+	ID:           uuid.Must(uuid.NewV4()),
+	Email:        uuid.Must(uuid.NewV4()).String(),
 	FullName:     "Test Developer",
 	Cluster:      "https://api.starter-us-east-2.openshift.com",
 	EmailPrivate: true,
@@ -52,41 +52,41 @@ var TestUserPrivate = account.User{
 
 // TestIdentity only creates in memory obj for testing purposes
 var TestIdentity = account.Identity{
-	ID:           uuid.NewV4(),
-	Username:     "TestDeveloper" + uuid.NewV4().String(),
+	ID:           uuid.Must(uuid.NewV4()),
+	Username:     "TestDeveloper" + uuid.Must(uuid.NewV4()).String(),
 	User:         TestUser,
 	ProviderType: account.KeycloakIDP,
 }
 
 // TestObserverIdentity only creates in memory obj for testing purposes
 var TestObserverIdentity = account.Identity{
-	ID:       uuid.NewV4(),
+	ID:       uuid.Must(uuid.NewV4()),
 	Username: "TestObserver",
 	User:     TestUser,
 }
 
 // TestIdentity2 only creates in memory obj for testing purposes
 var TestIdentity2 = account.Identity{
-	ID:           uuid.NewV4(),
-	Username:     "TestDeveloper2" + uuid.NewV4().String(),
+	ID:           uuid.Must(uuid.NewV4()),
+	Username:     "TestDeveloper2" + uuid.Must(uuid.NewV4()).String(),
 	User:         TestUser2,
 	ProviderType: account.KeycloakIDP,
 }
 
 var TestOnlineRegistrationAppIdentity = account.Identity{
-	ID:       uuid.NewV4(),
+	ID:       uuid.Must(uuid.NewV4()),
 	Username: "online-registration",
 	User:     TestUser,
 }
 
 var TestNotificationIdentity = account.Identity{
-	ID:       uuid.NewV4(),
+	ID:       uuid.Must(uuid.NewV4()),
 	Username: "fabric8-notification",
 	User:     TestUser,
 }
 
 var TestTenantIdentity = account.Identity{
-	ID:       uuid.NewV4(),
+	ID:       uuid.Must(uuid.NewV4()),
 	Username: "fabric8-tenant",
 	User:     TestUser,
 }
@@ -151,8 +151,8 @@ func CreateTestIdentity(db *gorm.DB, username, providerType string) (account.Ide
 // CreateTestIdentityAndUser creates an identity & user with the given `username` in the database. For testing purpose only.
 func CreateTestIdentityAndUser(db *gorm.DB, username, providerType string) (account.Identity, error) {
 	testUser := account.User{
-		ID:       uuid.NewV4(),
-		Email:    uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    uuid.Must(uuid.NewV4()).String(),
 		FullName: "Test Developer",
 		Cluster:  "https://api.starter-us-east-2a.openshift.com",
 	}
@@ -167,8 +167,8 @@ func CreateTestIdentityAndUser(db *gorm.DB, username, providerType string) (acco
 
 func CreateDeprovisionedTestIdentityAndUser(db *gorm.DB, username string) (account.Identity, error) {
 	testUser := account.User{
-		ID:            uuid.NewV4(),
-		Email:         uuid.NewV4().String(),
+		ID:            uuid.Must(uuid.NewV4()),
+		Email:         uuid.Must(uuid.NewV4()).String(),
 		FullName:      "Test Developer " + username,
 		Cluster:       "https://api.starter-us-east-2a.openshift.com",
 		Deprovisioned: true,
@@ -207,7 +207,7 @@ func CreateTestUser(db *gorm.DB, user *account.User) (account.Identity, error) {
 	userRepository := account.NewUserRepository(db)
 	identityRepository := account.NewIdentityRepository(db)
 	identity := account.Identity{
-		Username:     uuid.NewV4().String(),
+		Username:     uuid.Must(uuid.NewV4()).String(),
 		ProviderType: account.KeycloakIDP,
 	}
 	err := models.Transactional(db, func(tx *gorm.DB) error {

--- a/test/authorization.go
+++ b/test/authorization.go
@@ -17,8 +17,8 @@ import (
 func CreateTestIdentityRole(ctx context.Context, db *gorm.DB, resourceRef resource.Resource, roleRef role.Role) (*role.IdentityRole, error) {
 
 	assignedIdentity := &account.Identity{
-		ID:           uuid.NewV4(),
-		Username:     uuid.NewV4().String(),
+		ID:           uuid.Must(uuid.NewV4()),
+		Username:     uuid.Must(uuid.NewV4()).String(),
 		ProviderType: account.KeycloakIDP,
 	}
 	identityRepository := account.NewIdentityRepository(db)
@@ -29,7 +29,7 @@ func CreateTestIdentityRole(ctx context.Context, db *gorm.DB, resourceRef resour
 	}
 
 	identityRoleRef := role.IdentityRole{
-		IdentityRoleID: uuid.NewV4(),
+		IdentityRoleID: uuid.Must(uuid.NewV4()),
 		Identity:       *assignedIdentity,
 		IdentityID:     assignedIdentity.ID,
 		Resource:       resourceRef,
@@ -48,7 +48,7 @@ func CreateTestIdentityRole(ctx context.Context, db *gorm.DB, resourceRef resour
 
 func CreateTestIdentityRoleForIdentity(ctx context.Context, db *gorm.DB, identity account.Identity, resourceRef resource.Resource, roleRef role.Role) (*role.IdentityRole, error) {
 	identityRoleRef := role.IdentityRole{
-		IdentityRoleID: uuid.NewV4(),
+		IdentityRoleID: uuid.Must(uuid.NewV4()),
 		Identity:       identity,
 		IdentityID:     identity.ID,
 		Resource:       resourceRef,
@@ -102,7 +102,7 @@ func CreateTestResource(ctx context.Context, db *gorm.DB, resourceType resourcet
 		ResourceType:     resourceType,
 		ResourceTypeID:   resourceType.ResourceTypeID,
 		Name:             name,
-		ResourceID:       uuid.NewV4().String(),
+		ResourceID:       uuid.Must(uuid.NewV4()).String(),
 		ParentResourceID: parentResourceID,
 	}
 	resourceRepository := resource.NewResourceRepository(db)
@@ -142,9 +142,9 @@ func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name strin
 	}
 
 	rts := resourcetype.ResourceTypeScope{
-		ResourceTypeScopeID: uuid.NewV4(),
+		ResourceTypeScopeID: uuid.Must(uuid.NewV4()),
 		ResourceTypeID:      resourceType.ResourceTypeID,
-		Name:                uuid.NewV4().String(),
+		Name:                uuid.Must(uuid.NewV4()).String(),
 	}
 
 	resourceTypeScopeRepo := resourcetype.NewResourceTypeScopeRepository(db)
@@ -158,7 +158,7 @@ func CreateTestScopeWithDefaultType(ctx context.Context, db *gorm.DB, name strin
 func CreateTestScope(ctx context.Context, db *gorm.DB, resourceType resourcetype.ResourceType, name string) (*resourcetype.ResourceTypeScope, error) {
 
 	rts := resourcetype.ResourceTypeScope{
-		ResourceTypeScopeID: uuid.NewV4(),
+		ResourceTypeScopeID: uuid.Must(uuid.NewV4()),
 		ResourceTypeID:      resourceType.ResourceTypeID,
 		Name:                name,
 	}
@@ -204,7 +204,7 @@ func CreateTestResourceWithDefaultType(ctx context.Context, db *gorm.DB, name st
 		ResourceType:   *resourceType,
 		ResourceTypeID: resourceType.ResourceTypeID,
 		Name:           name,
-		ResourceID:     uuid.NewV4().String(),
+		ResourceID:     uuid.Must(uuid.NewV4()).String(),
 	}
 	roleRepository := resource.NewResourceRepository(db)
 	err = roleRepository.Create(ctx, &resourceRef)
@@ -253,12 +253,12 @@ func CreateRandomIdentityRole(ctx context.Context, db *gorm.DB) (*role.IdentityR
 		return nil, err
 	}
 
-	testResource, err := CreateTestResource(ctx, db, *resourceType, uuid.NewV4().String(), nil)
+	testResource, err := CreateTestResource(ctx, db, *resourceType, uuid.Must(uuid.NewV4()).String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	testRole, err := CreateTestRole(ctx, db, *resourceType, uuid.NewV4().String())
+	testRole, err := CreateTestRole(ctx, db, *resourceType, uuid.Must(uuid.NewV4()).String())
 	if err != nil {
 		return nil, err
 	}

--- a/test/common.go
+++ b/test/common.go
@@ -7,7 +7,7 @@ import (
 
 // CreateRandomValidTestName functions creates a valid length name
 func CreateRandomValidTestName(name string) string {
-	randomName := name + uuid.NewV4().String()
+	randomName := name + uuid.Must(uuid.NewV4()).String()
 	if len(randomName) > 62 {
 		return randomName[:61]
 	}

--- a/test/login.go
+++ b/test/login.go
@@ -109,7 +109,7 @@ func WithServiceAccountAuthz(ctx context.Context, tokenManager token.Manager, id
 		Request: &http.Request{Host: "example.com"},
 	}
 	if ident.ID == uuid.Nil {
-		ident.ID = uuid.NewV4()
+		ident.ID = uuid.Must(uuid.NewV4())
 	}
 	token := tokenManager.GenerateUnsignedServiceAccountToken(r, ident.ID.String(), ident.Username)
 	return goajwt.WithJWT(ctx, token)

--- a/test/token/token.go
+++ b/test/token/token.go
@@ -79,12 +79,12 @@ func GenerateToken(identityID string, identityUsername string) (string, error) {
 func GenerateTokenWithClaims(claims map[string]interface{}) (string, error) {
 	token := jwt.New(jwt.SigningMethodRS256)
 
-	token.Claims.(jwt.MapClaims)["uuid"] = uuid.NewV4().String()
-	token.Claims.(jwt.MapClaims)["preferred_username"] = fmt.Sprintf("testUser-%s", uuid.NewV4().String())
-	token.Claims.(jwt.MapClaims)["sub"] = uuid.NewV4().String()
+	token.Claims.(jwt.MapClaims)["uuid"] = uuid.Must(uuid.NewV4()).String()
+	token.Claims.(jwt.MapClaims)["preferred_username"] = fmt.Sprintf("testUser-%s", uuid.Must(uuid.NewV4()).String())
+	token.Claims.(jwt.MapClaims)["sub"] = uuid.Must(uuid.NewV4()).String()
 
-	token.Claims.(jwt.MapClaims)["jti"] = uuid.NewV4().String()
-	token.Claims.(jwt.MapClaims)["session_state"] = uuid.NewV4().String()
+	token.Claims.(jwt.MapClaims)["jti"] = uuid.Must(uuid.NewV4()).String()
+	token.Claims.(jwt.MapClaims)["session_state"] = uuid.Must(uuid.NewV4()).String()
 	token.Claims.(jwt.MapClaims)["iat"] = time.Now().Unix()
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Unix() + 60*60*24*30
 
@@ -97,7 +97,7 @@ func GenerateTokenWithClaims(claims map[string]interface{}) (string, error) {
 	token.Claims.(jwt.MapClaims)["company"] = "Company Inc."
 	token.Claims.(jwt.MapClaims)["given_name"] = "Test"
 	token.Claims.(jwt.MapClaims)["family_name"] = "User"
-	token.Claims.(jwt.MapClaims)["email"] = fmt.Sprintf("testuser+%s@email.com", uuid.NewV4().String())
+	token.Claims.(jwt.MapClaims)["email"] = fmt.Sprintf("testuser+%s@email.com", uuid.Must(uuid.NewV4()).String())
 	token.Claims.(jwt.MapClaims)["email_verified"] = true
 
 	for key, value := range claims {

--- a/token/link/link.go
+++ b/token/link/link.go
@@ -121,7 +121,7 @@ func (service *LinkService) ProviderLocation(ctx context.Context, req *goa.Reque
 	if err != nil {
 		return "", err
 	}
-	state := uuid.NewV4().String()
+	state := uuid.Must(uuid.NewV4()).String()
 	err = oauth.SaveReferrer(ctx, service.app, state, redirectURL, nil, service.config.GetValidRedirectURLs())
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{

--- a/token/link/link_test.go
+++ b/token/link/link_test.go
@@ -145,13 +145,13 @@ func (s *LinkTestSuite) stateParam(location string) string {
 }
 
 func (s *LinkTestSuite) TestCallbackFailsForUnknownIdentity() {
-	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, uuid.NewV4().String(), "https://github.com/org/repo", "https://openshift.io/home")
+	location, err := s.linkService.ProviderLocation(context.Background(), s.requestData, uuid.Must(uuid.NewV4()).String(), "https://github.com/org/repo", "https://openshift.io/home")
 	require.Nil(s.T(), err)
 	state := s.stateParam(location)
 
-	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: uuid.NewV4().String(), Config: s.Configuration, App: s.Application})
+	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: uuid.Must(uuid.NewV4()).String(), Config: s.Configuration, App: s.Application})
 
-	code := uuid.NewV4().String()
+	code := uuid.Must(uuid.NewV4()).String()
 	_, err = linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
 	require.NotNil(s.T(), err)
 }
@@ -161,10 +161,10 @@ func (s *LinkTestSuite) TestProviderSavesTokenOK() {
 	require.Nil(s.T(), err)
 	state := s.stateParam(location)
 
-	token := uuid.NewV4().String()
+	token := uuid.Must(uuid.NewV4()).String()
 	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, App: s.Application})
 
-	code := uuid.NewV4().String()
+	code := uuid.Must(uuid.NewV4()).String()
 	callbackLocation, err := linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
 	require.Nil(s.T(), err)
 	require.Contains(s.T(), callbackLocation, "https://openshift.io/home")
@@ -177,10 +177,10 @@ func (s *LinkTestSuite) TestProviderSavesTokenWithUnavailableProfileFails() {
 	require.Nil(s.T(), err)
 	state := s.stateParam(location)
 
-	token := uuid.NewV4().String()
+	token := uuid.Must(uuid.NewV4()).String()
 	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, LoadProfileFail: true, App: s.Application})
 
-	code := uuid.NewV4().String()
+	code := uuid.Must(uuid.NewV4()).String()
 	_, err = linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, code)
 	require.NotNil(s.T(), err)
 	require.Contains(s.T(), err.Error(), "unable to load profile")
@@ -221,9 +221,9 @@ func (s *LinkTestSuite) TestProviderSavesTokensForMultipleAliases() {
 }
 
 func (s *LinkTestSuite) checkCallback(providerID string, state string, expectedURL url.URL) string {
-	token := uuid.NewV4().String()
+	token := uuid.Must(uuid.NewV4()).String()
 	linkServiceWithDummyProviderFactory := NewLinkServiceWithFactory(s.Configuration, gormapplication.NewGormDB(s.DB), &test.DummyProviderFactory{Token: token, Config: s.Configuration, App: s.Application})
-	callbackLocation, err := linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, uuid.NewV4().String())
+	callbackLocation, err := linkServiceWithDummyProviderFactory.Callback(context.Background(), s.requestData, state, uuid.Must(uuid.NewV4()).String())
 	require.Nil(s.T(), err)
 	locationURL, err := url.Parse(callbackLocation)
 	require.Nil(s.T(), err)

--- a/token/provider/external_provider_token.go
+++ b/token/provider/external_provider_token.go
@@ -100,7 +100,7 @@ func (m *GormExternalTokenRepository) CheckExists(ctx context.Context, id string
 func (m *GormExternalTokenRepository) Create(ctx context.Context, model *ExternalToken) error {
 	defer goa.MeasureSince([]string{"goa", "db", "ExternalToken", "create"}, time.Now())
 	if model.ID == uuid.Nil {
-		model.ID = uuid.NewV4()
+		model.ID = uuid.Must(uuid.NewV4())
 	}
 	err := m.db.Create(model).Error
 	if err != nil {

--- a/token/provider/external_provider_token_blackbox_test.go
+++ b/token/provider/external_provider_token_blackbox_test.go
@@ -82,7 +82,7 @@ func (s *externalTokenBlackboxTest) TestExistsExternalProvider() {
 
 	t.Run("externalToken doesn't exist", func(t *testing.T) {
 		//t.Parallel()
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.Must(uuid.NewV4()).String())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
@@ -93,7 +93,7 @@ func (s *externalTokenBlackboxTest) TestExternalProviderOKToSave() {
 	// given
 	externalToken := createAndLoadExternalToken(s)
 	// when
-	externalToken.Token = uuid.NewV4().String()
+	externalToken.Token = uuid.Must(uuid.NewV4()).String()
 	err := s.repo.Save(s.Ctx, externalToken)
 	// then
 	require.Nil(s.T(), err, "Could not update externalToken")
@@ -162,9 +162,9 @@ func (s *externalTokenBlackboxTest) TestExternalProviderOKToFilterByIdentityIDAn
 	lastTokenID := externalToken.ID // initialize
 	for i := 0; i < 10; i++ {
 		anotherExternalToken := provider.ExternalToken{
-			ID:         uuid.NewV4(),
+			ID:         uuid.Must(uuid.NewV4()),
 			ProviderID: externalToken.ProviderID,
-			Token:      uuid.NewV4().String(),
+			Token:      uuid.Must(uuid.NewV4()).String(),
 			Scope:      "user:full",
 			IdentityID: externalToken.IdentityID,
 			Username:   externalToken.Username,
@@ -193,16 +193,16 @@ func (s *externalTokenBlackboxTest) TestExternalProviderOKToFilterByIdentityIDAn
 
 func createAndLoadExternalToken(s *externalTokenBlackboxTest) *provider.ExternalToken {
 
-	identity, err := test.CreateTestIdentity(s.DB, uuid.NewV4().String(), "kc")
+	identity, err := test.CreateTestIdentity(s.DB, uuid.Must(uuid.NewV4()).String(), "kc")
 	require.Nil(s.T(), err)
 
 	externalToken := provider.ExternalToken{
-		ID:         uuid.NewV4(),
-		ProviderID: uuid.NewV4(),
-		Token:      uuid.NewV4().String(),
+		ID:         uuid.Must(uuid.NewV4()),
+		ProviderID: uuid.Must(uuid.NewV4()),
+		Token:      uuid.Must(uuid.NewV4()).String(),
 		Scope:      "user:full",
 		IdentityID: identity.ID,
-		Username:   uuid.NewV4().String(),
+		Username:   uuid.Must(uuid.NewV4()).String(),
 	}
 	fmt.Println(externalToken)
 

--- a/token/token.go
+++ b/token/token.go
@@ -389,7 +389,7 @@ func (mgm *tokenManager) GenerateUnsignedServiceAccountToken(req *goa.RequestDat
 	claims := token.Claims.(jwt.MapClaims)
 	claims["service_accountname"] = saName
 	claims["sub"] = saID
-	claims["jti"] = uuid.NewV4().String()
+	claims["jti"] = uuid.Must(uuid.NewV4()).String()
 	claims["iat"] = time.Now().Unix()
 	claims["iss"] = rest.AbsoluteURL(req, "", nil)
 	claims["scopes"] = []string{"uma_protection"}
@@ -504,7 +504,7 @@ func (mgm *tokenManager) GenerateUnsignedUserAccessToken(ctx context.Context, ke
 	}
 
 	claims := token.Claims.(jwt.MapClaims)
-	claims["jti"] = uuid.NewV4().String()
+	claims["jti"] = uuid.Must(uuid.NewV4()).String()
 	claims["exp"] = kcClaims.ExpiresAt
 	claims["nbf"] = kcClaims.NotBefore
 	claims["iat"] = kcClaims.IssuedAt
@@ -576,7 +576,7 @@ func (mgm *tokenManager) GenerateUnsignedUserAccessTokenForIdentity(ctx context.
 	}
 
 	claims := token.Claims.(jwt.MapClaims)
-	claims["jti"] = uuid.NewV4().String()
+	claims["jti"] = uuid.Must(uuid.NewV4()).String()
 	iat := time.Now().Unix()
 	claims["exp"] = iat + mgm.config.GetAccessTokenExpiresIn()
 	claims["nbf"] = 0
@@ -622,7 +622,7 @@ func (mgm *tokenManager) GenerateUnsignedUserRefreshToken(ctx context.Context, k
 		typ = "Offline"
 	}
 	claims := token.Claims.(jwt.MapClaims)
-	claims["jti"] = uuid.NewV4().String()
+	claims["jti"] = uuid.Must(uuid.NewV4()).String()
 	claims["exp"] = kcClaims.ExpiresAt
 	claims["nbf"] = kcClaims.NotBefore
 	claims["iat"] = kcClaims.IssuedAt
@@ -660,7 +660,7 @@ func (mgm *tokenManager) GenerateUnsignedUserRefreshTokenForIdentity(ctx context
 	}
 
 	claims := token.Claims.(jwt.MapClaims)
-	claims["jti"] = uuid.NewV4().String()
+	claims["jti"] = uuid.Must(uuid.NewV4()).String()
 	iat := time.Now().Unix()
 	var exp int64 // Offline tokens do not expire
 	typ := "Offline"

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -205,15 +205,15 @@ func (s *TestTokenSuite) checkConvertToken(offlineToken bool) {
 func (s *TestTokenSuite) generateToken(offlineToken bool) (*oauth2.Token, account.Identity, context.Context) {
 	ctx := testtoken.ContextWithRequest(nil)
 	user := account.User{
-		ID:       uuid.NewV4(),
-		Email:    uuid.NewV4().String(),
-		FullName: uuid.NewV4().String(),
-		Cluster:  uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Email:    uuid.Must(uuid.NewV4()).String(),
+		FullName: uuid.Must(uuid.NewV4()).String(),
+		Cluster:  uuid.Must(uuid.NewV4()).String(),
 	}
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
+		ID:       uuid.Must(uuid.NewV4()),
 		User:     user,
-		Username: uuid.NewV4().String(),
+		Username: uuid.Must(uuid.NewV4()).String(),
 	}
 	token, err := testtoken.TokenManager.GenerateUserTokenForIdentity(ctx, identity, offlineToken)
 	require.NoError(s.T(), err)
@@ -223,7 +223,7 @@ func (s *TestTokenSuite) generateToken(offlineToken bool) (*oauth2.Token, accoun
 
 func (s *TestTokenSuite) TestValidOAuthAccessToken() {
 	identity := account.Identity{
-		ID:       uuid.NewV4(),
+		ID:       uuid.Must(uuid.NewV4()),
 		Username: "testuser",
 	}
 	generatedToken, err := testtoken.GenerateToken(identity.ID.String(), identity.Username)
@@ -284,7 +284,7 @@ func (s *TestTokenSuite) TestCheckClaimsOK() {
 		Email:    "somemail@domain.com",
 		Username: "testuser",
 	}
-	claims.Subject = uuid.NewV4().String()
+	claims.Subject = uuid.Must(uuid.NewV4()).String()
 
 	assert.Nil(s.T(), token.CheckClaims(claims))
 }
@@ -293,13 +293,13 @@ func (s *TestTokenSuite) TestCheckClaimsFails() {
 	claimsNoEmail := &token.TokenClaims{
 		Username: "testuser",
 	}
-	claimsNoEmail.Subject = uuid.NewV4().String()
+	claimsNoEmail.Subject = uuid.Must(uuid.NewV4()).String()
 	assert.NotNil(s.T(), token.CheckClaims(claimsNoEmail))
 
 	claimsNoUsername := &token.TokenClaims{
 		Email: "somemail@domain.com",
 	}
-	claimsNoUsername.Subject = uuid.NewV4().String()
+	claimsNoUsername.Subject = uuid.Must(uuid.NewV4()).String()
 	assert.NotNil(s.T(), token.CheckClaims(claimsNoUsername))
 
 	claimsNoSubject := &token.TokenClaims{
@@ -310,7 +310,7 @@ func (s *TestTokenSuite) TestCheckClaimsFails() {
 }
 
 func (s *TestTokenSuite) TestLocateTokenInContex() {
-	id := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 
 	tk := jwt.New(jwt.SigningMethodRS256)
 	tk.Claims.(jwt.MapClaims)["sub"] = id.String()

--- a/token/token_whitebox_test.go
+++ b/token/token_whitebox_test.go
@@ -72,7 +72,7 @@ func (s *TestWhiteboxTokenSuite) TestServiceAccountGeneratedOK() {
 		Request: &http.Request{Host: "example.com"},
 	}
 
-	saID := uuid.NewV4().String()
+	saID := uuid.Must(uuid.NewV4()).String()
 	tokenString, err := s.tokenManager.GenerateServiceAccountToken(r, saID, "test-token")
 	require.Nil(s.T(), err)
 	s.checkServiceAccountToken(tokenString, saID, "test-token")


### PR DESCRIPTION
- WIT repo needs to upgrade goa version
- This also means upgrading go.uuid version upgrade
- go.uuid new version has changed its API to multi-value return
- This patch prepares for the dep upgrades and syncs with the new UUID API

Unblocks fabric8-services/fabric8-wit#2059
