### PR TITLE
Create authz resource for new spaces

### DIFF
--- a/application/service/factory/service_factory.go
+++ b/application/service/factory/service_factory.go
@@ -2,6 +2,8 @@ package factory
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/fabric8-services/fabric8-auth/application/repository"
 	"github.com/fabric8-services/fabric8-auth/application/service"
 	"github.com/fabric8-services/fabric8-auth/application/service/context"
@@ -11,10 +13,11 @@ import (
 	permissionservice "github.com/fabric8-services/fabric8-auth/authorization/permission/service"
 	resourceservice "github.com/fabric8-services/fabric8-auth/authorization/resource/service"
 	roleservice "github.com/fabric8-services/fabric8-auth/authorization/role/service"
+	spaceservice "github.com/fabric8-services/fabric8-auth/authorization/space/service"
 	teamservice "github.com/fabric8-services/fabric8-auth/authorization/team/service"
 	"github.com/fabric8-services/fabric8-auth/log"
+
 	"github.com/pkg/errors"
-	"time"
 )
 
 type serviceContextImpl struct {
@@ -150,4 +153,8 @@ func (f *ServiceFactory) RoleManagementService() service.RoleManagementService {
 
 func (f *ServiceFactory) TeamService() service.TeamService {
 	return teamservice.NewTeamService(f.getContext())
+}
+
+func (f *ServiceFactory) SpaceService() service.SpaceService {
+	return spaceservice.NewSpaceService(f.getContext())
 }

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -19,7 +19,7 @@ type InvitationService interface {
 }
 
 type OrganizationService interface {
-	CreateOrganization(ctx context.Context, identityID uuid.UUID, organizationName string) (*uuid.UUID, error)
+	CreateOrganization(ctx context.Context, creatorIdentityID uuid.UUID, organizationName string) (*uuid.UUID, error)
 	ListOrganizations(ctx context.Context, identityID uuid.UUID) ([]authorization.IdentityAssociation, error)
 }
 

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -14,6 +14,18 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+/*
+Steps for adding a new Service:
+1. Add a new service interface to application/service/service.go
+2. Create an implementation of the service interface
+3. Add a new method to service.Service interface in application/service/service.go for accessing the service interface
+   defined in step 1
+4. Add a new method to application/service/factory/service_factory.go which implements the service access method
+   from step #3 and uses the service constructor from step 2
+5. Add a new method to gormapplication/application.go which implements the service access method from step #3
+   and use the factory method from the step #4
+*/
+
 type InvitationService interface {
 	Issue(ctx context.Context, issuingUserId uuid.UUID, inviteTo string, invitations []invitation.Invitation) error
 }
@@ -48,6 +60,11 @@ type TeamService interface {
 	ListTeamsForIdentity(ctx context.Context, identityID uuid.UUID) ([]authorization.IdentityAssociation, error)
 }
 
+type SpaceService interface {
+	CreateSpace(ctx context.Context, spaceCreatorIdentityID uuid.UUID, spaceID string) error
+	DeleteSpace(ctx context.Context, spaceID string) error
+}
+
 //Services creates instances of service layer objects
 type Services interface {
 	InvitationService() InvitationService
@@ -56,4 +73,5 @@ type Services interface {
 	PermissionService() PermissionService
 	RoleManagementService() RoleManagementService
 	TeamService() TeamService
+	SpaceService() SpaceService
 }

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -39,7 +39,7 @@ type RoleManagementService interface {
 	ListAvailableRolesByResourceType(ctx context.Context, resourceType string) ([]role.RoleDescriptor, error)
 	ListByResourceAndRoleName(ctx context.Context, resourceID string, roleName string) ([]rolerepo.IdentityRole, error)
 	Assign(ctx context.Context, assignedBy uuid.UUID, roleAssignments map[string][]uuid.UUID, resourceID string, appendToExistingRoles bool) error
-	AssignAsAdmin(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error
+	ForceAssign(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error
 }
 
 type TeamService interface {

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -62,7 +62,7 @@ type TeamService interface {
 
 type SpaceService interface {
 	CreateSpace(ctx context.Context, spaceCreatorIdentityID uuid.UUID, spaceID string) error
-	DeleteSpace(ctx context.Context, spaceID string) error
+	DeleteSpace(ctx context.Context, byIdentityID uuid.UUID, spaceID string) error
 }
 
 //Services creates instances of service layer objects

--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -41,6 +41,9 @@ const (
 	// viewSpaceScope is a general scope required to perform many space-related operations
 	viewSpaceScope = "view"
 
+	// manageSpaceScope is a general scope required to perform operations for managing a space
+	manageSpaceScope = manageScope
+
 	// contributeSpaceScope is a general scope required to perform many space-related operations
 	contributeSpaceScope = "contribute"
 
@@ -61,6 +64,9 @@ const (
 
 	// ManageRoleAssignmentsInSpaceScope is the scope required for managing role assignments in a space
 	ManageRoleAssignmentsInSpaceScope = manageScope
+
+	// DeleteSpaceScope is the scope required for deleting a space. It's a space level scope.
+	DeleteSpaceScope = manageSpaceScope
 )
 
 // CanHaveMembers returns a boolean indicating whether the specified resource type may have member Identities

--- a/authorization/organization/service/organization_service.go
+++ b/authorization/organization/service/organization_service.go
@@ -31,15 +31,16 @@ func NewOrganizationService(context *servicecontext.ServiceContext) service.Orga
 
 // Creates a new organization.  The specified identityID is the user creating the organization, while the name parameter
 // specifies the organization name.  The organization's identity ID is returned.
+// Also assigns Admin role to the organization creator.
 // IMPORTANT: This is a transactional method, which manages its own transaction/s internally
-func (s *organizationServiceImpl) CreateOrganization(ctx context.Context, identityID uuid.UUID, organizationName string) (*uuid.UUID, error) {
+func (s *organizationServiceImpl) CreateOrganization(ctx context.Context, creatorIdentityID uuid.UUID, organizationName string) (*uuid.UUID, error) {
 	var organizationId uuid.UUID
 
 	err := s.ExecuteInTransaction(func() error {
 		// Lookup the identity for the current user
-		userIdentity, err := s.Repositories().Identities().Load(ctx, identityID)
+		userIdentity, err := s.Repositories().Identities().Load(ctx, creatorIdentityID)
 		if err != nil {
-			return errors.NewUnauthorizedError(fmt.Sprintf("auth token contains id %s of unknown Identity\n", identityID))
+			return errors.NewUnauthorizedError(fmt.Sprintf("auth token contains id %s of unknown Identity\n", creatorIdentityID))
 		}
 
 		// Lookup the organization resource type

--- a/authorization/resource/repository/resource_blackbox_test.go
+++ b/authorization/resource/repository/resource_blackbox_test.go
@@ -77,6 +77,14 @@ func (s *resourceBlackBoxTest) TestOKToLoadChildren() {
 	for _, child := range foundChildren {
 		assert.Contains(s.T(), children, child.ResourceID)
 		assert.Equal(s.T(), parent.ResourceType.Name, child.ResourceType.Name)
+
+		grandChildren, err := s.repo.LoadChildren(s.Ctx, child.ResourceID)
+		require.NoError(s.T(), err)
+		require.Len(s.T(), grandChildren, 1)
+
+		grandGrandChildren, err := s.repo.LoadChildren(s.Ctx, grandChildren[0].ResourceID)
+		require.NoError(s.T(), err)
+		require.Len(s.T(), grandGrandChildren, 0)
 	}
 }
 

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -38,14 +38,12 @@ func (s *resourceServiceImpl) Delete(ctx context.Context, resourceID string) err
 }
 
 func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, visitedChildren map[string]bool) error {
-	// TODO delete:
-	// Role Mapping
-	// Role Identities
-	// associated identities where identities.identity_resource_id = resource.resource_id
+	// TODO delete associated identities where identities.identity_resource_id = resource.resource_id
+
+	// Delete children
 
 	// visitedChildren is used to make sure we don't have cycle resource references
 	visitedChildren[resourceID] = true
-
 	children, err := s.Repositories().ResourceRepository().LoadChildren(ctx, resourceID)
 	if err != nil {
 		return err
@@ -60,7 +58,18 @@ func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, vis
 			return err
 		}
 	}
-	//err := s.Repositories().RoleMappingRepository().Create(ctx, roleMapping)
+
+	// Delete role mapping
+	err = s.Repositories().RoleMappingRepository().DeleteForResource(ctx, resourceID)
+	if err != nil {
+		return err
+	}
+
+	// Delete identity roles
+	err = s.Repositories().IdentityRoleRepository().DeleteForResource(ctx, resourceID)
+	if err != nil {
+		return err
+	}
 
 	return s.Repositories().ResourceRepository().Delete(ctx, resourceID)
 }

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -57,7 +57,7 @@ func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, vis
 		}
 	}
 
-	// Delete role mapping
+	// Delete role mappings
 	err = s.Repositories().RoleMappingRepository().DeleteForResource(ctx, resourceID)
 	if err != nil {
 		return err

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -41,8 +41,7 @@ func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, vis
 	// TODO delete:
 	// Role Mapping
 	// Role Identities
-	// associated identities also
-	// where identities.identity_resource_id = resource.resource_id
+	// associated identities where identities.identity_resource_id = resource.resource_id
 
 	// visitedChildren is used to make sure we don't have cycle resource references
 	visitedChildren[resourceID] = true

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -38,8 +38,6 @@ func (s *resourceServiceImpl) Delete(ctx context.Context, resourceID string) err
 }
 
 func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, visitedChildren map[string]bool) error {
-	// TODO delete associated identities where identities.identity_resource_id = resource.resource_id
-
 	// Delete children
 
 	// visitedChildren is used to make sure we don't have cycle resource references
@@ -67,6 +65,12 @@ func (s *resourceServiceImpl) delete(ctx context.Context, resourceID string, vis
 
 	// Delete identity roles
 	err = s.Repositories().IdentityRoleRepository().DeleteForResource(ctx, resourceID)
+	if err != nil {
+		return err
+	}
+
+	// Delete assosiated identities in case of Organization, Team or Security Group
+	err = s.Repositories().Identities().DeleteForResource(ctx, resourceID)
 	if err != nil {
 		return err
 	}

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -26,9 +26,26 @@ func NewResourceService(context *servicecontext.ServiceContext) service.Resource
 }
 
 // Delete deletes the resource with resourceID
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
 func (s *resourceServiceImpl) Delete(ctx context.Context, resourceID string) error {
 
-	return s.Repositories().ResourceRepository().Delete(ctx, resourceID)
+	// TODO delete:
+	// Role Mapping
+	// Role Identities
+	// Child resources
+
+	err := s.ExecuteInTransaction(func() error {
+		//err := s.Repositories().RoleMappingRepository().Create(ctx, roleMapping)
+
+		err := s.Repositories().ResourceRepository().Delete(ctx, resourceID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 // Read reads resource

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -142,8 +142,8 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceOK() {
 	s.checkIdentityRole(2, teamToDeleteA.ResourceID())
 	s.checkIdentityRole(2, teamToDeleteB.ResourceID())
 
-	s.checkRoleMapping(true, spaceRoleMappingToDelete.RoleMapping().RoleMappingID.String())
-	s.checkRoleMapping(true, grandchildRoleMappingToDelete.RoleMapping().RoleMappingID.String())
+	s.checkRoleMapping(true, spaceRoleMappingToDelete.RoleMapping().RoleMappingID)
+	s.checkRoleMapping(true, grandchildRoleMappingToDelete.RoleMapping().RoleMappingID)
 
 	// Delete the space
 
@@ -166,8 +166,8 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceOK() {
 	s.checkIdentityRole(0, teamToDeleteA.ResourceID())
 	s.checkIdentityRole(0, teamToDeleteB.ResourceID())
 
-	s.checkRoleMapping(false, spaceRoleMappingToDelete.RoleMapping().RoleMappingID.String())
-	s.checkRoleMapping(false, grandchildRoleMappingToDelete.RoleMapping().RoleMappingID.String())
+	s.checkRoleMapping(false, spaceRoleMappingToDelete.RoleMapping().RoleMappingID)
+	s.checkRoleMapping(false, grandchildRoleMappingToDelete.RoleMapping().RoleMappingID)
 
 	// Check all not-related artifacts are still present
 
@@ -180,7 +180,7 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceOK() {
 	s.checkIdentityRole(1, spaceToStay.SpaceID())
 	s.checkIdentityRole(1, teamToStay.ResourceID())
 
-	s.checkRoleMapping(true, spaceRoleMappingToStay.RoleMapping().RoleMappingID.String())
+	s.checkRoleMapping(true, spaceRoleMappingToStay.RoleMapping().RoleMappingID)
 }
 
 func (s *resourceServiceBlackBoxTest) TestDeleteResourceWithCycleReferencesFails() {
@@ -196,7 +196,7 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceWithCycleReferencesFails
 	testsupport.AssertError(s.T(), err, errors.InternalError{}, "cycle resource references detected for resource %s with parent %s", parent.ResourceID(), child.ResourceID())
 }
 
-func (s *resourceServiceBlackBoxTest) checkRoleMapping(shouldExist bool, roleMappingID string) {
+func (s *resourceServiceBlackBoxTest) checkRoleMapping(shouldExist bool, roleMappingID uuid.UUID) {
 	err := s.Application.RoleMappingRepository().CheckExists(s.Ctx, roleMappingID)
 	if shouldExist {
 		assert.NoError(s.T(), err)

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -82,7 +82,7 @@ func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK
 	assert.Equal(s.T(), "", resource.Name)
 	assert.Equal(s.T(), "6422fda4-a0fa-4d3c-8b79-8061e5c05e12", resource.ResourceTypeID.String())
 	assert.Equal(s.T(), authorization.ResourceTypeSpace, resource.ResourceType.Name)
-	assert.NotNil(s.T(), resource.ParentResourceID)
+	require.NotNil(s.T(), resource.ParentResourceID)
 	assert.Equal(s.T(), parent.ResourceID, *resource.ParentResourceID)
 	require.NotNil(s.T(), resource.ParentResource)
 	assert.Equal(s.T(), parent.ResourceID, resource.ParentResource.ResourceID)

--- a/authorization/role/repository/role.go
+++ b/authorization/role/repository/role.go
@@ -212,7 +212,7 @@ func (m *GormRoleRepository) Lookup(ctx context.Context, name string, resourceTy
 		"left join resource_type on resource_type.resource_type_id = role.resource_type_id").Preload(
 		"ResourceType").Where("role.name = ? and resource_type.name = ?", name, resourceType).Find(&native).Error
 	if err == gorm.ErrRecordNotFound {
-		return nil, errors.NewNotFoundError("role", name)
+		return nil, errors.NewNotFoundErrorWithKey("role", "name", name)
 	}
 	return &native, errs.WithStack(err)
 }

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -61,7 +61,7 @@ func NewRoleMappingRepository(db *gorm.DB) RoleMappingRepository {
 
 // RoleMappingRepository represents the storage interface.
 type RoleMappingRepository interface {
-	CheckExists(ctx context.Context, ID uuid.UUID) error
+	CheckExists(ctx context.Context, id string) error
 	Load(ctx context.Context, ID uuid.UUID) (*RoleMapping, error)
 	Create(ctx context.Context, u *RoleMapping) error
 	Save(ctx context.Context, u *RoleMapping) error
@@ -78,9 +78,9 @@ func (m *GormRoleMappingRepository) TableName() string {
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormRoleMappingRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
+func (m *GormRoleMappingRepository) CheckExists(ctx context.Context, id string) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role_mapping", "exists"}, time.Now())
-	return base.CheckExistsWithCustomIDColumn(ctx, m.db, m.TableName(), "role_mapping_id", id.String())
+	return base.CheckExistsWithCustomIDColumn(ctx, m.db, m.TableName(), "role_mapping_id", id)
 }
 
 // CRUD Functions

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -61,7 +61,7 @@ func NewRoleMappingRepository(db *gorm.DB) RoleMappingRepository {
 
 // RoleMappingRepository represents the storage interface.
 type RoleMappingRepository interface {
-	CheckExists(ctx context.Context, id string) error
+	CheckExists(ctx context.Context, id uuid.UUID) error
 	Load(ctx context.Context, ID uuid.UUID) (*RoleMapping, error)
 	Create(ctx context.Context, u *RoleMapping) error
 	Save(ctx context.Context, u *RoleMapping) error
@@ -78,9 +78,9 @@ func (m *GormRoleMappingRepository) TableName() string {
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormRoleMappingRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormRoleMappingRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role_mapping", "exists"}, time.Now())
-	return base.CheckExistsWithCustomIDColumn(ctx, m.db, m.TableName(), "role_mapping_id", id)
+	return base.CheckExistsWithCustomIDColumn(ctx, m.db, m.TableName(), "role_mapping_id", id.String())
 }
 
 // CRUD Functions

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -178,7 +178,7 @@ func (m *GormRoleMappingRepository) Delete(ctx context.Context, id uuid.UUID) er
 }
 
 // DeleteForResource deletes all role mappings for the given resource ID
-// If no role mappings found then nil is returned
+// No error is returned if no role mappings found
 func (m *GormRoleMappingRepository) DeleteForResource(ctx context.Context, resourceID string) error {
 	defer goa.MeasureSince([]string{"goa", "db", "role_mapping", "deleteForResource"}, time.Now())
 

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -58,6 +58,42 @@ func (s *roleMappingBlackBoxTest) TestOKToDelete() {
 	}
 }
 
+func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
+	g := s.NewTestGraph()
+
+	// Create 5 role mappings
+	r := g.CreateResource(g.ID("r"))
+	for i := 0; i < 5; i++ {
+		g.CreateRoleMapping(r)
+	}
+
+	// Check all of them are present
+	mappings, err := s.repo.FindForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
+	require.NoError(s.T(), err)
+	assert.Len(s.T(), mappings, 5)
+
+	// Make some noise
+	var others []*rolerepo.RoleMapping
+	for i := 0; i < 10; i++ {
+		others = append(others, g.CreateRoleMapping().RoleMapping())
+	}
+
+	// Delete role mappings for the resource
+	err = s.repo.DeleteForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
+	require.NoError(s.T(), err)
+
+	for _, mapping := range mappings {
+		_, err = s.repo.Load(s.Ctx, mapping.RoleMappingID)
+		testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", mapping.RoleMappingID.String())
+	}
+
+	// Check the role mapping for other resources are still preset
+	for _, mapping := range others {
+		err = s.repo.CheckExists(s.Ctx, mapping.RoleMappingID)
+		assert.NoError(s.T(), err)
+	}
+}
+
 func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName string, fromRoleName string, toResourceTypeName string, toRoleName string) (rolerepo.RoleMapping, error) {
 	resourceTypeRepo := resourcetyperepo.NewResourceTypeRepository(s.DB)
 
@@ -119,7 +155,7 @@ func (s *roleMappingBlackBoxTest) TestExistsRoleMapping() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rm1)
 
-	_, err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID)
+	err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID)
 	require.NoError(s.T(), err)
 }
 

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -94,6 +94,12 @@ func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
 	}
 }
 
+func (s *roleMappingBlackBoxTest) TestExistsUnknownRoleMappingFails() {
+	id := uuid.NewV4()
+	err := s.repo.CheckExists(s.Ctx, id)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", id.String())
+}
+
 func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName string, fromRoleName string, toResourceTypeName string, toRoleName string) (rolerepo.RoleMapping, error) {
 	resourceTypeRepo := resourcetyperepo.NewResourceTypeRepository(s.DB)
 

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -62,13 +62,13 @@ func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
 	g := s.NewTestGraph()
 
 	// Create 5 role mappings
-	r := g.CreateResource(g.ID("r"))
+	r := g.CreateResource()
 	for i := 0; i < 5; i++ {
 		g.CreateRoleMapping(r)
 	}
 
 	// Check all of them are present
-	mappings, err := s.repo.FindForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
+	mappings, err := s.repo.FindForResource(s.Ctx, r.Resource().ResourceID)
 	require.NoError(s.T(), err)
 	assert.Len(s.T(), mappings, 5)
 
@@ -79,7 +79,7 @@ func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
 	}
 
 	// Delete role mappings for the resource
-	err = s.repo.DeleteForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
+	err = s.repo.DeleteForResource(s.Ctx, r.Resource().ResourceID)
 	require.NoError(s.T(), err)
 
 	for _, mapping := range mappings {
@@ -89,15 +89,15 @@ func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
 
 	// Check the role mapping for other resources are still preset
 	for _, mapping := range others {
-		err = s.repo.CheckExists(s.Ctx, mapping.RoleMappingID.String())
+		err = s.repo.CheckExists(s.Ctx, mapping.RoleMappingID)
 		assert.NoError(s.T(), err)
 	}
 }
 
 func (s *roleMappingBlackBoxTest) TestExistsUnknownRoleMappingFails() {
-	id := uuid.NewV4().String()
+	id := uuid.NewV4()
 	err := s.repo.CheckExists(s.Ctx, id)
-	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", id)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", id.String())
 }
 
 func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName string, fromRoleName string, toResourceTypeName string, toRoleName string) (rolerepo.RoleMapping, error) {
@@ -161,7 +161,7 @@ func (s *roleMappingBlackBoxTest) TestExistsRoleMapping() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rm1)
 
-	err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID.String())
+	err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID)
 	require.NoError(s.T(), err)
 }
 

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -89,15 +89,15 @@ func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
 
 	// Check the role mapping for other resources are still preset
 	for _, mapping := range others {
-		err = s.repo.CheckExists(s.Ctx, mapping.RoleMappingID)
+		err = s.repo.CheckExists(s.Ctx, mapping.RoleMappingID.String())
 		assert.NoError(s.T(), err)
 	}
 }
 
 func (s *roleMappingBlackBoxTest) TestExistsUnknownRoleMappingFails() {
-	id := uuid.NewV4()
+	id := uuid.NewV4().String()
 	err := s.repo.CheckExists(s.Ctx, id)
-	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", id.String())
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role_mapping with id '%s' not found", id)
 }
 
 func (s *roleMappingBlackBoxTest) createTestRoleMapping(fromResourceTypeName string, fromRoleName string, toResourceTypeName string, toRoleName string) (rolerepo.RoleMapping, error) {
@@ -161,7 +161,7 @@ func (s *roleMappingBlackBoxTest) TestExistsRoleMapping() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), rm1)
 
-	err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID)
+	err = s.repo.CheckExists(s.Ctx, rm1.RoleMappingID.String())
 	require.NoError(s.T(), err)
 }
 

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -153,11 +153,11 @@ func (s *roleManagementServiceImpl) Assign(ctx context.Context, assignedBy uuid.
 	return err
 }
 
-// AssignAsAdmin assigns an identity (users, organizations, teams or groups) with a role for a specific resource.
+// ForceAssign assigns an identity (users, organizations, teams or groups) with a role for a specific resource.
 // This method doesn't check any permissions and assumes that the caller does all needed permissions checks.
 // As an example: this method is to be used when creating a resource (space) to assign initial admin role to the resource creator.
 // IMPORTANT: This is a transactional method, which manages its own transaction/s internally
-func (s *roleManagementServiceImpl) AssignAsAdmin(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error {
+func (s *roleManagementServiceImpl) ForceAssign(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error {
 
 	err := s.ExecuteInTransaction(func() error {
 		role, err := s.Repositories().RoleRepository().Lookup(ctx, roleName, res.ResourceType.Name)

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -153,8 +153,8 @@ func (s *roleManagementServiceImpl) Assign(ctx context.Context, assignedBy uuid.
 	return err
 }
 
-// AssignAsAdmin assigns an identity ( users or organizations or teams or groups ) with a role, for a specific resource.
-// This method doesn't check any permissions and assumes that the caller did all needed permissions checks.
+// AssignAsAdmin assigns an identity (users, organizations, teams or groups) with a role for a specific resource.
+// This method doesn't check any permissions and assumes that the caller does all needed permissions checks.
 // As an example: this method is to be used when creating a resource (space) to assign initial admin role to the resource creator.
 // IMPORTANT: This is a transactional method, which manages its own transaction/s internally
 func (s *roleManagementServiceImpl) AssignAsAdmin(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error {

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -357,7 +357,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminOK() {
 	spaceCreator := g.CreateUser()
 	s.addNoisyAssignments()
 
-	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, *newSpace.Resource())
+	err := s.repo.ForceAssign(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, *newSpace.Resource())
 	require.NoError(s.T(), err)
 
 	// Check the role was assigned
@@ -369,7 +369,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignUnknownRoleAsAdminFails() 
 	newSpace := g.CreateSpace()
 	spaceCreator := g.CreateUser()
 
-	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, "unknownRole", *newSpace.Resource())
+	err := s.repo.ForceAssign(context.Background(), spaceCreator.Identity().ID, "unknownRole", *newSpace.Resource())
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role with name 'unknownRole' not found")
 }
 
@@ -378,7 +378,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminToUnknownIdenti
 	newSpace := g.CreateSpace()
 	id := uuid.NewV4()
 
-	err := s.repo.AssignAsAdmin(context.Background(), id, authorization.SpaceAdminRole, *newSpace.Resource())
+	err := s.repo.ForceAssign(context.Background(), id, authorization.SpaceAdminRole, *newSpace.Resource())
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "identity with id '%s' not found", id)
 }
 
@@ -388,11 +388,11 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminForUnknownResou
 	id := uuid.NewV4().String()
 
 	// Should fail because of there is no "admin" role for an unknown resource type
-	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{})
+	err := s.repo.ForceAssign(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{})
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role with name 'admin' not found")
 
 	// Should fail because of unknown resource ID
-	err = s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{ResourceID: id, ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace}})
+	err = s.repo.ForceAssign(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{ResourceID: id, ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace}})
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "resource with id '%s' not found", id)
 }
 

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -357,11 +357,11 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminOK() {
 	spaceCreator := g.CreateUser()
 	s.addNoisyAssignments()
 
-	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.AdminRole, *newSpace.Resource())
+	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, *newSpace.Resource())
 	require.NoError(s.T(), err)
 
 	// Check the role was assigned
