### PR TITLE
Set maximum allowed username to 45 chars

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -129,6 +129,8 @@ const (
 	// sentry
 	varEnvironment = "environment"
 	varSentryDSN   = "sentry.dsn"
+
+	varMaxUsernameLength = "max.username.length"
 )
 
 type serviceAccountConfig struct {
@@ -607,6 +609,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 
 	// prod-preview or prod
 	c.v.SetDefault(varEnvironment, "local")
+
+	c.v.SetDefault(varMaxUsernameLength, 45)
 }
 
 // GetEmailVerifiedRedirectURL returns the url where the user would be redirected to after clicking on email
@@ -802,6 +806,11 @@ func (c *ConfigurationData) GetOpenShiftClientApiUrl() string {
 // May return empty string which means an unauthorized error should be returned instead of redirecting the user
 func (c *ConfigurationData) GetNotApprovedRedirect() string {
 	return c.v.GetString(varNotApprovedRedirect)
+}
+
+// GetMaxUsernameLength returns the maximum allowed length of the username
+func (c *ConfigurationData) GetMaxUsernameLength() int {
+	return c.v.GetInt(varMaxUsernameLength)
 }
 
 // GetKeycloakSecret returns the keycloak client secret (as set via config file or environment variable)

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -282,6 +282,22 @@ func TestGetSentryDSNOK(t *testing.T) {
 	assert.Equal(t, "something", config.GetSentryDSN())
 }
 
+func TestGetMaxUsernameLengthOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	constEnvName := "AUTH_MAX_USERNAME_LENGTH"
+	existingValue := os.Getenv(constEnvName)
+	defer func() {
+		os.Setenv(constEnvName, existingValue)
+		resetConfiguration()
+	}()
+
+	os.Unsetenv(constEnvName)
+	assert.Equal(t, 45, config.GetMaxUsernameLength())
+
+	os.Setenv(constEnvName, "7")
+	assert.Equal(t, 7, config.GetMaxUsernameLength())
+}
+
 func TestGetWITURLDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	existingWITprefix := os.Getenv("AUTH_WIT_DOMAIN_PREFIX")

--- a/controller/users.go
+++ b/controller/users.go
@@ -56,6 +56,7 @@ type UsersControllerConfiguration interface {
 	GetEmailVerifiedRedirectURL() string
 	GetInternalUsersEmailAddressSuffix() string
 	GetIgnoreEmailInProd() string
+	GetMaxUsernameLength() int
 }
 
 // NewUsersController creates a users controller.
@@ -111,6 +112,10 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 	if !isSvcAccount {
 		log.Error(ctx, nil, "The account is not an authorized service account allowed to create a new user")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("account not authorized to create users."))
+	}
+
+	if len(ctx.Payload.Data.Attributes.Username) > c.config.GetMaxUsernameLength() {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("username", ctx.Payload.Data.Attributes.Username).Expected("less than 46 characters"))
 	}
 
 	// ----- Ignore users created for Preview environment

--- a/test/account.go
+++ b/test/account.go
@@ -53,7 +53,7 @@ var TestUserPrivate = account.User{
 // TestIdentity only creates in memory obj for testing purposes
 var TestIdentity = account.Identity{
 	ID:           uuid.NewV4(),
-	Username:     "TestDeveloper" + uuid.NewV4().String(),
+	Username:     uuid.NewV4().String(),
 	User:         TestUser,
 	ProviderType: account.KeycloakIDP,
 }
@@ -68,7 +68,7 @@ var TestObserverIdentity = account.Identity{
 // TestIdentity2 only creates in memory obj for testing purposes
 var TestIdentity2 = account.Identity{
 	ID:           uuid.NewV4(),
-	Username:     "TestDeveloper2" + uuid.NewV4().String(),
+	Username:     uuid.NewV4().String(),
 	User:         TestUser2,
 	ProviderType: account.KeycloakIDP,
 }


### PR DESCRIPTION
When registration-app calls Auth service to `Create` a new user, return 400 Bad request if username is longer than 45 characters.