### PR TITLE
Add the "Assign role" API

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -4,6 +4,7 @@ import (
 	invitationservice "github.com/fabric8-services/fabric8-auth/authorization/invitation/service"
 	organizationservice "github.com/fabric8-services/fabric8-auth/authorization/organization/service"
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
 	teamservice "github.com/fabric8-services/fabric8-auth/authorization/team/service"
 )
@@ -15,4 +16,5 @@ type Services interface {
 	PermissionService() permissionservice.PermissionService
 	RoleManagementService() roleservice.RoleManagementService
 	TeamService() teamservice.TeamService
+	ResourceService() resourceservice.ResourceService
 }

--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -44,11 +44,14 @@ const (
 	// contributeSpaceScope is a general scope required to perform many space-related operations
 	contributeSpaceScope = "contribute"
 
-	// ManageTeamsScope is the scope required for users wishing to manage teams for a space
+	// ManageTeamsInSpaceScope is the scope required for users wishing to manage teams for a space
 	ManageTeamsInSpaceScope = manageSpaceScope
 
 	// ViewTeamsInSpaceScope is the scope required for users wishing to view the teams in a space
 	ViewTeamsInSpaceScope = viewSpaceScope
+
+	// ManageRoleAssignmentsInSpaceScope is the scope required for managing role assignments in a space
+	ManageRoleAssignmentsInSpaceScope = manageSpaceScope
 )
 
 // CanHaveMembers returns a boolean indicating whether the specified resource type may have member Identities
@@ -56,6 +59,22 @@ func CanHaveMembers(resourceTypeName string) bool {
 	return resourceTypeName == IdentityResourceTypeOrganization ||
 		resourceTypeName == IdentityResourceTypeTeam ||
 		resourceTypeName == IdentityResourceTypeGroup
+}
+
+// ScopeForManagingRolesInResourceType returns the name of the scope that gives a user privileges to manage roles in a resource
+func ScopeForManagingRolesInResourceType(resourceType string) string {
+	switch resourceType {
+	case ResourceTypeSpace:
+		return ManageRoleAssignmentsInSpaceScope
+	case IdentityResourceTypeOrganization:
+		return ManageMembersScope
+	case IdentityResourceTypeTeam:
+		return ManageMembersScope
+	case IdentityResourceTypeGroup:
+		return ManageMembersScope
+	}
+	// a default which we can choose to change later
+	return ManageRoleAssignmentsInSpaceScope
 }
 
 // IdentityAssociation represents an association between an Identity and either another Identity or a Resource, whether by

--- a/authorization/authorization_blackbox_test.go
+++ b/authorization/authorization_blackbox_test.go
@@ -145,3 +145,13 @@ func (s *authorizationBlackBoxTest) TestMergeAssociations() {
 		}
 	}
 }
+
+func (s *authorizationBlackBoxTest) TestScopeForManagingResourceType() {
+	require.Equal(s.T(), authorization.ScopeForManagingRolesInResourceType(authorization.ResourceTypeSpace), authorization.ManageRoleAssignmentsInSpaceScope)
+	require.Equal(s.T(), authorization.ScopeForManagingRolesInResourceType(authorization.IdentityResourceTypeOrganization), authorization.ManageMembersScope)
+	require.Equal(s.T(), authorization.ScopeForManagingRolesInResourceType(authorization.IdentityResourceTypeTeam), authorization.ManageMembersScope)
+	require.Equal(s.T(), authorization.ScopeForManagingRolesInResourceType(authorization.IdentityResourceTypeGroup), authorization.ManageMembersScope)
+
+	// test the default
+	require.Equal(s.T(), authorization.ScopeForManagingRolesInResourceType(authorization.IdentityResourceTypeUser), authorization.ManageRoleAssignmentsInSpaceScope)
+}

--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -158,7 +158,8 @@ func (m *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 func (m *GormResourceRepository) Save(ctx context.Context, resource *Resource) error {
 	defer goa.MeasureSince([]string{"goa", "db", "resource", "save"}, time.Now())
 
-	obj, err := m.Load(ctx, resource.ResourceID)
+	err := m.db.Save(resource).Error
+
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resource.ResourceID,
@@ -166,13 +167,12 @@ func (m *GormResourceRepository) Save(ctx context.Context, resource *Resource) e
 		}, "unable to update the resource")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Save(resource).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"resource_id": resource.ResourceID,
 	}, "Resource saved!")
 
-	return errs.WithStack(err)
+	return nil
 }
 
 // Delete removes a single record.