-	s.checkRoleAssignments([]uuid.UUID{spaceCreator.Identity().ID}, authorization.AdminRole, newSpace.SpaceID())
+	s.checkRoleAssignments([]uuid.UUID{spaceCreator.Identity().ID}, "admin", newSpace.SpaceID())
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignUnknownRoleAsAdminFails() {
@@ -378,7 +378,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminToUnknownIdenti
 	newSpace := g.CreateSpace()
 	id := uuid.NewV4()
 
-	err := s.repo.AssignAsAdmin(context.Background(), id, authorization.AdminRole, *newSpace.Resource())
+	err := s.repo.AssignAsAdmin(context.Background(), id, authorization.SpaceAdminRole, *newSpace.Resource())
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "identity with id '%s' not found", id)
 }
 
@@ -388,11 +388,11 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminForUnknownResou
 	id := uuid.NewV4().String()
 
 	// Should fail because of there is no "admin" role for an unknown resource type
-	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.AdminRole, resource.Resource{})
+	err := s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{})
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "role with name 'admin' not found")
 
 	// Should fail because of unknown resource ID
-	err = s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.AdminRole, resource.Resource{ResourceID: id, ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace}})
+	err = s.repo.AssignAsAdmin(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, resource.Resource{ResourceID: id, ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace}})
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "resource with id '%s' not found", id)
 }
 

