### PR TITLE
Reorganize resource management

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -4,6 +4,7 @@ import (
 	invitationservice "github.com/fabric8-services/fabric8-auth/authorization/invitation/service"
 	organizationservice "github.com/fabric8-services/fabric8-auth/authorization/organization/service"
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
 	teamservice "github.com/fabric8-services/fabric8-auth/authorization/team/service"
 )
@@ -15,4 +16,5 @@ type Services interface {
 	PermissionService() permissionservice.PermissionService
 	RoleManagementService() roleservice.RoleManagementService
 	TeamService() teamservice.TeamService
+	ResourceService() resourceservice.ResourceService
 }

--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -158,7 +158,8 @@ func (m *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 func (m *GormResourceRepository) Save(ctx context.Context, resource *Resource) error {
 	defer goa.MeasureSince([]string{"goa", "db", "resource", "save"}, time.Now())
 
-	obj, err := m.Load(ctx, resource.ResourceID)
+	err := m.db.Save(resource).Error
+
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resource.ResourceID,
@@ -166,13 +167,12 @@ func (m *GormResourceRepository) Save(ctx context.Context, resource *Resource) e
 		}, "unable to update the resource")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Save(resource).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"resource_id": resource.ResourceID,
 	}, "Resource saved!")
 
-	return errs.WithStack(err)
+	return nil
 }
 
 // Delete removes a single record.

--- a/authorization/resource/service/doc.go
+++ b/authorization/resource/service/doc.go
@@ -1,0 +1,2 @@
+// Package service encapsulates the business logic for managing protected resources
+package service

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -16,7 +16,6 @@ type ResourceService interface {
 	Delete(ctx context.Context, resourceID string) error
 	Read(ctx context.Context, resourceID string) (*app.Resource, error)
 	Register(ctx context.Context, resourceType string, resourceID, parentResourceID *string) (*resource.Resource, error)
-	Update(ctx context.Context, resourceID, parentResourceID string) (*resource.Resource, error)
 }
 
 // resourceServiceImpl is the implementation of the interface for