--- a/authorization/resource/service/doc.go
+++ b/authorization/resource/service/doc.go
@@ -1,0 +1,2 @@
+// Package service encapsulates the business logic for managing protected resources
+package service

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fabric8-services/fabric8-auth/app"
+	"github.com/fabric8-services/fabric8-auth/application/repository"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
+	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	"github.com/fabric8-services/fabric8-auth/errors"
+
+	"github.com/satori/go.uuid"
+)
+
+type ResourceService interface {
+	Delete(ctx context.Context, resourceID string) error
+	Read(ctx context.Context, resourceID string) (*app.Resource, error)
+	Register(ctx context.Context, resourceTypeName string, resourceID, parentResourceID *string) (*resource.Resource, error)
+}
+
+// resourceServiceImpl is the implementation of the interface for
+// ResourceService.
+type resourceServiceImpl struct {
+	repo repository.Repositories
+	tm   transaction.TransactionManager
+}
+
+// NewResourceService creates a new service.
+func NewResourceService(repo repository.Repositories, tm transaction.TransactionManager) ResourceService {
+	return &resourceServiceImpl{repo: repo, tm: tm}
+}
+
+// Delete deletes the resource with resourceID
+func (s *resourceServiceImpl) Delete(ctx context.Context, resourceID string) error {
+
+	return s.repo.ResourceRepository().Delete(ctx, resourceID)
+}
+
+// Read reads resource
+func (s *resourceServiceImpl) Read(ctx context.Context, resourceID string) (*app.Resource, error) {
+
+	res, err := s.repo.ResourceRepository().Load(ctx, resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the resource type scopes
+	scopes, err := s.repo.ResourceTypeScopeRepository().LookupForType(ctx, res.ResourceTypeID)
+	if err != nil {
+		return nil, errors.NewInternalError(ctx, err)
+	}
+
+	var scopeValues []string
+
+	for index := range scopes {
+		scopeValues = append(scopeValues, scopes[index].Name)
+	}
+
+	return &app.Resource{
+		ResourceID:       &res.ResourceID,
+		Type:             &res.ResourceType.Name,
+		ParentResourceID: res.ParentResourceID,
+		ResourceScopes:   scopeValues,
+	}, nil
+}
+
+// Register registers/creates a new resource
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (s *resourceServiceImpl) Register(ctx context.Context, resourceTypeName string, resourceID, parentResourceID *string) (*resource.Resource, error) {
+
+	var res *resource.Resource
+
+	err := transaction.Transactional(s.tm, func(tr transaction.TransactionalResources) error {
+
+		// Lookup the resource type
+		resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, resourceTypeName)
+		if err != nil {
+			return errors.NewBadParameterErrorFromString("type", resourceTypeName, err.Error())
+		}
+
+		// Lookup the parent resource if it's specified
+		var parentResource *resource.Resource
+
+		if parentResourceID != nil {
+			parentResource, err = tr.ResourceRepository().Load(ctx, *parentResourceID)
+			if err != nil {
+				return errors.NewBadParameterErrorFromString("parent resource ID", *parentResourceID, err.Error())
+			}
+		}
+
+		var rID string
+		if resourceID != nil {
+			rID = *resourceID
+		} else {
+			rID = uuid.NewV4().String()
+		}
+
+		var parentResourceID *string
+
+		if parentResource != nil {
+			parentResourceID = &parentResource.ResourceID
+		}
+
+		// Create a new resource instance
+		res = &resource.Resource{
+			ResourceID:       rID,
+			ParentResourceID: parentResourceID,
+			ResourceType:     *resourceType,
+			ResourceTypeID:   resourceType.ResourceTypeID,
+			ParentResource:   parentResource,
+		}
+
+		// Persist the resource
+		return tr.ResourceRepository().Create(ctx, res)
+	})
+
+	return res, err
+}

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -1,0 +1,111 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/authorization"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type resourceServiceBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+	resourceService resourceservice.ResourceService
+}
+
+func TestRunResourceServiceBlackBoxTest(t *testing.T) {
+	suite.Run(t, &resourceServiceBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *resourceServiceBlackBoxTest) SetupSuite() {
+	s.DBTestSuite.SetupSuite()
+	s.resourceService = resourceservice.NewResourceService(s.Application, s.Application)
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterResourceUnknownResourceTypeFails() {
+	resourceID := uuid.NewV4().String()
+	unknownResourceType := uuid.NewV4().String()
+	_, err := s.resourceService.Register(context.Background(), unknownResourceType, &resourceID, nil)
+	require.EqualError(s.T(), err, fmt.Sprintf("Bad value for parameter 'type': '%s' - resource_type with name '%s' not found", unknownResourceType, unknownResourceType))
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterResourceUnknownParentResourceFails() {
+	resourceID := uuid.NewV4().String()
+	unknownParentID := uuid.NewV4().String()
+	_, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, &unknownParentID)
+	require.EqualError(s.T(), err, fmt.Sprintf("Bad value for parameter 'parent resource ID': '%s' - resource with id '%s' not found", unknownParentID, unknownParentID))
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithoutParentOK() {
+	resourceID := uuid.NewV4().String()
+
+	// Register. No parent
+	resource, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, nil)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), resourceID, resource.ResourceID)
+	assert.Equal(s.T(), "", resource.Name)
+	assert.Equal(s.T(), "6422fda4-a0fa-4d3c-8b79-8061e5c05e12", resource.ResourceTypeID.String())
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, resource.ResourceType.Name)
+	assert.Nil(s.T(), resource.ParentResourceID)
+	assert.Nil(s.T(), resource.ParentResource)
+
+	// Read
+	r, err := s.resourceService.Read(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), r)
+	require.NotNil(s.T(), r.ResourceID)
+	assert.Equal(s.T(), resourceID, *r.ResourceID)
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, *r.Type)
+	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
+
+	// Delete
+	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK() {
+	resourceID := uuid.NewV4().String()
+
+	// With parent resource
+	g := s.DBTestSuite.NewTestGraph()
+	g.CreateResource(g.ID("myparentresource"))
+	parent := g.ResourceByID("myparentresource").Resource()
+	resource, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, &parent.ResourceID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), resourceID, resource.ResourceID)
+	assert.Equal(s.T(), "", resource.Name)
+	assert.Equal(s.T(), "6422fda4-a0fa-4d3c-8b79-8061e5c05e12", resource.ResourceTypeID.String())
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, resource.ResourceType.Name)
+	assert.NotNil(s.T(), resource.ParentResourceID)
+	assert.Equal(s.T(), parent.ResourceID, *resource.ParentResourceID)
+	require.NotNil(s.T(), resource.ParentResource)
+	assert.Equal(s.T(), parent.ResourceID, resource.ParentResource.ResourceID)
+
+	// Read
+	r, err := s.resourceService.Read(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), r)
+	require.NotNil(s.T(), r.ResourceID)
+	assert.Equal(s.T(), resourceID, *r.ResourceID)
+	require.NotNil(s.T(), r.ParentResourceID)
+	assert.Equal(s.T(), parent.ResourceID, *r.ParentResourceID)
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, *r.Type)
+	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
+
+	// Delete
+	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+}
+
+func (s *resourceServiceBlackBoxTest) TestReadUnknownResourceFails() {
+	unknownResourceID := uuid.NewV4().String()
+	_, err := s.resourceService.Read(context.Background(), unknownResourceID)
+	require.EqualError(s.T(), err, fmt.Sprintf("resource with id '%s' not found", unknownResourceID))
+}

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -66,8 +66,7 @@ func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithoutParen
 	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
 
 	// Delete
-	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
-	require.NoError(s.T(), err)
+	s.checkDeleteResource(resource.ResourceID)
 }
 
 func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK() {
@@ -100,12 +99,20 @@ func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK
 	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
 
 	// Delete
-	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
-	require.NoError(s.T(), err)
+	s.checkDeleteResource(resource.ResourceID)
 }
 
 func (s *resourceServiceBlackBoxTest) TestReadUnknownResourceFails() {
-	unknownResourceID := uuid.NewV4().String()
-	_, err := s.resourceService.Read(context.Background(), unknownResourceID)
-	require.EqualError(s.T(), err, fmt.Sprintf("resource with id '%s' not found", unknownResourceID))
+	s.checkUnknownResourceID(uuid.NewV4().String())
+}
+
+func (s *resourceServiceBlackBoxTest) checkDeleteResource(resourceID string) {
+	err := s.resourceService.Delete(context.Background(), resourceID)
+	require.NoError(s.T(), err)
+	s.checkUnknownResourceID(resourceID)
+}
+
+func (s *resourceServiceBlackBoxTest) checkUnknownResourceID(resourceID string) {
+	_, err := s.resourceService.Read(context.Background(), resourceID)
+	require.EqualError(s.T(), err, fmt.Sprintf("resource with id '%s' not found", resourceID))
 }

--- a/authorization/resourcetype/repository/resource_type.go
+++ b/authorization/resourcetype/repository/resource_type.go
@@ -69,7 +69,7 @@ func (m *GormResourceTypeRepository) Lookup(ctx context.Context, name string) (*
 	var native ResourceType
 	err := m.db.Table(m.TableName()).Where("name = ?", name).First(&native).Error
 	if err == gorm.ErrRecordNotFound {
-		return nil, errors.NewNotFoundError("resource_type", name)
+		return nil, errors.NewNotFoundErrorWithKey("resource_type", "name", name)
 	}
 	return &native, err
 }