--- a/authorization/space/doc.go
+++ b/authorization/space/doc.go
@@ -1,0 +1,2 @@
+// Package space provides APIs for managing spaces
+package space

--- a/authorization/space/service/doc.go
+++ b/authorization/space/service/doc.go
@@ -1,0 +1,2 @@
+// Package service provides the code which encapsulates business logic for managing spaces
+package service

--- a/authorization/space/service/space_service.go
+++ b/authorization/space/service/space_service.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fabric8-services/fabric8-auth/application/service"
+	"github.com/fabric8-services/fabric8-auth/application/service/base"
+	servicecontext "github.com/fabric8-services/fabric8-auth/application/service/context"
+	"github.com/fabric8-services/fabric8-auth/authorization"
+
+	"github.com/satori/go.uuid"
+)
+
+// spaceService is the default implementation of SpaceService. It is a private struct and should only be instantiated
+// via the NewSpaceService() function.
+type spaceService struct {
+	base.BaseService
+}
+
+// NewSpaceService creates a new space service.
+func NewSpaceService(context *servicecontext.ServiceContext) service.SpaceService {
+	return &spaceService{base.NewBaseService(context)}
+}
+
+// CreateSpace creates a new space. The specified spaceCreatorIdentityID is the user creating the space, and the spaceID is the identifier for the
+// space resource. The space creator will be assigned with Admin role in the space.
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (s *spaceService) CreateSpace(ctx context.Context, spaceCreatorIdentityID uuid.UUID, spaceID string) error {
+
+	err := s.ExecuteInTransaction(func() error {
+		res, err := s.Services().ResourceService().Register(ctx, authorization.ResourceTypeSpace, &spaceID, nil)
+		if err != nil {
+			return err
+		}
+
+		return s.Services().RoleManagementService().ForceAssign(ctx, spaceCreatorIdentityID, authorization.SpaceAdminRole, *res)
+	})
+
+	return err
+}
+
+// DeleteSpace deletes the space.
+// IMPORTANT: This is a transactional method, which manages its own transaction/s internally
+func (s *spaceService) DeleteSpace(ctx context.Context, spaceID string) error {
+
+	return s.ExecuteInTransaction(func() error {
+		return s.Services().ResourceService().Delete(ctx, spaceID)
+	})
+}