@@ -112,34 +111,6 @@ func (s *resourceServiceImpl) Register(ctx context.Context, resourceType string,
 
 		// Persist the resource
 		return tr.ResourceRepository().Create(ctx, res)
-	})
-
-	return res, err
-}
-
-// Update updates the resource.
-// Only parent resource ID update is currently supported.
-// If parentResourceID == "" then the parent resource ID will be set to nil.
-// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
-func (s *resourceServiceImpl) Update(ctx context.Context, resourceID, parentResourceID string) (*resource.Resource, error) {
-
-	var res *resource.Resource
-
-	err := transaction.Transactional(s.tm, func(tr transaction.TransactionalResources) error {
-		var err error
-		res, err = tr.ResourceRepository().Load(ctx, resourceID)
-		if err != nil {
-			return err
-		}
-
-		// Update the parent resource
-		// If an empty string then set to nil
-		if parentResourceID == "" {
-			res.ParentResourceID = nil
-		} else {
-			res.ParentResourceID = &parentResourceID
-		}
-		return tr.ResourceRepository().Save(ctx, res)
 	})
 
 	return res, err

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -1,0 +1,146 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fabric8-services/fabric8-auth/app"
+	"github.com/fabric8-services/fabric8-auth/application/repository"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
+	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	"github.com/fabric8-services/fabric8-auth/errors"
+
+	"github.com/satori/go.uuid"
+)
+
+type ResourceService interface {
+	Delete(ctx context.Context, resourceID string) error
+	Read(ctx context.Context, resourceID string) (*app.Resource, error)
+	Register(ctx context.Context, resourceType string, resourceID, parentResourceID *string) (*resource.Resource, error)
+	Update(ctx context.Context, resourceID, parentResourceID string) (*resource.Resource, error)
+}
+
+// resourceServiceImpl is the implementation of the interface for
+// ResourceService.
+type resourceServiceImpl struct {
+	repo repository.Repositories
+	tm   transaction.TransactionManager
+}
+
+// NewResourceService creates a new service.
+func NewResourceService(repo repository.Repositories, tm transaction.TransactionManager) ResourceService {
+	return &resourceServiceImpl{repo: repo, tm: tm}
+}
+
+// Delete deletes the resource with resourceID
+func (s *resourceServiceImpl) Delete(ctx context.Context, resourceID string) error {
+
+	return s.repo.ResourceRepository().Delete(ctx, resourceID)
+}
+
+// Read reads resource
+func (s *resourceServiceImpl) Read(ctx context.Context, resourceID string) (*app.Resource, error) {
+
+	res, err := s.repo.ResourceRepository().Load(ctx, resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the resource type scopes
+	scopes, err := s.repo.ResourceTypeScopeRepository().LookupForType(ctx, res.ResourceTypeID)
+	if err != nil {
+		return nil, errors.NewInternalError(ctx, err)
+	}
+
+	var scopeValues []string
+
+	for index := range scopes {
+		scopeValues = append(scopeValues, scopes[index].Name)
+	}
+
+	return &app.Resource{
+		ResourceID:       &res.ResourceID,
+		Type:             &res.ResourceType.Name,
+		ParentResourceID: res.ParentResourceID,
+		ResourceScopes:   scopeValues,
+	}, nil
+}
+
+// Register registers/creates a new resource
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (s *resourceServiceImpl) Register(ctx context.Context, resourceType string, resourceID, parentResourceID *string) (*resource.Resource, error) {
+
+	var res *resource.Resource
+
+	err := transaction.Transactional(s.tm, func(tr transaction.TransactionalResources) error {
+
+		// Lookup the resource type
+		resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, resourceType)
+		if err != nil {
+			return errors.NewBadParameterError("type", resourceType)
+		}
+
+		// Lookup the parent resource if it's specified
+		var parentResource *resource.Resource
+
+		if parentResourceID != nil {
+			parentResource, err = tr.ResourceRepository().Load(ctx, *parentResourceID)
+			if err != nil {
+				return errors.NewBadParameterErrorFromString("parent resource ID", *parentResourceID, err.Error())
+			}
+		}
+
+		var rID string
+		if resourceID != nil {
+			rID = *resourceID
+		} else {
+			rID = uuid.NewV4().String()
+		}
+
+		var parentResourceID *string
+
+		if parentResource != nil {
+			parentResourceID = &parentResource.ResourceID
+		}
+
+		// Create a new resource instance
+		res = &resource.Resource{
+			ResourceID:       rID,
+			ParentResourceID: parentResourceID,
+			ResourceType:     *resourceType,
+			ResourceTypeID:   resourceType.ResourceTypeID,
+		}
+
+		// Persist the resource
+		return tr.ResourceRepository().Create(ctx, res)
+	})
+
+	return res, err
+}
+
+// Update updates the resource.
+// Only parent resource ID update is currently supported.
+// If parentResourceID == "" then the parent resource ID will be set to nil.
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (s *resourceServiceImpl) Update(ctx context.Context, resourceID, parentResourceID string) (*resource.Resource, error) {
+
+	var res *resource.Resource
+
+	err := transaction.Transactional(s.tm, func(tr transaction.TransactionalResources) error {
+		var err error
+		res, err = tr.ResourceRepository().Load(ctx, resourceID)
+		if err != nil {
+			return err
+		}
+
+		// Update the parent resource
+		// If an empty string then set to nil
+		if parentResourceID == "" {
+			res.ParentResourceID = nil
+		} else {
+			res.ParentResourceID = &parentResourceID
+		}
+		return tr.ResourceRepository().Save(ctx, res)
+	})
+
+	return res, err
+}

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -1,0 +1,111 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/authorization"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type resourceServiceBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+	resourceService resourceservice.ResourceService
+}
+
+func TestRunResourceServiceBlackBoxTest(t *testing.T) {
+	suite.Run(t, &resourceServiceBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *resourceServiceBlackBoxTest) SetupSuite() {
+	s.DBTestSuite.SetupSuite()
+	s.resourceService = resourceservice.NewResourceService(s.Application, s.Application)
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterResourceUnknownResourceTypeFails() {
+	resourceID := uuid.NewV4().String()
+	unknownResourceType := uuid.NewV4().String()
+	_, err := s.resourceService.Register(context.Background(), unknownResourceType, &resourceID, nil)
+	require.EqualError(s.T(), err, fmt.Sprintf("Bad value for parameter 'type': '%s' - resource_type with name '%s' not found", unknownResourceType, unknownResourceType))
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterResourceUnknownParentResourceFails() {
+	resourceID := uuid.NewV4().String()
+	unknownParentID := uuid.NewV4().String()
+	_, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, &unknownParentID)
+	require.EqualError(s.T(), err, fmt.Sprintf("Bad value for parameter 'parent resource ID': '%s' - resource with id '%s' not found", unknownParentID, unknownParentID))
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithoutParentOK() {
+	resourceID := uuid.NewV4().String()
+
+	// Register. No parent
+	resource, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, nil)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), resourceID, resource.ResourceID)
+	assert.Equal(s.T(), "", resource.Name)
+	assert.Equal(s.T(), "6422fda4-a0fa-4d3c-8b79-8061e5c05e12", resource.ResourceTypeID.String())
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, resource.ResourceType.Name)
+	assert.Nil(s.T(), resource.ParentResourceID)
+	assert.Nil(s.T(), resource.ParentResource)
+
+	// Read
+	r, err := s.resourceService.Read(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), r)
+	require.NotNil(s.T(), r.ResourceID)
+	assert.Equal(s.T(), resourceID, *r.ResourceID)
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, *r.Type)
+	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
+
+	// Delete
+	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+}
+
+func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK() {
+	resourceID := uuid.NewV4().String()
+
+	// With parent resource
+	g := s.DBTestSuite.NewTestGraph()
+	g.CreateResource(g.ID("myparentresource"))
+	parent := g.ResourceByID("myparentresource").Resource()
+	resource, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, &parent.ResourceID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), resourceID, resource.ResourceID)
+	assert.Equal(s.T(), "", resource.Name)
+	assert.Equal(s.T(), "6422fda4-a0fa-4d3c-8b79-8061e5c05e12", resource.ResourceTypeID.String())
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, resource.ResourceType.Name)
+	assert.NotNil(s.T(), resource.ParentResourceID)
+	assert.Equal(s.T(), parent.ResourceID, *resource.ParentResourceID)
+	require.NotNil(s.T(), resource.ParentResource)
+	assert.Equal(s.T(), parent.ResourceID, resource.ParentResource.ResourceID)
+
+	// Read
+	r, err := s.resourceService.Read(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), r)
+	require.NotNil(s.T(), r.ResourceID)
+	assert.Equal(s.T(), resourceID, *r.ResourceID)
+	require.NotNil(s.T(), r.ParentResourceID)
+	assert.Equal(s.T(), parent.ResourceID, *r.ParentResourceID)
+	assert.Equal(s.T(), authorization.ResourceTypeSpace, *r.Type)
+	assert.Equal(s.T(), []string{"view", "contribute", "manage"}, r.ResourceScopes)
+
+	// Delete
+	err = s.resourceService.Delete(context.Background(), resource.ResourceID)
+	require.NoError(s.T(), err)
+}
+
+func (s *resourceServiceBlackBoxTest) TestReadUnknownResourceFails() {
+	unknownResourceID := uuid.NewV4().String()
+	_, err := s.resourceService.Read(context.Background(), unknownResourceID)
+	require.EqualError(s.T(), err, fmt.Sprintf("resource with id '%s' not found", unknownResourceID))
+}