--- a/authorization/role/repository/identity_role.go
+++ b/authorization/role/repository/identity_role.go
@@ -163,16 +163,18 @@ func (m *GormIdentityRoleRepository) Delete(ctx context.Context, id uuid.UUID) e
 
 	obj := IdentityRole{IdentityRoleID: id}
 
-	err := m.db.Delete(&obj).Error
+	db := m.db.Delete(obj)
 
-	if err != nil {
+	if db.Error != nil {
 		log.Error(ctx, map[string]interface{}{
 			"identity_role_id": id,
-			"err":              err,
+			"err":              db.Error,
 		}, "unable to delete the identity role")
-		return errs.WithStack(err)
+		return errs.WithStack(db.Error)
 	}
-
+	if db.RowsAffected == 0 {
+		return errors.NewNotFoundError("identity_role", id.String())
+	}
 	log.Debug(ctx, map[string]interface{}{
 		"identity_role_id": id,
 	}, "Identity role deleted!")

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -14,6 +14,7 @@ import (
 	errs "github.com/pkg/errors"
 
 	"context"
+	"fmt"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +63,14 @@ func (s *identityRoleBlackBoxTest) TestOKToDelete() {
 		// that none of the role objects returned include the one deleted.
 		require.NotEqual(s.T(), identityRole.IdentityRoleID.String(), data.IdentityRoleID.String())
 	}
+}
+
+func (s *identityRoleBlackBoxTest) TestDeleteUnknownFails() {
+	identityRoleID := uuid.NewV4()
+
+	err := s.repo.Delete(s.Ctx, identityRoleID)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), fmt.Sprintf("identity_role with id '%s' not found", identityRoleID), err.Error())
 }
 
 func (s *identityRoleBlackBoxTest) TestOKToLoad() {

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -183,20 +183,20 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResource() {
 
 func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByIdentityAndResource() {
 	g := s.DBTestSuite.NewTestGraph()
-	newSpace := g.CreateSpace(g.ID("myspace"))
+	newSpace := g.CreateSpace()
 
 	var createdIdentities []uuid.UUID
 
 	for i := 0; i <= 10; i++ {
-		user := g.CreateUser(g.ID("foo"))
+		user := g.CreateUser()
 		newSpace.AddAdmin(user)
 		createdIdentities = append(createdIdentities, user.Identity().ID)
 	}
 
 	// noise
 	for i := 0; i <= 10; i++ {
-		g.CreateSpace(g.ID("myspace")).AddAdmin(g.CreateUser(g.ID("somename")))
-		newSpace.AddContributor(g.CreateUser(g.ID("someothername")))
+		g.CreateSpace().AddAdmin(g.CreateUser())
+		newSpace.AddContributor(g.CreateUser())
 	}
 
 	for _, i := range createdIdentities {
@@ -210,7 +210,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByIdentityAndResource() 
 
 func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownIdentity() {
 	g := s.DBTestSuite.NewTestGraph()
-	newSpace := g.CreateSpace(g.ID("myspace"))
+	newSpace := g.CreateSpace()
 
 	knownRoleID := getKnownRoleIDForSpace(s)
 
@@ -226,8 +226,8 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownIdentity() {
 
 func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownRole() {
 	g := s.DBTestSuite.NewTestGraph()
-	newSpace := g.CreateSpace(g.ID("myspace"))
-	existingUser := g.CreateUser(g.ID("somename"))
+	newSpace := g.CreateSpace()
+	existingUser := g.CreateUser()
 
 	ir := role.IdentityRole{
 		IdentityRoleID: uuid.NewV4(),
@@ -242,7 +242,7 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownRole() {
 func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownResource() {
 	g := s.DBTestSuite.NewTestGraph()
 
-	existingUser := g.CreateUser(g.ID("somename"))
+	existingUser := g.CreateUser()
 	knownRoleID := getKnownRoleIDForSpace(s)
 
 	ir := role.IdentityRole{
@@ -258,9 +258,9 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownResource() {
 func (s *identityRoleBlackBoxTest) TestCreateIdentityExistingAssignmentFails() {
 	g := s.DBTestSuite.NewTestGraph()
 
-	existingUser := g.CreateUser(g.ID("somename"))
+	existingUser := g.CreateUser()
 	knownRoleID := getKnownRoleIDForSpace(s)
-	newSpace := g.CreateSpace(g.ID("myspace"))
+	newSpace := g.CreateSpace()
 
 	ir := role.IdentityRole{
 		IdentityRoleID: uuid.NewV4(),

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"github.com/fabric8-services/fabric8-auth/authorization"
 	"testing"
 
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
@@ -10,7 +11,9 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
+	errs "github.com/pkg/errors"
 
+	"context"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,6 +179,111 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResource() {
 
 	require.Len(s.T(), identityRoles, 1)
 	require.Equal(s.T(), identityRole.IdentityRoleID, identityRoles[0].IdentityRoleID)
+}
+
+func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByIdentityAndResource() {
+	g := s.DBTestSuite.NewTestGraph()
+	newSpace := g.CreateSpace(g.ID("myspace"))
+
+	var createdIdentities []uuid.UUID
+
+	for i := 0; i <= 10; i++ {
+		user := g.CreateUser(g.ID("foo"))
+		newSpace.AddAdmin(user)
+		createdIdentities = append(createdIdentities, user.Identity().ID)
+	}
+
+	// noise
+	for i := 0; i <= 10; i++ {
+		g.CreateSpace(g.ID("myspace")).AddAdmin(g.CreateUser(g.ID("somename")))
+		newSpace.AddContributor(g.CreateUser(g.ID("someothername")))
+	}
+
+	for _, i := range createdIdentities {
+		result, err := s.repo.FindIdentityRolesByIdentityAndResource(context.Background(), newSpace.SpaceID(), i)
+		require.NoError(s.T(), err)
+		require.Len(s.T(), result, 1)
+		require.Equal(s.T(), i, result[0].IdentityID)
+		require.Equal(s.T(), newSpace.SpaceID(), result[0].ResourceID)
+	}
+}
+
+func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownIdentity() {
+	g := s.DBTestSuite.NewTestGraph()
+	newSpace := g.CreateSpace(g.ID("myspace"))
+
+	knownRoleID := getKnownRoleIDForSpace(s)
+
+	ir := role.IdentityRole{
+		IdentityRoleID: uuid.NewV4(),
+		IdentityID:     uuid.NewV4(), // unknown identity
+		ResourceID:     newSpace.SpaceID(),
+		RoleID:         knownRoleID,
+	}
+	err := s.repo.Create(context.Background(), &ir)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+}
+
+func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownRole() {
+	g := s.DBTestSuite.NewTestGraph()
+	newSpace := g.CreateSpace(g.ID("myspace"))
+	existingUser := g.CreateUser(g.ID("somename"))
+
+	ir := role.IdentityRole{
+		IdentityRoleID: uuid.NewV4(),
+		IdentityID:     existingUser.Identity().ID,
+		ResourceID:     newSpace.SpaceID(),
+		RoleID:         uuid.NewV4(), // unknown role
+	}
+	err := s.repo.Create(context.Background(), &ir)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+}
+
+func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownResource() {
+	g := s.DBTestSuite.NewTestGraph()
+
+	existingUser := g.CreateUser(g.ID("somename"))
+	knownRoleID := getKnownRoleIDForSpace(s)
+
+	ir := role.IdentityRole{
+		IdentityRoleID: uuid.NewV4(),
+		IdentityID:     existingUser.Identity().ID,
+		ResourceID:     uuid.NewV4().String(),
+		RoleID:         knownRoleID,
+	}
+	err := s.repo.Create(context.Background(), &ir)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+}
+
+func (s *identityRoleBlackBoxTest) TestCreateIdentityExistingAssignmentFails() {
+	g := s.DBTestSuite.NewTestGraph()
+
+	existingUser := g.CreateUser(g.ID("somename"))
+	knownRoleID := getKnownRoleIDForSpace(s)
+	newSpace := g.CreateSpace(g.ID("myspace"))
+
+	ir := role.IdentityRole{
+		IdentityRoleID: uuid.NewV4(),
+		IdentityID:     existingUser.Identity().ID,
+		ResourceID:     newSpace.SpaceID(),
+		RoleID:         knownRoleID,
+	}
+	err := s.repo.Create(context.Background(), &ir)
+	require.NoError(s.T(), err)
+
+	ir.IdentityRoleID = uuid.NewV4()
+	err = s.repo.Create(context.Background(), &ir)
+	require.IsType(s.T(), errors.DataConflictError{}, errs.Cause(err))
+}
+
+func getKnownRoleIDForSpace(s *identityRoleBlackBoxTest) uuid.UUID {
+	roles, err := s.roleRepo.FindRolesByResourceType(context.Background(), authorization.ResourceTypeSpace)
+	require.Nil(s.T(), err)
+	require.Len(s.T(), roles, 3)
+
+	knownRoleID, err := uuid.FromString(roles[0].RoleID)
+	require.Nil(s.T(), err)
+	return knownRoleID
 }
 
 func createAndLoadIdentityRole(s *identityRoleBlackBoxTest) *role.IdentityRole {

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -66,20 +66,9 @@ func (r *RoleManagementServiceImpl) Assign(ctx context.Context, assignedBy uuid.
 	// check if the current user token belongs to a user who has the necessary privileges
 	// for assigning roles to other users.
 	permissionService := permservice.NewPermissionService(r.repo)
-	hasScope, err := permissionService.HasScope(ctx, assignedBy, resourceID, authorization.ScopeForManagingRolesInResourceType(rt.Name))
+	err = permissionService.RequireScope(ctx, assignedBy, resourceID, authorization.ScopeForManagingRolesInResourceType(rt.Name))
 	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"resource_id": resourceID,
-			"identity_id": assignedBy,
-		}, "error determining if user may manage roles for resource")
 		return err
-	}
-	if !hasScope {
-		log.Error(ctx, map[string]interface{}{
-			"resource_id": resourceID,
-			"identity_id": assignedBy,
-		}, "user not authorized to assign roles")
-		return errors.NewForbiddenError("user is not authorized to assign roles")
 	}
 
 	// Valid all the roles and user identity IDs, and ensure each user has been previously assigned

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -2,9 +2,16 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"github.com/fabric8-services/fabric8-auth/application/repository"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
+	"github.com/fabric8-services/fabric8-auth/authorization"
+	permservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	"github.com/fabric8-services/fabric8-auth/authorization/role"
 	rolerepo "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/satori/go.uuid"
 )
 
 // RoleManagementService defines the service contract for managing role assignments
@@ -12,16 +19,18 @@ type RoleManagementService interface {
 	ListByResource(ctx context.Context, resourceID string) ([]rolerepo.IdentityRole, error)
 	ListAvailableRolesByResourceType(ctx context.Context, resourceType string) ([]role.RoleDescriptor, error)
 	ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]rolerepo.IdentityRole, error)
+	Assign(ctx context.Context, assignedBy uuid.UUID, identitiesToBeAssigned []uuid.UUID, resourceID string, roleName string) error
 }
 
 // NewRoleManagementService creates a new service to manage role assignments
-func NewRoleManagementService(repo repository.Repositories) *RoleManagementServiceImpl {
-	return &RoleManagementServiceImpl{repo: repo}
+func NewRoleManagementService(repo repository.Repositories, tm transaction.TransactionManager) *RoleManagementServiceImpl {
+	return &RoleManagementServiceImpl{repo: repo, tm: tm}
 }
 
 // RoleManagementServiceImpl implements the RoleManagementService to manage role assignments
 type RoleManagementServiceImpl struct {
 	repo repository.Repositories
+	tm   transaction.TransactionManager
 }
 
 // ListByResourceAndRoleName lists role assignments of a specific resource.
@@ -37,4 +46,95 @@ func (r *RoleManagementServiceImpl) ListByResource(ctx context.Context, resource
 // ListAvailableRolesByResourceType lists role assignments of a specific resource.
 func (r *RoleManagementServiceImpl) ListAvailableRolesByResourceType(ctx context.Context, resourceType string) ([]role.RoleDescriptor, error) {
 	return r.repo.RoleRepository().FindRolesByResourceType(ctx, resourceType)
+}
+
+// assign assigns an identity ( users or organizations or teams or groups ) with a role, for a specific resource
+func (r *RoleManagementServiceImpl) assign(ctx context.Context, identityID uuid.UUID, resourceID string, roleRef rolerepo.Role) error {
+
+	ir := rolerepo.IdentityRole{
+		ResourceID: resourceID,
+		IdentityID: identityID,
+		RoleID:     roleRef.RoleID,
+	}
+
+	return r.repo.IdentityRoleRepository().Create(ctx, &ir)
+}
+
+// Assign assigns an identity ( users or organizations or teams or groups ) with a role, for a specific resource
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (r *RoleManagementServiceImpl) Assign(ctx context.Context, assignedBy uuid.UUID, identitiesToBeAssigned []uuid.UUID, resourceID string, roleName string) error {
+
+	rt, err := r.repo.ResourceRepository().Load(ctx, resourceID)
+
+	if err != nil {
+		return err
+	}
+
+	roleRef, err := r.repo.RoleRepository().Lookup(ctx, roleName, rt.ResourceType.Name)
+	if err != nil {
+		return err
+	}
+
+	// check if the current user token belongs to a user who has the necessary privileges
+	// for assigning roles to other users.
+
+	permissionService := permservice.NewPermissionService(r.repo)
+	hasScope, err := permissionService.HasScope(ctx, assignedBy, resourceID, authorization.ScopeForManagingRolesInResourceType(rt.Name))
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": resourceID,
+			"identity_id": assignedBy,
+			"role":        roleName,
+		}, "error determining if user has manage scope")
+		return err
+	}
+	if !hasScope {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": resourceID,
+			"identity_id": assignedBy,
+			"role":        roleName,
+		}, "user not authorizied to assign roles")
+		return errors.NewForbiddenError("user is not authorized to assign roles")
+	}
+
+	// In batch assignment of roles all selected users must have previously been assigned
+	// privileges for the resource, otherwise the invitation workflow should be used instead
+	for _, identityIDAsUUID := range identitiesToBeAssigned {
+		assignedRoles, err := r.repo.IdentityRoleRepository().FindIdentityRolesByIdentityAndResource(ctx, resourceID, identityIDAsUUID)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"resource_id": resourceID,
+				"identity_id": assignedBy,
+				"role":        roleName,
+			}, "error looking up existing assignments")
+			return err
+		}
+		if len(assignedRoles) == 0 {
+			log.Error(ctx, map[string]interface{}{
+				"resource_id": resourceID,
+				"identity_id": identityIDAsUUID,
+				"role":        roleName,
+			}, "identity not part of a resource cannot be assigned a role")
+			return errors.NewBadParameterErrorFromString("identityID", identityIDAsUUID, fmt.Sprintf("cannot update roles for an identity %s without an existing role", identityIDAsUUID))
+		}
+	}
+
+	err = transaction.Transactional(r.tm, func(tr transaction.TransactionalResources) error {
+		// Now that we have confirmed that all users have pre-existing role assignments
+		// we can proceed with the assignment of roles.
+		for _, identityIDAsUUID := range identitiesToBeAssigned {
+			err = r.assign(ctx, identityIDAsUUID, resourceID, *roleRef)
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"resource_id": resourceID,
+					"identity_id": identityIDAsUUID,
+					"role":        roleName,
+				}, "assignment failed")
+				return err
+			}
+		}
+		return nil
+	})
+
+	return err
 }

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -3,16 +3,12 @@ package controller
 import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
-	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
-	resourceType "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/token"
 
-	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
 )
 
 // ResourceController implements the resource resource.