--- a/authorization/space/service/space_service_blackbox_test.go
+++ b/authorization/space/service/space_service_blackbox_test.go
@@ -1,0 +1,64 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type spaceServiceBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+}
+
+func TestRunSpaceServiceBlackBoxTest(t *testing.T) {
+	suite.Run(t, &spaceServiceBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *spaceServiceBlackBoxTest) TestCreateOK() {
+
+}
+
+func (s *spaceServiceBlackBoxTest) _TestDeleteOK() {
+	g := s.DBTestSuite.NewTestGraph()
+	g.CreateSpace(g.ID("myspace")).AddAdmin(g.CreateUser(g.ID("foo")))
+
+	teamName := "TestTeam" + uuid.NewV4().String()
+	teamID, err := s.Application.TeamService().CreateTeam(s.Ctx, g.UserByID("foo").Identity().ID, g.SpaceByID("myspace").Resource().ResourceID, teamName)
+	require.NoError(s.T(), err)
+
+	teamName2 := "TestTeam" + uuid.NewV4().String()
+	teamID2, err := s.Application.TeamService().CreateTeam(s.Ctx, g.UserByID("foo").Identity().ID, g.SpaceByID("myspace").Resource().ResourceID, teamName2)
+	require.NoError(s.T(), err)
+
+	g.CreateSpace(g.ID("otherspace")).AddAdmin(g.CreateUser(g.ID("bar")))
+	teamName3 := "TestTeam" + uuid.NewV4().String()
+	_, err = s.Application.TeamService().CreateTeam(s.Ctx, g.UserByID("bar").Identity().ID, g.SpaceByID("otherspace").Resource().ResourceID, teamName3)
+	require.NoError(s.T(), err)
+
+	teams, err := s.Application.TeamService().ListTeamsInSpace(s.Ctx, g.UserByID("foo").Identity().ID, g.SpaceByID("myspace").Resource().ResourceID)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), teams, 2)
+	team1Found := false
+	team2Found := false
+
+	for i := range teams {
+		if teams[i].ID == *teamID {
+			team1Found = true
+			require.Equal(s.T(), teamName, teams[i].IdentityResource.Name)
+		} else if teams[i].ID == *teamID2 {
+			team2Found = true
+			require.Equal(s.T(), teamName2, teams[i].IdentityResource.Name)
+		}
+	}
+
+	require.True(s.T(), team1Found)
+	require.True(s.T(), team2Found)
+
+	teams, err = s.Application.TeamService().ListTeamsInSpace(s.Ctx, g.UserByID("bar").Identity().ID, g.SpaceByID("otherspace").Resource().ResourceID)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), teams, 1)
+}