--- a/authorization/resourcetype/repository/resource_type.go
+++ b/authorization/resourcetype/repository/resource_type.go
@@ -69,7 +69,7 @@ func (m *GormResourceTypeRepository) Lookup(ctx context.Context, name string) (*
 	var native ResourceType
 	err := m.db.Table(m.TableName()).Where("name = ?", name).First(&native).Error
 	if err == gorm.ErrRecordNotFound {
-		return nil, errors.NewNotFoundError("resource_type", name)
+		return nil, errors.NewNotFoundErrorWithKey("resource_type", "name", name)
 	}
 	return &native, err
 }

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -82,23 +82,3 @@ func (c *ResourceController) Register(ctx *app.RegisterResourceContext) error {
 
 	return ctx.Created(&app.RegisterResourceResponse{ResourceID: &res.ResourceID})
 }
-
-// Update runs the update action.
-func (c *ResourceController) Update(ctx *app.UpdateResourceContext) error {
-
-	if !token.IsServiceAccount(ctx) {
-		log.Error(ctx, map[string]interface{}{}, "Unable to register resource. Not a service account")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
-	}
-
-	svc := resourceservice.NewResourceService(c.app, c.app)
-	res, err := svc.Update(ctx, ctx.ResourceID, ctx.Payload.ParentResourceID)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"resource_id": ctx.ResourceID,
-		}, "unable to update resource")
-		return jsonapi.JSONErrorResponse(ctx, err)
-	}
-
-	return ctx.OK(&app.RegisterResourceResponse{ResourceID: &res.ResourceID})
-}

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
-	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
@@ -31,7 +30,7 @@ func (c *ResourceController) Delete(ctx *app.DeleteResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	svc := resourceservice.NewResourceService(c.app, c.app)
+	svc := c.app.ResourceService()
 	err := svc.Delete(ctx, ctx.ResourceID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -51,7 +50,7 @@ func (c *ResourceController) Read(ctx *app.ReadResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	svc := resourceservice.NewResourceService(c.app, c.app)
+	svc := c.app.ResourceService()
 	res, err := svc.Read(ctx, ctx.ResourceID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -71,7 +70,7 @@ func (c *ResourceController) Register(ctx *app.RegisterResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	svc := resourceservice.NewResourceService(c.app, c.app)
+	svc := c.app.ResourceService()
 	res, err := svc.Register(ctx, ctx.Payload.Type, ctx.Payload.ResourceID, ctx.Payload.ParentResourceID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -3,16 +3,13 @@ package controller
 import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
-	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
-	resourceType "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/token"
 
-	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
 )
 
 // ResourceController implements the resource resource.
@@ -34,19 +31,12 @@ func (c *ResourceController) Delete(ctx *app.DeleteResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		// Delete the resource
-		error := tr.ResourceRepository().Delete(ctx, ctx.ResourceID)
-
-		log.Debug(ctx, map[string]interface{}{
-			"resource_id": ctx.ResourceID,
-		}, "Deleted resource.")
-
-		return error
-	})
-
+	svc := resourceservice.NewResourceService(c.app, c.app)
+	err := svc.Delete(ctx, ctx.ResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": ctx.ResourceID,
+		}, "unable to delete resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
@@ -61,42 +51,16 @@ func (c *ResourceController) Read(ctx *app.ReadResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	var res *resource.Resource
-	var scopes []resourceType.ResourceTypeScope
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		var error error
-		// Load the resource
-		res, error = tr.ResourceRepository().Load(ctx, ctx.ResourceID)
-
-		if error != nil {
-			return error
-		}
-
-		// Load the resource type scopes
-		scopes, error = tr.ResourceTypeScopeRepository().LookupForType(ctx, res.ResourceTypeID)
-
-		return error
-	})
-
+	svc := resourceservice.NewResourceService(c.app, c.app)
+	res, err := svc.Read(ctx, ctx.ResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": ctx.ResourceID,
+		}, "unable to read resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	var scopeValues []string
-
-	for index := range scopes {
-		scopeValues = append(scopeValues, scopes[index].Name)
-	}
-
-	return ctx.OK(&app.Resource{
-		ResourceID:       &res.ResourceID,
-		Type:             res.ResourceType.Name,
-		Name:             res.Name,
-		ParentResourceID: res.ParentResourceID,
-		ResourceScopes:   scopeValues,
-	})
+	return ctx.OK(res)
 }
 
 // Register runs the register action.
@@ -107,76 +71,16 @@ func (c *ResourceController) Register(ctx *app.RegisterResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	var res *resource.Resource
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-
-		// Lookup the resource type
-		resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, ctx.Payload.Type)
-		if err != nil {
-			return errors.NewBadParameterError("type", ctx.Payload.Type)
-		}
-
-		// Lookup the parent resource if one has been specified
-		var parentResource *resource.Resource
-
-		if ctx.Payload.ParentResourceID != nil {
-
-			parentResource, err = tr.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"err":                err,
-					"parent_resource_id": ctx.Payload.ParentResourceID,
-				}, "Parent resource could not be found.")
-
-				return errors.NewBadParameterError("invalid parent resource ID specified", err)
-			}
-		}
-
-		var resourceID string
-		if ctx.Payload.ResourceID != nil {
-			resourceID = *ctx.Payload.ResourceID
-		} else {
-			resourceID = uuid.NewV4().String()
-		}
-
-		var parentResourceID *string
-
-		if parentResource != nil {
-			parentResourceID = &parentResource.ResourceID
-		}
-
-		// Create the new resource instance
-		res = &resource.Resource{
-			ResourceID:       resourceID,
-			Name:             ctx.Payload.Name,
-			ParentResourceID: parentResourceID,
-			ResourceType:     *resourceType,
-			ResourceTypeID:   resourceType.ResourceTypeID,
-		}
-
-		// Persist the resource
-		return tr.ResourceRepository().Create(ctx, res)
-	})
-
+	svc := resourceservice.NewResourceService(c.app, c.app)
+	res, err := svc.Register(ctx, ctx.Payload.Type, ctx.Payload.ResourceID, ctx.Payload.ParentResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_type": ctx.Payload.Type,
+		}, "unable to register resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	var parentResourceID string
-	if res.ParentResourceID != nil {
-		parentResourceID = *res.ParentResourceID
-	} else {
-		parentResourceID = ""
-	}
-
-	log.Debug(ctx, map[string]interface{}{
-		"resource_id":        res.ResourceID,
-		"parent_resource_id": parentResourceID,
-		"resource_type":      res.ResourceType.Name,
-	}, "resource registered")
-
-	return ctx.Created(&app.RegisterResource{ID: &res.ResourceID})
+	return ctx.Created(&app.RegisterResourceResponse{ResourceID: &res.ResourceID})
 }
 
 // Update runs the update action.