@@ -34,19 +30,12 @@ func (c *ResourceController) Delete(ctx *app.DeleteResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		// Delete the resource
-		error := tr.ResourceRepository().Delete(ctx, ctx.ResourceID)
-
-		log.Debug(ctx, map[string]interface{}{
-			"resource_id": ctx.ResourceID,
-		}, "Deleted resource.")
-
-		return error
-	})
-
+	svc := c.app.ResourceService()
+	err := svc.Delete(ctx, ctx.ResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": ctx.ResourceID,
+		}, "unable to delete resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
@@ -61,42 +50,16 @@ func (c *ResourceController) Read(ctx *app.ReadResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	var res *resource.Resource
-	var scopes []resourceType.ResourceTypeScope
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		var error error
-		// Load the resource
-		res, error = tr.ResourceRepository().Load(ctx, ctx.ResourceID)
-
-		if error != nil {
-			return error
-		}
-
-		// Load the resource type scopes
-		scopes, error = tr.ResourceTypeScopeRepository().LookupForType(ctx, res.ResourceTypeID)
-
-		return error
-	})
-
+	svc := c.app.ResourceService()
+	res, err := svc.Read(ctx, ctx.ResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": ctx.ResourceID,
+		}, "unable to read resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	var scopeValues []string
-
-	for index := range scopes {
-		scopeValues = append(scopeValues, scopes[index].Name)
-	}
-
-	return ctx.OK(&app.Resource{
-		ResourceID:       &res.ResourceID,
-		Type:             res.ResourceType.Name,
-		Name:             res.Name,
-		ParentResourceID: res.ParentResourceID,
-		ResourceScopes:   scopeValues,
-	})
+	return ctx.OK(res)
 }
 
 // Register runs the register action.
