### PR TITLE
WIP - Set ID of dev identity explicitly

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -124,11 +124,13 @@ func (c *TokenController) Generate(ctx *app.GenerateTokenContext) error {
 	if len(identities) == 0 {
 		// Dev user doesn't exist yet. Let's create it.
 		devUser := account.User{
+			ID:            uuid.NewV4(),
 			EmailVerified: true,
 			FullName:      "OSIO Developer",
 			Email:         "osio-developer@email.com",
 		}
 		devIdentity = account.Identity{
+			ID:                    uuid.NewV4(),
 			User:                  devUser,
 			Username:              devUsername,
 			ProviderType:          account.KeycloakIDP,

--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -296,6 +296,9 @@ func (rest *TestTokenREST) TestGenerateOK() {
 	_, result := test.GenerateTokenOK(rest.T(), svc.Context, svc, ctrl)
 	require.Len(rest.T(), result, 1)
 	validateToken(rest.T(), result[0])
+	claims, err := testtoken.TokenManager.ParseToken(context.Background(), *result[0].Token.AccessToken)
+	require.NoError(rest.T(), err)
+	require.NotEqual(rest.T(), "00000000-00000000-00000000-00000000", claims.Subject)
 }
 
 func validateToken(t *testing.T, token *app.AuthToken) {


### PR DESCRIPTION
To ensure that the identity/user created in WIT has a matching+valid ID.

DO NOT MERGE : trying out a few things with @surajssd to make authorization work with WIT.