@@ -187,56 +91,14 @@ func (c *ResourceController) Update(ctx *app.UpdateResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("not a service account"))
 	}
 
-	var res *resource.Resource
-
-	err := transaction.Transactional(c.app, func(tr transaction.TransactionalResources) error {
-		var error error
-		res, error = tr.ResourceRepository().Load(ctx, ctx.ResourceID)
-		if error != nil {
-			return error
-		}
-
-		// If a name attribute has been passed in, update the resource name
-		if ctx.Payload.Name != nil {
-			res.Name = *ctx.Payload.Name
-		}
-
-		// If a type attribute has been passed in, update the resource type
-		if ctx.Payload.Type != nil {
-			resourceType, err := tr.ResourceTypeRepository().Lookup(ctx, *ctx.Payload.Type)
-			if err != nil {
-				return errors.NewBadParameterError("type", ctx.Payload.Type)
-			}
-			res.ResourceTypeID = resourceType.ResourceTypeID
-		}
-
-		// If a parent resource ID has been passed in, update the parent resource
-		if ctx.Payload.ParentResourceID != nil {
-			if *ctx.Payload.ParentResourceID != "" {
-				// If a parent ID has been specified, lookup the parent resource
-				parentResource, err := tr.ResourceRepository().Load(ctx, *ctx.Payload.ParentResourceID)
-				if err != nil {
-					log.Error(ctx, map[string]interface{}{
-						"err":                err,
-						"parent_resource_id": *ctx.Payload.ParentResourceID,
-					}, "Parent resource could not be found.")
-
-					return errors.NewBadParameterError("invalid parent resource ID specified", err)
-				}
-
-				res.ParentResourceID = &parentResource.ResourceID
-			} else {
-				res.ParentResourceID = nil
-			}
-
-		}
-
-		return tr.ResourceRepository().Save(ctx, res)
-	})
-
+	svc := resourceservice.NewResourceService(c.app, c.app)
+	res, err := svc.Update(ctx, ctx.ResourceID, ctx.Payload.ParentResourceID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"resource_id": ctx.ResourceID,
+		}, "unable to update resource")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	return ctx.OK(&app.RegisterResource{ID: &res.ResourceID})
+	return ctx.OK(&app.RegisterResourceResponse{ResourceID: &res.ResourceID})
 }