@@ -107,136 +70,14 @@ func (c *ResourceController) Register(ctx *app.RegisterResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	var res *resource.Resource
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		// Lookup the resource type
-		resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, ctx.Payload.Type)
-		if err != nil {
-			return errors.NewBadParameterError("type", ctx.Payload.Type)
-		}
-
-		// Lookup the parent resource if one has been specified
-		var parentResource *resource.Resource
-
-		if ctx.Payload.ParentResourceID != nil {
-
-			parentResource, err = tr.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"err":                err,
-					"parent_resource_id": ctx.Payload.ParentResourceID,
-				}, "Parent resource could not be found.")
-
-				return errors.NewBadParameterError("invalid parent resource ID specified", err)
-			}
-		}
-
-		var resourceID string
-		if ctx.Payload.ResourceID != nil {
-			resourceID = *ctx.Payload.ResourceID
-		} else {
-			resourceID = uuid.NewV4().String()
-		}
-
-		var parentResourceID *string
-
-		if parentResource != nil {
-			parentResourceID = &parentResource.ResourceID
-		}
-
-		// Create the new resource instance
-		res = &resource.Resource{
-			ResourceID:       resourceID,
-			Name:             ctx.Payload.Name,
-			ParentResourceID: parentResourceID,
-			ResourceType:     *resourceType,
-			ResourceTypeID:   resourceType.ResourceTypeID,
-		}
-
-		// Persist the resource
-		return tr.ResourceRepository().Create(ctx, res)
-	})
-
+	svc := c.app.ResourceService()
+	res, err := svc.Register(ctx, ctx.Payload.Type, ctx.Payload.ResourceID, ctx.Payload.ParentResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_type": ctx.Payload.Type,
+		}, "unable to register resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	var parentResourceID string
-	if res.ParentResourceID != nil {
-		parentResourceID = *res.ParentResourceID
-	} else {
-		parentResourceID = ""
-	}
-
-	log.Debug(ctx, map[string]interface{}{
-		"resource_id":        res.ResourceID,
-		"parent_resource_id": parentResourceID,
-		"resource_type":      res.ResourceType.Name,
-	}, "resource registered")
-
-	return ctx.Created(&app.RegisterResource{ID: &res.ResourceID})
-}
-
-// Update runs the update action.
-func (c *ResourceController) Update(ctx *app.UpdateResourceContext) error {
-
-	if !token.IsServiceAccount(ctx) {
-		log.Error(ctx, map[string]interface{}{}, "Unable to register resource. Not a service account")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
-	}
-
-	var res *resource.Resource
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-		var error error
-		res, error = tr.ResourceRepository().Load(ctx, ctx.ResourceID)
-		if error != nil {
-			return error
-		}
-
-		// If a name attribute has been passed in, update the resource name
-		if ctx.Payload.Name != nil {
-			res.Name = *ctx.Payload.Name
-		}
-
-		// If a type attribute has been passed in, update the resource type
-		if ctx.Payload.Type != nil {
-			resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, *ctx.Payload.Type)
-			if err != nil {
-				return errors.NewBadParameterError("type", ctx.Payload.Type)
-			}
-			res.ResourceTypeID = resourceType.ResourceTypeID
-		}
-
-		// If a parent resource ID has been passed in, update the parent resource
-		if ctx.Payload.ParentResourceID != nil {
-			if *ctx.Payload.ParentResourceID != "" {
-				// If a parent ID has been specified, lookup the parent resource
-				parentResource, err := tr.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
-				if err != nil {
-					log.Error(ctx, map[string]interface{}{
-						"err":                err,
-						"parent_resource_id": *ctx.Payload.ParentResourceID,
-					}, "Parent resource could not be found.")
-
-					return errors.NewBadParameterError("invalid parent resource ID specified", err)
-				}
-
-				res.ParentResourceID = &parentResource.ResourceID
-			} else {
-				res.ParentResourceID = nil
-			}
-
-		}
-
-		return tr.ResourceRepository().Save(ctx, res)
-	})
-
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, err)
-	}
-
-	return ctx.OK(&app.RegisterResource{ID: &res.ResourceID})
+	return ctx.Created(&app.RegisterResourceResponse{ResourceID: &res.ResourceID})
 }