--- a/authorization/team/service/team_service_blackbox_test.go
+++ b/authorization/team/service/team_service_blackbox_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -16,10 +17,6 @@ type teamServiceBlackBoxTest struct {
 
 func TestRunTeamServiceBlackBoxTest(t *testing.T) {
 	suite.Run(t, &teamServiceBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
-}
-
-func (s *teamServiceBlackBoxTest) SetupTest() {
-	s.DBTestSuite.SetupTest()
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateAndListTeamsSuccessful() {

--- a/controller/space.go
+++ b/controller/space.go
@@ -170,8 +170,6 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 		}
 	}
 
-	// TODO Clean up Identity-role's assigned to this resource/space?
-
 	return ctx.OK([]byte{})
 }
 

--- a/controller/space.go
+++ b/controller/space.go
@@ -85,7 +85,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	err = c.app.RoleManagementService().AssignAsAdmin(ctx, currentIdentity.ID, authorization.SpaceAdminRole, *res)
+	err = c.app.RoleManagementService().ForceAssign(ctx, currentIdentity.ID, authorization.SpaceAdminRole, *res)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"space_id": ctx.SpaceID,

--- a/controller/space.go
+++ b/controller/space.go
@@ -145,16 +145,17 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 
 	// Try to delete AuthZ resource for the space as part of soft migration from deprecated Keycloak AuthZ API to new OSIO AuthZ API
 	// Old spaces doesn't have any registered resources, so, we don't return an error if unable to find the corresponding resource
-	err = c.app.SpaceService().DeleteSpace(ctx, ctx.SpaceID.String())
+	err = c.app.SpaceService().DeleteSpace(ctx, currentIdentity.ID, ctx.SpaceID.String())
 	if err != nil {
 		if notFound, _ := errors.IsNotFoundError(err); notFound {
 			log.Warn(ctx, map[string]interface{}{
 				"space_id": ctx.SpaceID,
 			}, "unable to delete authZ space resource: resource not found; that's OK for old spaces")
+			// Just log a warning and proceed. Old spaces doesn't have any registered resources.
 		} else {
 			log.Error(ctx, map[string]interface{}{
 				"space_id": ctx.SpaceID,
-			}, "unable to delete authZ space resource")
+			}, "unable to load authZ space resource")
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 	}