--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -57,16 +58,10 @@ func (rest *TestResourceREST) TestFailRegisterResourceNonServiceAccount() {
 	service, controller := rest.SecuredController(sa)
 
 	resourceID := ""
-	resourceScopes := []string{}
-
-	resourceOwnerID := rest.testIdentity.ID
 
 	payload := &app.RegisterResourcePayload{
-		Name:             "My new resource",
 		ParentResourceID: nil,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
@@ -74,7 +69,7 @@ func (rest *TestResourceREST) TestFailRegisterResourceNonServiceAccount() {
 
 	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
-	test.ReadResourceUnauthorized(rest.T(), service.Context, service, controller, *created.ID)
+	test.ReadResourceUnauthorized(rest.T(), service.Context, service, controller, *created.ResourceID)
 }
 
 /*
@@ -82,17 +77,11 @@ func (rest *TestResourceREST) TestFailRegisterResourceNonServiceAccount() {
  */
 func (rest *TestResourceREST) TestFailRegisterResourceInvalidParentResource() {
 	resourceID := ""
-	resourceScopes := []string{}
-
-	resourceOwnerID := rest.testIdentity.ID
 	parentResourceID := uuid.NewV4().String()
 
 	payload := &app.RegisterResourcePayload{
-		Name:             "My new resource",
 		ParentResourceID: &parentResourceID,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
@@ -101,159 +90,107 @@ func (rest *TestResourceREST) TestFailRegisterResourceInvalidParentResource() {
 
 func (rest *TestResourceREST) TestRegisterResourceCreated() {
 	resourceID := ""
-	resourceScopes := []string{}
-	resourceOwnerID := rest.testIdentity.ID
 
 	payload := &app.RegisterResourcePayload{
-		Name:             "My new resource",
 		ParentResourceID: nil,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
 	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), created)
-	require.NotNil(rest.T(), created.ID)
+	require.NotNil(rest.T(), created.ResourceID)
 }
 
 func (rest *TestResourceREST) TestRegisterResourceWithResourceIDSetCreated() {
 	resourceID := uuid.NewV4().String()
-	resourceScopes := []string{}
-	resourceOwnerID := rest.testIdentity.ID
 
 	payload := &app.RegisterResourcePayload{
-		Name:             "My new resource",
 		ParentResourceID: nil,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
 	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), created)
-	require.NotNil(rest.T(), created.ID)
-	require.EqualValues(rest.T(), *created.ID, resourceID)
+	require.NotNil(rest.T(), created.ResourceID)
+	require.EqualValues(rest.T(), *created.ResourceID, resourceID)
 
-	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
-	require.EqualValues(rest.T(), payload.Name, readResource.Name)
+	require.NotNil(rest.T(), readResource)
+	require.NotNil(rest.T(), readResource.ResourceID)
+	require.NotNil(rest.T(), readResource.Type)
+	assert.EqualValues(rest.T(), resourceID, *readResource.ResourceID)
+	assert.EqualValues(rest.T(), payload.Type, *readResource.Type)
 }
 
 func (rest *TestResourceREST) TestRegisterResourceWithInvalidResourceType() {
 	resourceID := uuid.NewV4().String()
-	resourceScopes := []string{}
-	resourceOwnerID := rest.testIdentity.ID
 
 	payload := &app.RegisterResourcePayload{
-		Name:             "My invalid resource",
 		ParentResourceID: nil,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "invalid_type",
 	}
 
-	_, _ = test.RegisterResourceBadRequest(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
+	test.RegisterResourceBadRequest(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 }
 
 func (rest *TestResourceREST) TestRegisterResourceWithParentResourceSetCreated() {
 	resourceID := ""
-	resourceScopes := []string{}
-	resourceOwnerID := rest.testIdentity.ID
 
 	// First we will create the parent resource
 	payload := &app.RegisterResourcePayload{
-		Name:             "My new parent resource",
 		ParentResourceID: nil,
-		ResourceScopes:   resourceScopes,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
 	_, parentCreated := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), parentCreated)
-	require.NotNil(rest.T(), parentCreated.ID)
+	require.NotNil(rest.T(), parentCreated.ResourceID)
 
 	// Now we create the child resource
 	payload = &app.RegisterResourcePayload{
-		Name:             "My new child resource",
-		ParentResourceID: parentCreated.ID,
-		ResourceScopes:   resourceScopes,
+		ParentResourceID: parentCreated.ResourceID,
 		ResourceID:       &resourceID,
-		ResourceOwnerID:  resourceOwnerID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
 	_, childCreated := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), childCreated)
-	require.NotNil(rest.T(), childCreated.ID)
+	require.NotNil(rest.T(), childCreated.ResourceID)
 
-	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *childCreated.ID)
+	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *childCreated.ResourceID)
 
-	require.EqualValues(rest.T(), payload.Name, readResource.Name)
 	require.EqualValues(rest.T(), payload.Type, "openshift.io/resource/area")
-	require.EqualValues(rest.T(), payload.ParentResourceID, parentCreated.ID)
-	require.EqualValues(rest.T(), payload.ResourceOwnerID, resourceOwnerID.String())
+	require.EqualValues(rest.T(), payload.ParentResourceID, readResource.ParentResourceID)
 }
 
 func (rest *TestResourceREST) TestUpdateResource() {
 	// Create the resource first
 	payload := &app.RegisterResourcePayload{
-		Name:             "Resource_Alpha",
 		ParentResourceID: nil,
-		ResourceScopes:   []string{},
-		ResourceOwnerID:  rest.testIdentity.ID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
 	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), created)
-	require.NotNil(rest.T(), created.ID)
+	require.NotNil(rest.T(), created.ResourceID)
 
-	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	_, readCreatedResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
-	require.EqualValues(rest.T(), created.ID, readResource.ResourceID)
-	require.EqualValues(rest.T(), payload.Name, readResource.Name)
-
-	var updatedName = "Resource_Bravo"
-	updatePayload := &app.UpdateResourcePayload{
-		Name: &updatedName,
-	}
-
-	_, updated := test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID, updatePayload)
-
-	// First confirm we get the correct resource ID back in the response
-	require.EqualValues(rest.T(), created.ID, updated.ID)
-
-	// Read the resource again, and check the name has been updated
-	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
-	require.EqualValues(rest.T(), updatedName, readResource.Name)
-
-	// Also confirm that no other fields have been updated
-	require.EqualValues(rest.T(), "openshift.io/resource/area", readResource.Type)
-
-	// Set the type to an invalid type and try to update it
-	invalidType := "invalid-type"
-	updatePayload = &app.UpdateResourcePayload{
-		Type: &invalidType,
-	}
-	test.UpdateResourceBadRequest(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID, updatePayload)
+	require.EqualValues(rest.T(), created.ResourceID, readCreatedResource.ResourceID)
 
 	// Create another resource - we will use this as the parent
 	parentPayload := &app.RegisterResourcePayload{
-		Name:             "Resource_Parent",
 		ParentResourceID: nil,
-		ResourceScopes:   []string{},
-		ResourceOwnerID:  rest.testIdentity.ID.String(),
 		Type:             "openshift.io/resource/area",
 	}
 