--- a/controller/resource_roles.go
+++ b/controller/resource_roles.go
@@ -120,7 +120,7 @@ func (c *ResourceRolesController) AssignRole(ctx *app.AssignRoleResourceRolesCon
 			}
 		}
 	}
-	err = c.app.RoleManagementService().Assign(ctx, *currentUser, roleAssignments, ctx.ResourceID)
+	err = c.app.RoleManagementService().Assign(ctx, *currentUser, roleAssignments, ctx.ResourceID, false)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/controller/resource_roles.go
+++ b/controller/resource_roles.go
@@ -101,21 +101,23 @@ func (c *ResourceRolesController) AssignRole(ctx *app.AssignRoleResourceRolesCon
 	}
 
 	roleAssignments := make(map[string][]uuid.UUID)
-	//var identitiesToBeAssigned []uuid.UUID
 	for _, assignment := range ctx.Payload.Data {
-		identityIDAsUUID, err := uuid.FromString(assignment.ID)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"resource_id": ctx.ResourceID,
-				"identity_id": assignment.ID,
-				"role":        assignment.Role,
-			}, "invalid identity ID")
-			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("identity", assignment.ID).Expected("uuid"))
-		}
-		if ids, found := roleAssignments[assignment.Role]; found {
-			roleAssignments[assignment.Role] = append(ids, identityIDAsUUID)
-		} else {
-			roleAssignments[assignment.Role] = []uuid.UUID{identityIDAsUUID}
+		for _, id := range assignment.Ids {
+
+			identityIDAsUUID, err := uuid.FromString(id)
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"resource_id": ctx.ResourceID,
+					"identity_id": id,
+					"role":        assignment.Role,
+				}, "invalid identity ID")
+				return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("ids", id).Expected("uuid"))
+			}
+			if ids, found := roleAssignments[assignment.Role]; found {
+				roleAssignments[assignment.Role] = append(ids, identityIDAsUUID)
+			} else {
+				roleAssignments[assignment.Role] = []uuid.UUID{identityIDAsUUID}
+			}
 		}
 	}
 	err = c.app.RoleManagementService().Assign(ctx, *currentUser, roleAssignments, ctx.ResourceID)

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -47,7 +47,7 @@ func TestRunResourceRolesRest(t *testing.T) {
 
 func (rest *TestResourceRolesRest) TestListAssignedRolesOK() {
 
-	// Create a role for the inbuild resource type
+	// Create a role for the inbuilt resource type
 	// Create a resource of the inbuilt resource type
 	// Create two assignments for that role.
 

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"github.com/fabric8-services/fabric8-auth/authorization"
 	"testing"
 
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
@@ -26,7 +27,17 @@ func (s *TestResourceRolesRest) SetupSuite() {
 }
 
 func (rest *TestResourceRolesRest) SecuredControllerWithIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
-	svc := testsupport.ServiceAsUser("Resource-roles-Service", testsupport.TestIdentity)
+	svc := testsupport.ServiceAsUser("Resource-roles-Service", identity)
+	return svc, NewResourceRolesController(svc, rest.Application)
+}
+
+func (rest *TestResourceRolesRest) SecuredControllerWithIncompleteIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
+	svc := testsupport.ServiceAsUserWithIncompleteClaims("Resource-roles-Service", identity)
+	return svc, NewResourceRolesController(svc, rest.Application)
+}
+
+func (rest *TestResourceRolesRest) UnSecuredController() (*goa.Service, *ResourceRolesController) {
+	svc := testsupport.UnsecuredService("Resource-roles-Service")
 	return svc, NewResourceRolesController(svc, rest.Application)
 }
 