--- a/controller/space.go
+++ b/controller/space.go
@@ -85,7 +85,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	err = c.app.RoleManagementService().AssignAsAdmin(ctx, currentIdentity.ID, authorization.AdminRole, *res)
+	err = c.app.RoleManagementService().AssignAsAdmin(ctx, currentIdentity.ID, authorization.SpaceAdminRole, *res)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"space_id": ctx.SpaceID,

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -115,7 +115,7 @@ func (rest *TestSpaceREST) TestCreateSpaceOK() {
 	require.NoError(rest.T(), err)
 	require.Len(rest.T(), assignedRoles, 1)
 	assert.Equal(rest.T(), creator.ID, assignedRoles[0].Identity.ID)
-	assert.Equal(rest.T(), authorization.AdminRole, assignedRoles[0].Role.Name)
+	assert.Equal(rest.T(), authorization.SpaceAdminRole, assignedRoles[0].Role.Name)
 }
 
 func (rest *TestSpaceREST) TestFailDeleteSpaceUnauthorized() {

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -51,7 +51,7 @@ const (
 
 func NewGormDB(db *gorm.DB) *GormDB {
 	val := new(GormDB)
-	val.db = db
+	val.db = db.Set("gorm:save_associations", false)
 	val.txIsoLevel = ""
 	val.serviceFactory = factory.NewServiceFactory(func() *context.ServiceContext {
 		ctx := factory.NewServiceContext(val, val)

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -162,6 +162,10 @@ func (g *GormDB) ResourceService() service.ResourceService {
 	return g.serviceFactory.ResourceService()
 }
 
+func (g *GormDB) SpaceService() service.SpaceService {
+	return g.serviceFactory.SpaceService()
+}
+
 func (g *GormBase) DB() *gorm.DB {
 	return g.db
 }

--- a/space/space_resource.go
+++ b/space/space_resource.go
@@ -188,7 +188,7 @@ func (r *GormResourceRepository) LoadBySpace(ctx context.Context, spaceID *uuid.
 		log.Error(ctx, map[string]interface{}{
 			"space_id": spaceID.String(),
 		}, "Could not find space resource by space ID")
-		return nil, errors.NewNotFoundError("space resource", spaceID.String())
+		return nil, errors.NewNotFoundErrorWithKey("space resource", "space_id", spaceID.String())
 	}
 	if tx.Error != nil {
 		return nil, errors.NewInternalError(ctx, tx.Error)

--- a/test/graph/organization_wrapper.go
+++ b/test/graph/organization_wrapper.go
@@ -1,0 +1,101 @@
+package graph
+
+import (
+	account "github.com/fabric8-services/fabric8-auth/account/repository"
+	"github.com/fabric8-services/fabric8-auth/authorization"
+	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// organizationWrapper represents an organization resource domain object
+type organizationWrapper struct {
+	baseWrapper
+	identity *account.Identity
+	resource *resource.Resource
+	creator  *account.Identity
+}
+
+func loadOrganizationWrapper(g *TestGraph, organizationID uuid.UUID) organizationWrapper {
+	w := organizationWrapper{baseWrapper: baseWrapper{g}}
+
+	var native account.Identity
+	err := w.graph.db.Table("identities").Preload("IdentityResource").Where("ID = ?", organizationID).Find(&native).Error
+	require.NoError(w.graph.t, err)
+
+	w.identity = &native
+
+	return w
+}
+
+func newOrganizationWrapper(g *TestGraph, params []interface{}) organizationWrapper {
+	w := organizationWrapper{baseWrapper: baseWrapper{g}}
+
+	var organizationName *string
+
+	for i := range params {
+		switch t := params[i].(type) {
+		case string:
+			organizationName = &t
+		case *userWrapper:
+			w.creator = t.Identity()
+		case userWrapper:
+			w.creator = t.Identity()
+		}
+	}
+
+	if w.creator == nil {
+		w.creator = w.graph.CreateUser().Identity()
+	}
+
+	if organizationName == nil {
+		nm := "Organization-" + uuid.NewV4().String()
+		organizationName = &nm
+	}
+
+	organizationIdentityID, err := g.app.OrganizationService().CreateOrganization(g.ctx, w.creator.ID, *organizationName)
+	require.NoError(g.t, err)
+
+	w.identity = g.LoadIdentity(organizationIdentityID).Identity()
+	organizationResource := g.LoadResource(w.identity.IdentityResourceID.String)
+	w.resource = organizationResource.Resource()
+
+	return w
+}
+
+func (w *organizationWrapper) OrganizationID() uuid.UUID {
+	return w.identity.ID
+}
+
+func (w *organizationWrapper) OrganizationName() string {
+	return w.identity.IdentityResource.Name
+}
+
+func (w *organizationWrapper) Identity() *account.Identity {
+	return w.identity
+}
+
+func (w *organizationWrapper) Resource() *resource.Resource {
+	return w.resource
+}
+
+func (w *organizationWrapper) ResourceID() string {
+	return w.resource.ResourceID
+}
+
+func (w *organizationWrapper) addUserRole(identityID uuid.UUID, roleName string) *organizationWrapper {
+	r, err := w.graph.app.RoleRepository().Lookup(w.graph.ctx, roleName, authorization.IdentityResourceTypeOrganization)
+	require.NoError(w.graph.t, err)
+
+	identityRole := &role.IdentityRole{
+		ResourceID: w.identity.IdentityResourceID.String,
+		IdentityID: identityID,
+		RoleID:     r.RoleID,
+	}
+
+	err = w.graph.app.IdentityRoleRepository().Create(w.graph.ctx, identityRole)
+	require.NoError(w.graph.t, err)
+	return w
+}

--- a/test/graph/resource_wrapper.go
+++ b/test/graph/resource_wrapper.go
@@ -62,7 +62,6 @@ func newResourceWrapper(g *TestGraph, params []interface{}) resourceWrapper {
 	w.resource = &resource.Resource{
 		Name:           *resourceName,
 		ResourceTypeID: resourceType.ResourceTypeID,
-		ParentResource: parentResource,
 	}
 
 	if parentResource != nil {
@@ -72,6 +71,7 @@ func newResourceWrapper(g *TestGraph, params []interface{}) resourceWrapper {
 	err := g.app.ResourceRepository().Create(g.ctx, w.resource)
 	require.NoError(g.t, err)
 
+	w.resource.ParentResource = parentResource
 	return w
 }
 

--- a/test/graph/resource_wrapper.go
+++ b/test/graph/resource_wrapper.go
@@ -3,6 +3,7 @@ package graph
 import (
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -18,13 +19,34 @@ func newResourceWrapper(g *TestGraph, params []interface{}) resourceWrapper {
 
 	var resourceName *string
 	var resourceType *resourcetype.ResourceType
+	var parentResource *resource.Resource
 
 	for i := range params {
 		switch t := params[i].(type) {
 		case string:
 			resourceName = &t
+		case *string:
+			resourceName = t
 		case resourceTypeWrapper:
 			resourceType = t.resourceType
+		case *resourceTypeWrapper:
+			resourceType = t.resourceType
+		case resourceWrapper:
+			parentResource = t.Resource()
+		case *resourceWrapper:
+			parentResource = t.Resource()
+		case spaceWrapper:
+			parentResource = t.Resource()
+		case *spaceWrapper:
+			parentResource = t.Resource()
+		case organizationWrapper:
+			parentResource = t.Resource()
+		case *organizationWrapper:
+			parentResource = t.Resource()
+		case resource.Resource:
+			parentResource = &t
+		case *resource.Resource:
+			parentResource = t
 		}
 	}
 
@@ -40,6 +62,11 @@ func newResourceWrapper(g *TestGraph, params []interface{}) resourceWrapper {
 	w.resource = &resource.Resource{
 		Name:           *resourceName,
 		ResourceTypeID: resourceType.ResourceTypeID,
+		ParentResource: parentResource,
+	}
+
+	if parentResource != nil {
+		w.resource.ParentResourceID = &parentResource.ResourceID
 	}
 
 	err := g.app.ResourceRepository().Create(g.ctx, w.resource)
@@ -48,6 +75,22 @@ func newResourceWrapper(g *TestGraph, params []interface{}) resourceWrapper {
 	return w
 }
 
-func (g *resourceWrapper) Resource() *resource.Resource {
-	return g.resource
+func loadResourceWrapper(g *TestGraph, resourceID string) resourceWrapper {
+	w := resourceWrapper{baseWrapper: baseWrapper{g}}
+
+	var native resource.Resource
+	err := w.graph.db.Table("resource").Where("resource_id = ?", resourceID).Find(&native).Error
+	require.NoError(w.graph.t, err)
+
+	w.resource = &native
+
+	return w
+}
+
+func (w *resourceWrapper) Resource() *resource.Resource {
+	return w.resource
+}
+
+func (w *resourceWrapper) ResourceID() string {
+	return w.resource.ResourceID
 }

--- a/test/graph/role_mapping_wrapper.go
+++ b/test/graph/role_mapping_wrapper.go
@@ -16,20 +16,24 @@ type roleMappingWrapper struct {
 func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrapper {
 	w := roleMappingWrapper{baseWrapper: baseWrapper{g}}
 
-	var resource *resource.Resource
+	var resrc *resource.Resource
 	var fromRole *role.Role
 	var toRole *role.Role
 
 	for i := range params {
 		switch t := params[i].(type) {
 		case resourceWrapper:
-			resource = t.Resource()
+			resrc = t.Resource()
 		case *resourceWrapper:
-			resource = t.Resource()
+			resrc = t.Resource()
 		case spaceWrapper:
-			resource = t.Resource()
+			resrc = t.Resource()
 		case *spaceWrapper:
-			resource = t.Resource()
+			resrc = t.Resource()
+		case resource.Resource:
+			resrc = &t
+		case *resource.Resource:
+			resrc = t
 		case roleWrapper:
 			if fromRole == nil {
 				fromRole = t.role
@@ -39,12 +43,12 @@ func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrappe
 		}
 	}
 
-	if resource == nil {
-		resource = w.graph.CreateResource().Resource()
+	if resrc == nil {
+		resrc = w.graph.CreateResource().Resource()
 	}
 
 	if fromRole == nil {
-		resourceType := w.graph.LoadResourceType(resource.ResourceTypeID)
+		resourceType := w.graph.LoadResourceType(resrc.ResourceTypeID)
 		fromRole = w.graph.CreateRole(resourceType).Role()
 	}
 
@@ -53,7 +57,7 @@ func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrappe
 	}
 
 	w.mapping = &role.RoleMapping{
-		ResourceID: resource.ResourceID,
+		ResourceID: resrc.ResourceID,
 		FromRoleID: fromRole.RoleID,
 		ToRoleID:   toRole.RoleID,
 	}

--- a/test/graph/role_mapping_wrapper.go
+++ b/test/graph/role_mapping_wrapper.go
@@ -1,7 +1,9 @@
 package graph
 
 import (
+	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,16 +16,20 @@ type roleMappingWrapper struct {
 func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrapper {
 	w := roleMappingWrapper{baseWrapper: baseWrapper{g}}
 
-	var resource *resourceWrapper
+	var resource *resource.Resource
 	var fromRole *role.Role
 	var toRole *role.Role
 
 	for i := range params {
 		switch t := params[i].(type) {
 		case resourceWrapper:
-			resource = &t
+			resource = t.Resource()
 		case *resourceWrapper:
-			resource = t
+			resource = t.Resource()
+		case spaceWrapper:
+			resource = t.Resource()
+		case *spaceWrapper:
+			resource = t.Resource()
 		case roleWrapper:
 			if fromRole == nil {
 				fromRole = t.role
@@ -34,11 +40,11 @@ func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrappe
 	}
 
 	if resource == nil {
-		resource = w.graph.CreateResource()
+		resource = w.graph.CreateResource().Resource()
 	}
 
 	if fromRole == nil {
-		resourceType := w.graph.LoadResourceType(resource.Resource().ResourceTypeID)
+		resourceType := w.graph.LoadResourceType(resource.ResourceTypeID)
 		fromRole = w.graph.CreateRole(resourceType).Role()
 	}
 
@@ -47,7 +53,7 @@ func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrappe
 	}
 
 	w.mapping = &role.RoleMapping{
-		ResourceID: resource.Resource().ResourceID,
+		ResourceID: resource.ResourceID,
 		FromRoleID: fromRole.RoleID,
 		ToRoleID:   toRole.RoleID,
 	}

--- a/test/graph/team_wrapper.go
+++ b/test/graph/team_wrapper.go
@@ -14,6 +14,7 @@ import (
 type teamWrapper struct {
 	baseWrapper
 	identity *account.Identity
+	resource *resource.Resource
 }
 
 func loadTeamWrapper(g *TestGraph, teamID uuid.UUID) teamWrapper {
@@ -57,20 +58,20 @@ func newTeamWrapper(g *TestGraph, params []interface{}) teamWrapper {
 		teamName = &nm
 	}
 
-	res := &resource.Resource{
+	w.resource = &resource.Resource{
 		Name:             *teamName,
 		ResourceType:     *resourceType,
 		ResourceTypeID:   resourceType.ResourceTypeID,
 		ParentResourceID: &space.ResourceID,
 	}
 
-	err = g.app.ResourceRepository().Create(g.ctx, res)
+	err = g.app.ResourceRepository().Create(g.ctx, w.resource)
 	require.NoError(g.t, err)
 
 	w.identity = &account.Identity{
 		ProviderType:       account.KeycloakIDP,
-		IdentityResourceID: sql.NullString{String: res.ResourceID, Valid: true},
-		IdentityResource:   *res,
+		IdentityResourceID: sql.NullString{String: w.resource.ResourceID, Valid: true},
+		IdentityResource:   *w.resource,
 	}
 
 	err = g.app.Identities().Create(g.ctx, w.identity)
@@ -89,6 +90,14 @@ func (w *teamWrapper) TeamName() string {
 
 func (w *teamWrapper) Identity() *account.Identity {
 	return w.identity
+}
+
+func (w *teamWrapper) Resource() *resource.Resource {
+	return w.resource
+}
+
+func (w *teamWrapper) ResourceID() string {
+	return w.resource.ResourceID
 }
 
 func (w *teamWrapper) AddMember(wrapper interface{}) *teamWrapper {

--- a/test/graph/team_wrapper.go
+++ b/test/graph/team_wrapper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// teamWrapper represents a space resource domain object
+// teamWrapper represents a team resource domain object
 type teamWrapper struct {
 	baseWrapper
 	identity *account.Identity

--- a/test/graph/team_wrapper.go
+++ b/test/graph/team_wrapper.go
@@ -27,6 +27,7 @@ func loadTeamWrapper(g *TestGraph, teamID uuid.UUID) teamWrapper {
 	require.NoError(w.graph.t, err)
 
 	w.identity = &native
+	w.resource = &native.IdentityResource
 
 	return w
 }

--- a/test/graph/team_wrapper.go
+++ b/test/graph/team_wrapper.go
@@ -2,10 +2,12 @@ package graph
 
 import (
 	"database/sql"
+
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
 	"github.com/fabric8-services/fabric8-auth/authorization"
 	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +69,7 @@ func newTeamWrapper(g *TestGraph, params []interface{}) teamWrapper {
 
 	err = g.app.ResourceRepository().Create(g.ctx, w.resource)
 	require.NoError(g.t, err)
+	w.resource.ParentResource = space
 
 	w.identity = &account.Identity{
 		ProviderType:       account.KeycloakIDP,

--- a/test/graph/test_graph.go
+++ b/test/graph/test_graph.go
@@ -156,6 +156,30 @@ func (g *TestGraph) LoadTeam(params ...interface{}) *teamWrapper {
 	return &w
 }
 
+func (g *TestGraph) CreateOrganization(params ...interface{}) *organizationWrapper {
+	obj := newOrganizationWrapper(g, params)
+	g.register(g.generateIdentifier(params), &obj)
+	return &obj
+}
+
+func (g *TestGraph) LoadOrganization(params ...interface{}) *organizationWrapper {
+	var organizationID *uuid.UUID
+	for i := range params {
+		switch t := params[i].(type) {
+		case *uuid.UUID:
+			organizationID = t
+		}
+	}
+	require.NotNil(g.t, organizationID, "Must specified a uuid parameter for the organization ID")
+	w := loadOrganizationWrapper(g, *organizationID)
+	g.register(g.generateIdentifier(params), &w)
+	return &w
+}
+
+func (g *TestGraph) OrganizationByID(id string) *organizationWrapper {
+	return g.graphObjects[id].(*organizationWrapper)
+}
+
 func (g *TestGraph) CreateIdentity(params ...interface{}) *identityWrapper {
 	obj := newIdentityWrapper(g, params)
 	g.register(g.generateIdentifier(params), &obj)
@@ -178,6 +202,22 @@ func (g *TestGraph) LoadIdentity(params ...interface{}) *identityWrapper {
 	}
 	require.NotNil(g.t, identityID, "Must specified a uuid parameter for the identity ID")
 	w := loadIdentityWrapper(g, *identityID)
+	g.register(g.generateIdentifier(params), &w)
+	return &w
+}
+
+func (g *TestGraph) LoadResource(params ...interface{}) *resourceWrapper {
+	var resourceID *string
+	for i := range params {
+		switch t := params[i].(type) {
+		case *string:
+			resourceID = t
+		case string:
+			resourceID = &t
+		}
+	}
+	require.NotNil(g.t, resourceID, "Must specified a string parameter for the resource ID")
+	w := loadResourceWrapper(g, *resourceID)
 	g.register(g.generateIdentifier(params), &w)
 	return &w
 }


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-auth/issues/366

- [x] When a new space is created or deleted then create/delete the corresponding AuthZ resource for the space
- [x] When creating a new resource assign an admin role for the resource creator (requires https://github.com/fabric8-services/fabric8-auth/pull/481 to be merged first)
- [x] Delete relevant references (role mapping, identities roles, identities, etc) when deleting a resource
- [x] Tests