@@ -262,33 +199,32 @@ func (rest *TestResourceREST) TestUpdateResource() {
 
 	// Confirm it was created successfully
 	require.NotNil(rest.T(), parentCreated)
-	require.NotNil(rest.T(), parentCreated.ID)
+	require.NotNil(rest.T(), parentCreated.ResourceID)
 
 	// Now test setting the original resource's parent to the newly created resource
-	updatePayload = &app.UpdateResourcePayload{
-		ParentResourceID: parentCreated.ID,
+	updatePayload := &app.UpdateResourcePayload{
+		ParentResourceID: *parentCreated.ResourceID,
 	}
 
 	// Update the original resource
-	_, updated = test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID, updatePayload)
+	_, updated := test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID, updatePayload)
+	require.EqualValues(rest.T(), created.ResourceID, updated.ResourceID)
 
 	// Read the resource again, and check the parent resource has been updated
-	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
-	require.EqualValues(rest.T(), *parentCreated.ID, *readResource.ParentResourceID)
-
-	emptyParentResourceID := ""
+	require.EqualValues(rest.T(), *parentCreated.ResourceID, *readResource.ParentResourceID)
 
 	// Now test clearing the original resource's parent to nil
 	updatePayload = &app.UpdateResourcePayload{
-		ParentResourceID: &emptyParentResourceID,
+		ParentResourceID: "",
 	}
 
 	// Update the original resource
-	_, updated = test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID, updatePayload)
+	_, updated = test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID, updatePayload)
 
 	// Read the resource again, and check the parent resource has been cleared
-	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
 	require.Nil(rest.T(), readResource.ParentResourceID)
 }