@@ -203,6 +214,158 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameFromInheritedO
 
 	// include these as a side-test
 	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), rest.Ctx, svc, ctrl, resourceRef.ResourceID, uuid.NewV4().String())
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleOK() {
+
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	var identitiesToBeAssigned []*app.UpdateUserID
+	for i := 0; i <= 10; i++ {
+		testUser := g.CreateUser(g.ID("someusername"))
+		res.AddViewer(testUser)
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: testUser.Identity().ID.String()})
+	}
+
+	// Create a user who has the privileges to assign roles
+	adminUser := g.CreateUser("adminuser")
+	res.AddAdmin(adminUser)
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesNoContent(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleConflict() {
+
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	testUser := g.CreateUser(g.ID("someusername"))
+	res.AddViewer(testUser)
+
+	// Create a user who has the privileges to assign roles
+	adminUser := g.CreateUser("adminuser")
+	res.AddAdmin(adminUser)
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: []*app.UpdateUserID{
+			{
+				ID:   testUser.Identity().ID.String(),
+				Type: "identities",
+			},
+		},
+	}
+
+	test.AssignRoleResourceRolesNoContent(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+	test.AssignRoleResourceRolesConflict(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleUnauthorized() {
+	svc, ctrl := rest.UnSecuredController()
+	payload := app.AssignRoleResourceRolesPayload{
+		Data: []*app.UpdateUserID{},
+	}
+	test.AssignRoleResourceRolesUnauthorized(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String(), uuid.NewV4().String(), &payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleBadRequestUserNotInSpace() {
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	var identitiesToBeAssigned []*app.UpdateUserID
+
+	// some already have roles assigned
+	for i := 0; i <= 2; i++ {
+		testUser := g.CreateUser(g.ID("someusername"))
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: testUser.Identity().ID.String()})
+		res.AddViewer(testUser)
+	}
+
+	// while others don't have any role assigned.
+	for i := 0; i <= 2; i++ {
+		testUser := g.CreateUser(g.ID("someusername"))
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: testUser.Identity().ID.String()})
+	}
+
+	// Create a user who has the privileges to assign roles
+	adminUser := g.CreateUser("adminuser")
+	res.AddAdmin(adminUser)
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesBadRequest(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleForbiddenNotAllowedToAssignRoles() {
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	var identitiesToBeAssigned []*app.UpdateUserID
+	for i := 0; i <= 2; i++ {
+		testUser := g.CreateUser(g.ID("someusername"))
+		res.AddViewer(testUser)
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: testUser.Identity().ID.String()})
+	}
+
+	// Create a user who has the privileges to assign roles
+	adminUser := g.CreateUser("adminuser")
+	res.AddContributor(adminUser) //not really an admin
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesForbidden(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleWithInvalidIdentityIDBadRequest() {
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	var identitiesToBeAssigned []*app.UpdateUserID
+	for i := 0; i <= 2; i++ {
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: uuid.NewV4().String() + "#$%"})
+	}
+
+	// Create a user who has the privileges to assign roles
+	adminUser := g.CreateUser("adminuser")
+	res.AddAdmin(adminUser)
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesBadRequest(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleWithIncompleteTokenClaims() {
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace(g.ID("somespacename"))
+
+	var identitiesToBeAssigned []*app.UpdateUserID
+	for i := 0; i <= 2; i++ {
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.UpdateUserID{Type: "identities", ID: uuid.NewV4().String() + "#$%"})
+	}
+	adminUser := g.CreateUser("adminuser")
+	res.AddContributor(adminUser) //not really an admin
+
+	svc, ctrl := rest.SecuredControllerWithIncompleteIdentity(*adminUser.Identity())
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesUnauthorized(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), authorization.SpaceContributorRole, payload)
 }
 
 func (rest *TestResourceRolesRest) checkExists(createdRole role.IdentityRole, pool *app.Identityroles, isInherited bool) bool {

--- a/design/resource.go
+++ b/design/resource.go
@@ -16,9 +16,9 @@ var _ = a.Resource("resource", func() {
 			a.POST(""),
 		)
 		a.Description("Register a new resource")
-		a.Payload(ResourceMedia)
+		a.Payload(RegisterResourceMedia)
 		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.Created, RegisterResourceMedia)
+		a.Response(d.Created, RegisterResourceResponseMedia)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -38,24 +38,6 @@ var _ = a.Resource("resource", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
-	a.Action("update", func() {
-		a.Routing(
-			a.PATCH("/:resourceId"),
-		)
-		a.Params(func() {
-			a.Param("resourceId", d.String, "Identifier of the resource to update")
-		})
-		a.Description("Update the details of the specified resource")
-		a.Payload(UpdateResourceMedia)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.Forbidden, JSONAPIErrors)
-		a.Response(d.TemporaryRedirect)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-		a.Response(d.OK, RegisterResourceMedia)
 	})
 
 	a.Action("delete", func() {
@@ -80,43 +62,40 @@ var _ = a.Resource("resource", func() {
 var ResourceMedia = a.MediaType("application/vnd.resource+json", func() {
 	a.Description("A Protected Resource")
 	a.Attributes(func() {
-		a.Attribute("resource_owner_id", d.String, "Identifier for the owner of the resource")
 		a.Attribute("resource_scopes", a.ArrayOf(d.String), "The valid scopes for this resource")
-		a.Attribute("name", d.String, "The name of the resource")
 		a.Attribute("type", d.String, "The type of resource")
 		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs")
 		a.Attribute("resource_id", d.String, "The identifier for this resource. If left blank, one will be generated")
-		a.Required("resource_owner_id", "name", "type")
 	})
 	a.View("default", func() {
 		a.Attribute("resource_scopes")
-		a.Attribute("name")
 		a.Attribute("type")
 		a.Attribute("parent_resource_id")
 		a.Attribute("resource_id")
 	})
 })
 
-var UpdateResourceMedia = a.MediaType("application/vnd.update_resource+json", func() {
-	a.Description("Payload for updating a resource")
+var RegisterResourceMedia = a.MediaType("application/vnd.register_resource+json", func() {
+	a.Description("Payload for registering a resource")
 	a.Attributes(func() {
-		a.Attribute("resource_owner_id", d.String, "Identifier for the owner of the resource")
-		a.Attribute("resource_scopes", a.ArrayOf(d.String), "The valid scopes for this resource")
-		a.Attribute("name", d.String, "The name of the resource")
 		a.Attribute("type", d.String, "The type of resource")
 		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs")
+		a.Attribute("resource_id", d.String, "The identifier for this resource. If left blank, one will be generated")
+		a.Required("type")
 	})
 	a.View("default", func() {
-		a.Attribute("name")
+		a.Attribute("type")
+		a.Attribute("parent_resource_id")
+		a.Attribute("resource_id")
 	})
 })
 
-var RegisterResourceMedia = a.MediaType("application/vnd.register_resource+json", func() {
+var RegisterResourceResponseMedia = a.MediaType("application/vnd.register_resource_response+json", func() {
 	a.Description("Response returned when a resource is registered")
 	a.Attributes(func() {
-		a.Attribute("_id", d.String, "The identifier for the registered resource")
+		a.Attribute("resource_id", d.String, "The identifier for the registered resource")
 	})
 	a.View("default", func() {
-		a.Attribute("_id")
+		a.Attribute("resource_id")
 	})
 })

--- a/design/role.go
+++ b/design/role.go
@@ -22,6 +22,7 @@ var _ = a.Resource("roles", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
+
 })
 
 var rolesMedia = a.MediaType("application/vnd.roles+json", func() {
@@ -69,6 +70,21 @@ var _ = a.Resource("resource_roles", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("assignRole", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PATCH("/:resourceID/roles/:roleName"),
+		)
+		a.Payload(updateUserIDList) // should refactor this variable's name in collaborators design definition too.
+		a.Description("Assigns a role to a identity, for a specific resource")
+		a.Response(d.NoContent)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 })
 

--- a/design/role.go
+++ b/design/role.go
@@ -129,6 +129,6 @@ var assignRoleArray = a.MediaType("application/vnd.assign-role-array+json", func
 
 var assignRoleData = a.Type("AssignRoleData", func() {
 	a.Attribute("role", d.String, "name of the role to assign")
-	a.Attribute("id", d.String, "identity id to assign role to")
-	a.Required("role", "id")
+	a.Attribute("ids", a.ArrayOf(d.String), "identity ids to assign role to")
+	a.Required("role", "ids")
 })

--- a/design/role.go
+++ b/design/role.go
@@ -22,7 +22,6 @@ var _ = a.Resource("roles", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
-
 })
 
 var rolesMedia = a.MediaType("application/vnd.roles+json", func() {
@@ -74,7 +73,7 @@ var _ = a.Resource("resource_roles", func() {
 	a.Action("assignRole", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:resourceID/roles"),
+			a.PUT("/:resourceID/roles"),
 		)
 		a.Payload(assignRoleArray) // should refactor this variable's name in collaborators design definition too.
 		a.Description("Assigns roles to one or more identities, for a specific resource")
@@ -119,7 +118,6 @@ var assignRoleArray = a.MediaType("application/vnd.assign-role-array+json", func
 	a.Attributes(func() {
 		a.Attribute("data", a.ArrayOf(assignRoleData))
 		a.Required("data")
-
 	})
 	a.View("default", func() {
 		a.Attribute("data")

--- a/design/role.go
+++ b/design/role.go
@@ -74,10 +74,10 @@ var _ = a.Resource("resource_roles", func() {
 	a.Action("assignRole", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:resourceID/roles/:roleName"),
+			a.PATCH("/:resourceID/roles"),
 		)
-		a.Payload(updateUserIDList) // should refactor this variable's name in collaborators design definition too.
-		a.Description("Assigns a role to a identity, for a specific resource")
+		a.Payload(assignRoleArray) // should refactor this variable's name in collaborators design definition too.
+		a.Description("Assigns roles to one or more identities, for a specific resource")
 		a.Response(d.NoContent)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -110,4 +110,25 @@ var identityRolesData = a.Type("identityRolesData", func() {
 	a.Attribute("inherited_from", d.String, "The ID of the resource from this role was inherited")
 
 	a.Required("role_name", "assignee_id", "assignee_type", "inherited")
+})
+
+var assignRoleArray = a.MediaType("application/vnd.assign-role-array+json", func() {
+	a.UseTrait("jsonapi-media-type")
+	a.TypeName("AssignRoleArray")
+	a.Description("Role Assignment Array")
+	a.Attributes(func() {
+		a.Attribute("data", a.ArrayOf(assignRoleData))
+		a.Required("data")
+
+	})
+	a.View("default", func() {
+		a.Attribute("data")
+		a.Required("data")
+	})
+})
+
+var assignRoleData = a.Type("AssignRoleData", func() {
+	a.Attribute("role", d.String, "name of the role to assign")
+	a.Attribute("id", d.String, "identity id to assign role to")
+	a.Required("role", "id")
 })

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,7 +11,7 @@ import (
 const (
 	stBadParameterErrorMsg         = "Bad value for parameter '%s': '%v' - %s"
 	stBadParameterErrorExpectedMsg = "Bad value for parameter '%s': '%v' (expected: '%v') - %s"
-	stNotFoundErrorMsg             = "%s with id '%s' not found"
+	stNotFoundErrorMsg             = "%s with %s '%s' not found"
 )
 
 // Constants that can be used to identify internal server errors
@@ -203,16 +203,22 @@ type ConversionError struct {
 // NotFoundError means the object specified for the operation does not exist
 type NotFoundError struct {
 	entity string
-	ID     string
+	key    string
+	value  string
 }
 
 func (err NotFoundError) Error() string {
-	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.ID)
+	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.key, err.value)
 }
 
 // NewNotFoundError returns the custom defined error of type NewNotFoundError.
-func NewNotFoundError(entity string, id string) NotFoundError {
-	return NotFoundError{entity: entity, ID: id}
+func NewNotFoundError(entity string, value string) NotFoundError {
+	return NotFoundError{entity: entity, key: "id", value: value}
+}
+
+// NewNotFoundErrorWithKey returns the custom defined error of type NewNotFoundError and custom key name (instead of the default 'ID")
+func NewNotFoundErrorWithKey(entity string, key, value string) NotFoundError {
+	return NotFoundError{entity: entity, key: key, value: value}
 }
 
 // IsNotFoundError returns true if the cause of the given error can be

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -154,8 +154,8 @@ func (err BadParameterError) Error() string {
 }
 
 // Expected sets the optional expectedValue parameter on the BadParameterError
-func (err BadParameterError) Expected(expexcted interface{}) BadParameterError {
-	err.expectedValue = expexcted
+func (err BadParameterError) Expected(expected interface{}) BadParameterError {
+	err.expectedValue = expected
 	err.hasExpectedValue = true
 	return err
 }

--- a/errors/errors_blackbox_test.go
+++ b/errors/errors_blackbox_test.go
@@ -51,6 +51,9 @@ func TestNewNotFoundError(t *testing.T) {
 	value := "10"
 	err := errors.NewNotFoundError(param, value)
 	assert.Equal(t, fmt.Sprintf("%s with id '%s' not found", param, value), err.Error())
+
+	err = errors.NewNotFoundErrorWithKey(param, "name", value)
+	assert.Equal(t, fmt.Sprintf("%s with name '%s' not found", param, value), err.Error())
 }
 
 func TestNewUnauthorizedError(t *testing.T) {

--- a/errors/errors_whitebox_test.go
+++ b/errors/errors_whitebox_test.go
@@ -28,6 +28,6 @@ func TestBadParameterError_Error(t *testing.T) {
 func TestNotFoundError_Error(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	e := NotFoundError{entity: "foo", ID: "bar"}
-	assert.Equal(t, fmt.Sprintf(stNotFoundErrorMsg, e.entity, e.ID), e.Error())
+	e := NotFoundError{entity: "foo", key: "id", value: "bar"}
+	assert.Equal(t, fmt.Sprintf(stNotFoundErrorMsg, e.entity, e.key, e.value), e.Error())
 }

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -5,12 +5,14 @@ import (
 	"strconv"
 
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/fabric8-services/fabric8-auth/auth"
 	invitation "github.com/fabric8-services/fabric8-auth/authorization/invitation/repository"
 	invitationservice "github.com/fabric8-services/fabric8-auth/authorization/invitation/service"
 	organizationservice "github.com/fabric8-services/fabric8-auth/authorization/organization/service"
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
@@ -18,7 +20,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/space"
 	"github.com/fabric8-services/fabric8-auth/token/provider"
 
-	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 )
@@ -142,6 +143,10 @@ func (g *GormDB) RoleManagementService() roleservice.RoleManagementService {
 
 func (g *GormDB) TeamService() teamservice.TeamService {
 	return teamservice.NewTeamService(g, g)
+}
+
+func (g *GormDB) ResourceService() resourceservice.ResourceService {
+	return resourceservice.NewResourceService(g, g)
 }
 
 func (g *GormBase) DB() *gorm.DB {

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -138,7 +138,7 @@ func (g *GormDB) PermissionService() permissionservice.PermissionService {
 }
 
 func (g *GormDB) RoleManagementService() roleservice.RoleManagementService {
-	return roleservice.NewRoleManagementService(g)
+	return roleservice.NewRoleManagementService(g, g)
 }
 
 func (g *GormDB) TeamService() teamservice.TeamService {

--- a/test/error.go
+++ b/test/error.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func AssertError(t require.TestingT, actualError error, expectedType interface{}, expectedMsgAndArgs ...interface{}) {
+	require.Error(t, actualError)
+	assert.IsType(t, expectedType, errors.Cause(actualError))
+	assert.Equal(t, messageFromMsgAndArgs(expectedMsgAndArgs...), actualError.Error())
+}
+
+func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+	if len(msgAndArgs) == 0 || msgAndArgs == nil {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		return msgAndArgs[0].(string)
+	}
+	if len(msgAndArgs) > 1 {
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+	return ""
+}


### PR DESCRIPTION
replaces #399 
```
PUT /api/resources/:resourceID/roles
Authorization: Bearer <AccessToken>
{
  "data": [
    { "role": "admin", "ids": ["<identityID1>"] },
    { "role": "contributor", "ids": ["<identityID2>", "<identityID3>"] },
    ...
  ]
}
```
fixes #398 