@@ -297,23 +233,20 @@ func (rest *TestResourceREST) TestDeleteResource() {
 
 	// Create the resource first
 	payload := &app.RegisterResourcePayload{
-		Name:            "My new resource",
-		ResourceScopes:  []string{},
-		ResourceOwnerID: rest.testIdentity.ID.String(),
-		Type:            "openshift.io/resource/area",
+		Type: "openshift.io/resource/area",
 	}
 
 	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
 
 	require.NotNil(rest.T(), created)
-	require.NotNil(rest.T(), created.ID)
+	require.NotNil(rest.T(), created.ResourceID)
 
-	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
-	require.EqualValues(rest.T(), created.ID, readResource.ResourceID)
+	require.EqualValues(rest.T(), created.ResourceID, readResource.ResourceID)
 
-	test.DeleteResourceNoContent(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	test.DeleteResourceNoContent(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
-	test.ReadResourceNotFound(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ID)
+	test.ReadResourceNotFound(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
 }

--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -172,63 +172,6 @@ func (rest *TestResourceREST) TestRegisterResourceWithParentResourceSetCreated()
 	require.EqualValues(rest.T(), payload.ParentResourceID, readResource.ParentResourceID)
 }
 
-func (rest *TestResourceREST) TestUpdateResource() {
-	// Create the resource first
-	payload := &app.RegisterResourcePayload{
-		ParentResourceID: nil,
-		Type:             "openshift.io/resource/area",
-	}
-
-	_, created := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, payload)
-
-	require.NotNil(rest.T(), created)
-	require.NotNil(rest.T(), created.ResourceID)
-
-	_, readCreatedResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
-
-	require.EqualValues(rest.T(), created.ResourceID, readCreatedResource.ResourceID)
-
-	// Create another resource - we will use this as the parent
-	parentPayload := &app.RegisterResourcePayload{
-		ParentResourceID: nil,
-		Type:             "openshift.io/resource/area",
-	}
-
-	// Create the parent resource
-	_, parentCreated := test.RegisterResourceCreated(rest.T(), rest.service.Context, rest.service, rest.securedController, parentPayload)
-
-	// Confirm it was created successfully
-	require.NotNil(rest.T(), parentCreated)
-	require.NotNil(rest.T(), parentCreated.ResourceID)
-
-	// Now test setting the original resource's parent to the newly created resource
-	updatePayload := &app.UpdateResourcePayload{
-		ParentResourceID: *parentCreated.ResourceID,
-	}
-
-	// Update the original resource
-	_, updated := test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID, updatePayload)
-	require.EqualValues(rest.T(), created.ResourceID, updated.ResourceID)
-
-	// Read the resource again, and check the parent resource has been updated
-	_, readResource := test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
-
-	require.EqualValues(rest.T(), *parentCreated.ResourceID, *readResource.ParentResourceID)
-
-	// Now test clearing the original resource's parent to nil
-	updatePayload = &app.UpdateResourcePayload{
-		ParentResourceID: "",
-	}
-
-	// Update the original resource
-	_, updated = test.UpdateResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID, updatePayload)
-
-	// Read the resource again, and check the parent resource has been cleared
-	_, readResource = test.ReadResourceOK(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
-
-	require.Nil(rest.T(), readResource.ParentResourceID)
-}
-
 func (rest *TestResourceREST) TestDeleteResource() {
 
 	// Create the resource first
@@ -248,5 +191,4 @@ func (rest *TestResourceREST) TestDeleteResource() {
 	test.DeleteResourceNoContent(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
 
 	test.ReadResourceNotFound(rest.T(), rest.service.Context, rest.service, rest.securedController, *created.ResourceID)
-
 }

--- a/design/resource.go
+++ b/design/resource.go
@@ -40,24 +40,6 @@ var _ = a.Resource("resource", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
 
-	a.Action("update", func() {
-		a.Routing(
-			a.PATCH("/:resourceId"),
-		)
-		a.Params(func() {
-			a.Param("resourceId", d.String, "Identifier of the resource to update")
-		})
-		a.Description("Update the details of the specified resource")
-		a.Payload(UpdateResourceMedia)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.Forbidden, JSONAPIErrors)
-		a.Response(d.TemporaryRedirect)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-		a.Response(d.OK, RegisterResourceResponseMedia)
-	})
-
 	a.Action("delete", func() {
 		a.Routing(
 			a.DELETE("/:resourceId"),
@@ -90,17 +72,6 @@ var ResourceMedia = a.MediaType("application/vnd.resource+json", func() {
 		a.Attribute("type")
 		a.Attribute("parent_resource_id")
 		a.Attribute("resource_id")
-	})
-})
-
-var UpdateResourceMedia = a.MediaType("application/vnd.update_resource+json", func() {
-	a.Description("Payload for updating a resource")
-	a.Attributes(func() {
-		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs. If set to an empty string then the resource won't have any parent resource anymore")
-		a.Required("parent_resource_id")
-	})
-	a.View("default", func() {
-		a.Attribute("parent_resource_id")
 	})
 })
 

--- a/design/resource.go
+++ b/design/resource.go
@@ -16,9 +16,9 @@ var _ = a.Resource("resource", func() {
 			a.POST(""),
 		)
 		a.Description("Register a new resource")
-		a.Payload(ResourceMedia)
+		a.Payload(RegisterResourceMedia)
 		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.Created, RegisterResourceMedia)
+		a.Response(d.Created, RegisterResourceResponseMedia)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -55,7 +55,7 @@ var _ = a.Resource("resource", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
-		a.Response(d.OK, RegisterResourceMedia)
+		a.Response(d.OK, RegisterResourceResponseMedia)
 	})
 
 	a.Action("delete", func() {
@@ -80,17 +80,13 @@ var _ = a.Resource("resource", func() {
 var ResourceMedia = a.MediaType("application/vnd.resource+json", func() {
 	a.Description("A Protected Resource")
 	a.Attributes(func() {
-		a.Attribute("resource_owner_id", d.String, "Identifier for the owner of the resource")
 		a.Attribute("resource_scopes", a.ArrayOf(d.String), "The valid scopes for this resource")
-		a.Attribute("name", d.String, "The name of the resource")
 		a.Attribute("type", d.String, "The type of resource")
 		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs")
 		a.Attribute("resource_id", d.String, "The identifier for this resource. If left blank, one will be generated")
-		a.Required("resource_owner_id", "name", "type")
 	})
 	a.View("default", func() {
 		a.Attribute("resource_scopes")
-		a.Attribute("name")
 		a.Attribute("type")
 		a.Attribute("parent_resource_id")
 		a.Attribute("resource_id")
@@ -100,23 +96,35 @@ var ResourceMedia = a.MediaType("application/vnd.resource+json", func() {
 var UpdateResourceMedia = a.MediaType("application/vnd.update_resource+json", func() {
 	a.Description("Payload for updating a resource")
 	a.Attributes(func() {
-		a.Attribute("resource_owner_id", d.String, "Identifier for the owner of the resource")
-		a.Attribute("resource_scopes", a.ArrayOf(d.String), "The valid scopes for this resource")
-		a.Attribute("name", d.String, "The name of the resource")
-		a.Attribute("type", d.String, "The type of resource")
-		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs")
+		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs. If set to an empty string then the resource won't have any parent resource anymore")
+		a.Required("parent_resource_id")
 	})
 	a.View("default", func() {
-		a.Attribute("name")
+		a.Attribute("parent_resource_id")
 	})
 })
 
 var RegisterResourceMedia = a.MediaType("application/vnd.register_resource+json", func() {
-	a.Description("Response returned when a resource is registered")
+	a.Description("Payload for registering a resource")
 	a.Attributes(func() {
-		a.Attribute("_id", d.String, "The identifier for the registered resource")
+		a.Attribute("type", d.String, "The type of resource")
+		a.Attribute("parent_resource_id", d.String, "The parent resource (of the same type) to which this resource belongs")
+		a.Attribute("resource_id", d.String, "The identifier for this resource. If left blank, one will be generated")
+		a.Required("type")
 	})
 	a.View("default", func() {
-		a.Attribute("_id")
+		a.Attribute("type")
+		a.Attribute("parent_resource_id")
+		a.Attribute("resource_id")
+	})
+})
+
+var RegisterResourceResponseMedia = a.MediaType("application/vnd.register_resource_response+json", func() {
+	a.Description("Response returned when a resource is registered")
+	a.Attributes(func() {
+		a.Attribute("resource_id", d.String, "The identifier for the registered resource")
+	})
+	a.View("default", func() {
+		a.Attribute("resource_id")
 	})
 })

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,7 +11,7 @@ import (
 const (
 	stBadParameterErrorMsg         = "Bad value for parameter '%s': '%v' - %s"
 	stBadParameterErrorExpectedMsg = "Bad value for parameter '%s': '%v' (expected: '%v') - %s"
-	stNotFoundErrorMsg             = "%s with id '%s' not found"
+	stNotFoundErrorMsg             = "%s with %s '%s' not found"
 )
 
 // Constants that can be used to identify internal server errors
@@ -203,16 +203,22 @@ type ConversionError struct {
 // NotFoundError means the object specified for the operation does not exist
 type NotFoundError struct {
 	entity string
-	ID     string
+	key    string
+	value  string
 }
 
 func (err NotFoundError) Error() string {
-	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.ID)
+	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.key, err.value)
 }
 
 // NewNotFoundError returns the custom defined error of type NewNotFoundError.
-func NewNotFoundError(entity string, id string) NotFoundError {
-	return NotFoundError{entity: entity, ID: id}
+func NewNotFoundError(entity string, value string) NotFoundError {
+	return NotFoundError{entity: entity, key: "id", value: value}
+}
+
+// NewNotFoundErrorWithKey returns the custom defined error of type NewNotFoundError and custom key name (instead of the default 'ID")
+func NewNotFoundErrorWithKey(entity string, key, value string) NotFoundError {
+	return NotFoundError{entity: entity, key: key, value: value}
 }
 
 // IsNotFoundError returns true if the cause of the given error can be

--- a/errors/errors_blackbox_test.go
+++ b/errors/errors_blackbox_test.go
@@ -51,6 +51,9 @@ func TestNewNotFoundError(t *testing.T) {
 	value := "10"
 	err := errors.NewNotFoundError(param, value)
 	assert.Equal(t, fmt.Sprintf("%s with id '%s' not found", param, value), err.Error())
+
+	err = errors.NewNotFoundErrorWithKey(param, "name", value)
+	assert.Equal(t, fmt.Sprintf("%s with name '%s' not found", param, value), err.Error())
 }
 
 func TestNewUnauthorizedError(t *testing.T) {

--- a/errors/errors_whitebox_test.go
+++ b/errors/errors_whitebox_test.go
@@ -28,6 +28,6 @@ func TestBadParameterError_Error(t *testing.T) {
 func TestNotFoundError_Error(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	e := NotFoundError{entity: "foo", ID: "bar"}
-	assert.Equal(t, fmt.Sprintf(stNotFoundErrorMsg, e.entity, e.ID), e.Error())
+	e := NotFoundError{entity: "foo", key: "id", value: "bar"}
+	assert.Equal(t, fmt.Sprintf(stNotFoundErrorMsg, e.entity, e.key, e.value), e.Error())
 }

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -5,12 +5,14 @@ import (
 	"strconv"
 
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/fabric8-services/fabric8-auth/auth"
 	invitation "github.com/fabric8-services/fabric8-auth/authorization/invitation/repository"
 	invitationservice "github.com/fabric8-services/fabric8-auth/authorization/invitation/service"
 	organizationservice "github.com/fabric8-services/fabric8-auth/authorization/organization/service"
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
@@ -18,7 +20,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/space"
 	"github.com/fabric8-services/fabric8-auth/token/provider"
 
-	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 )
@@ -142,6 +143,10 @@ func (g *GormDB) RoleManagementService() roleservice.RoleManagementService {
 
 func (g *GormDB) TeamService() teamservice.TeamService {
 	return teamservice.NewTeamService(g, g)
+}
+
+func (g *GormDB) ResourceService() resourceservice.ResourceService {
+	return resourceservice.NewResourceService(g, g)
 }
 
 func (g *GormBase) DB() *gorm.DB {


### PR DESCRIPTION
This is a prerequisite for https://github.com/fabric8-services/fabric8-auth/issues/366

- [x] Create resource service (and move business logic from controller to service)
- [x] Remove name and owner ID from resource REST API (it doesn't make much sense to store names and owners/creators of the resources created by resource services)
- [x] Remove Update Resource Endpoint. The only thing which would make sense to update in the resource via REST API is the resource parent. But I think we should create some dedicated and explicit endpoint for changing the parent to avoid confusions with empty or missing parent ID in the update payload. Basically in the current implementation an empty Payload (or a payload with missing parent ID) will remove the parent from the resource. Which is not obvious and may cause issues. So, until we really need to support this use case in clients let's just remove this update endpoint.
- [x] More tests.