### PR TITLE
Automatically create role mappings during resource registration

### DIFF
--- a/application/repository/repositories.go
+++ b/application/repository/repositories.go
@@ -25,4 +25,6 @@ type Repositories interface {
 	ResourceTypeScopeRepository() resourcetype.ResourceTypeScopeRepository
 	IdentityRoleRepository() role.IdentityRoleRepository
 	RoleRepository() role.RoleRepository
+	DefaultRoleMappingRepository() role.DefaultRoleMappingRepository
+	RoleMappingRepository() role.RoleMappingRepository
 }

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -106,6 +106,9 @@ func (s *resourceServiceImpl) Register(ctx context.Context, resourceTypeName str
 
 		// Persist the resource
 		return s.Repositories().ResourceRepository().Create(ctx, res)
+
+		// Search for any default role mappings for the resource type
+
 	})
 
 	return res, err

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/application/service"
 	"github.com/fabric8-services/fabric8-auth/application/service/base"
 	servicecontext "github.com/fabric8-services/fabric8-auth/application/service/context"
+	"github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/satori/go.uuid"
 )
 
@@ -105,10 +106,32 @@ func (s *resourceServiceImpl) Register(ctx context.Context, resourceTypeName str
 		}
 
 		// Persist the resource
-		return s.Repositories().ResourceRepository().Create(ctx, res)
+		err = s.Repositories().ResourceRepository().Create(ctx, res)
+		if err != nil {
+			return err
+		}
 
 		// Search for any default role mappings for the resource type
+		defaultRoleMappings, err := s.Repositories().DefaultRoleMappingRepository().FindForResourceType(ctx, resourceType.ResourceTypeID)
+		if err != nil {
+			return err
+		}
 
+		// For each default role mapping for the same resource type, create a role mapping for the resource
+		for _, m := range defaultRoleMappings {
+			roleMapping := &repository.RoleMapping{
+				ResourceID: rID,
+				FromRoleID: m.FromRoleID,
+				ToRoleID:   m.ToRoleID,
+			}
+
+			err = s.Repositories().RoleMappingRepository().Create(ctx, roleMapping)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 
 	return res, err

--- a/authorization/role/repository/default_role_mapping.go
+++ b/authorization/role/repository/default_role_mapping.go
@@ -143,7 +143,7 @@ func (m *GormDefaultRoleMappingRepository) Save(ctx context.Context, model *Defa
 		}, "unable to update default role mapping")
 		return errs.WithStack(err)
 	}
-	err = m.db.Debug().Model(obj).Select("ResourceTypeID", "FromRoleID", "ToRoleID").Updates(model).Error
+	err = m.db.Model(obj).Select("ResourceTypeID", "FromRoleID", "ToRoleID").Updates(model).Error
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/authorization/role/repository/default_role_mapping.go
+++ b/authorization/role/repository/default_role_mapping.go
@@ -1,0 +1,202 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/gormsupport"
+	"github.com/fabric8-services/fabric8-auth/log"
+
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
+	"github.com/satori/go.uuid"
+)
+
+type DefaultRoleMapping struct {
+	gormsupport.Lifecycle
+
+	// This is the primary key value
+	DefaultRoleMappingID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key;column:default_role_mapping_id"`
+	// The resource type that this role mapping applies to
+	ResourceType resourcetype.ResourceType `gorm:"ForeignKey:ResourceTypeID;AssociationForeignKey:ResourceTypeID"`
+	// The foreign key value for ResourceType
+	ResourceTypeID uuid.UUID
+	// The role that is being mapped from
+	FromRole Role `gorm:"ForeignKey:RoleID;AssociationForeignKey:FromRoleID"`
+	// The foreign key value for FromRole
+	FromRoleID uuid.UUID
+	// The role that is being mapped to
+	ToRole Role `gorm:"ForeignKey:RoleID;AssociationForeignKey:ToRoleID"`
+	// The foreign key value for ToRole
+	ToRoleID uuid.UUID
+}
+
+func (m DefaultRoleMapping) TableName() string {
+	return "default_role_mapping"
+}
+
+// GetLastModified returns the last modification time
+func (m DefaultRoleMapping) GetLastModified() time.Time {
+	return m.UpdatedAt
+}
+
+// GormDefaultRoleRepository is the implementation of the storage interface for Role.
+type GormDefaultRoleMappingRepository struct {
+	db *gorm.DB
+}
+
+// NewDefaultRoleMappingRepository creates a new storage type.
+func NewDefaultRoleMappingRepository(db *gorm.DB) DefaultRoleMappingRepository {
+	return &GormDefaultRoleMappingRepository{db: db}
+}
+
+// DefaultRoleMappingRepository represents the storage interface.
+type DefaultRoleMappingRepository interface {
+	CheckExists(ctx context.Context, ID uuid.UUID) (bool, error)
+	Load(ctx context.Context, ID uuid.UUID) (*DefaultRoleMapping, error)
+	Create(ctx context.Context, u *DefaultRoleMapping) error
+	Save(ctx context.Context, u *DefaultRoleMapping) error
+	List(ctx context.Context) ([]DefaultRoleMapping, error)
+	Delete(ctx context.Context, ID uuid.UUID) error
+	FindForResourceType(ctx context.Context, resourceTypeID uuid.UUID) ([]DefaultRoleMapping, error)
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m *GormDefaultRoleMappingRepository) TableName() string {
+	return "default_role_mapping"
+}
+
+// CheckExists returns nil if the given ID exists otherwise returns an error
+func (m *GormDefaultRoleMappingRepository) CheckExists(ctx context.Context, ID uuid.UUID) (bool, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "exists"}, time.Now())
+
+	var exists bool
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1 FROM %[1]s
+			WHERE
+				default_role_mapping_id=$1
+				AND deleted_at IS NULL
+		)`, m.TableName())
+
+	err := m.db.CommonDB().QueryRow(query, ID.String()).Scan(&exists)
+	if err == nil && !exists {
+		return exists, errors.NewNotFoundError(m.TableName(), ID.String())
+	}
+	if err != nil {
+		return false, errors.NewInternalError(ctx, errs.Wrapf(err, "unable to verify if %s exists", m.TableName()))
+	}
+	return exists, nil
+}
+
+// CRUD Functions
+
+// Load returns a single RoleMapping as a Database Model
+func (m *GormDefaultRoleMappingRepository) Load(ctx context.Context, id uuid.UUID) (*DefaultRoleMapping, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "load"}, time.Now())
+	var native DefaultRoleMapping
+	err := m.db.Table(m.TableName()).
+		Preload("ResourceType").
+		Preload("FromRole").
+		Preload("ToRole").
+		Where("default_role_mapping_id = ?", id).Find(&native).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, errors.NewNotFoundError("default_role_mapping", id.String())
+	}
+	return &native, errs.WithStack(err)
+}
+
+// Create creates a new record.
+func (m *GormDefaultRoleMappingRepository) Create(ctx context.Context, u *DefaultRoleMapping) error {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "create"}, time.Now())
+	if u.DefaultRoleMappingID == uuid.Nil {
+		u.DefaultRoleMappingID = uuid.NewV4()
+	}
+	err := m.db.Create(u).Error
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"default_role_mapping_id": u.DefaultRoleMappingID,
+			"err": err,
+		}, "unable to create the default role mapping")
+		return errs.WithStack(err)
+	}
+	log.Debug(ctx, map[string]interface{}{
+		"default_role_mapping_id": u.DefaultRoleMappingID,
+	}, "Default role mapping created!")
+	return nil
+}
+
+// Save modifies a single record
+func (m *GormDefaultRoleMappingRepository) Save(ctx context.Context, model *DefaultRoleMapping) error {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "save"}, time.Now())
+
+	obj, err := m.Load(ctx, model.DefaultRoleMappingID)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"default_role_mapping_id": model.DefaultRoleMappingID,
+			"err": err,
+		}, "unable to update default role mapping")
+		return errs.WithStack(err)
+	}
+	err = m.db.Debug().Model(obj).Select("ResourceTypeID", "FromRoleID", "ToRoleID").Updates(model).Error
+	if err != nil {
+		return errs.WithStack(err)
+	}
+
+	log.Debug(ctx, map[string]interface{}{
+		"default_role_mapping_id": model.DefaultRoleMappingID,
+	}, "Default role mapping saved!")
+	return nil
+}
+
+// List returns all default role mappings
+func (m *GormDefaultRoleMappingRepository) List(ctx context.Context) ([]DefaultRoleMapping, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "list"}, time.Now())
+	var rows []DefaultRoleMapping
+
+	err := m.db.Model(&DefaultRoleMapping{}).Find(&rows).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, errs.WithStack(err)
+	}
+	return rows, nil
+}
+
+// Delete removes a single record.
+func (m *GormDefaultRoleMappingRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "delete"}, time.Now())
+
+	obj := DefaultRoleMapping{DefaultRoleMappingID: id}
+
+	err := m.db.Delete(&obj).Error
+
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"default_role_mapping_id": id,
+			"err": err,
+		}, "unable to delete the default role mapping")
+		return errs.WithStack(err)
+	}
+
+	log.Debug(ctx, map[string]interface{}{
+		"default_role_mapping_id": id,
+	}, "Default role mapping deleted!")
+
+	return nil
+}
+
+func (m *GormDefaultRoleMappingRepository) FindForResourceType(ctx context.Context, resourceTypeID uuid.UUID) ([]DefaultRoleMapping, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "default_role_mapping", "FindForResourceType"}, time.Now())
+
+	var rows []DefaultRoleMapping
+
+	err := m.db.Model(&DefaultRoleMapping{}).Where("resource_type_id = ?", resourceTypeID).Find(&rows).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, errs.WithStack(err)
+	}
+	return rows, nil
+}

--- a/authorization/role/repository/default_role_mapping_blackbox_test.go
+++ b/authorization/role/repository/default_role_mapping_blackbox_test.go
@@ -1,0 +1,131 @@
+package repository_test
+
+import (
+	"testing"
+
+	rolerepo "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type defaultRoleMappingBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+	repo rolerepo.DefaultRoleMappingRepository
+}
+
+func TestRunDefaultRoleMappingBlackBoxTest(t *testing.T) {
+	suite.Run(t, &defaultRoleMappingBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *defaultRoleMappingBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.repo = rolerepo.NewDefaultRoleMappingRepository(s.DB)
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestOKToDelete() {
+	g := s.NewTestGraph()
+
+	rt := g.CreateResourceType()
+	rm := rolerepo.DefaultRoleMapping{
+		ResourceTypeID: rt.ResourceType().ResourceTypeID,
+		FromRoleID:     g.CreateRole(rt).Role().RoleID,
+		ToRoleID:       g.CreateRole().Role().RoleID,
+	}
+
+	err := s.repo.Create(s.Ctx, &rm)
+	require.NoError(s.T(), err)
+
+	rt2 := g.CreateResourceType()
+	rm2 := rolerepo.DefaultRoleMapping{
+		ResourceTypeID: rt2.ResourceType().ResourceTypeID,
+		FromRoleID:     g.CreateRole(rt).Role().RoleID,
+		ToRoleID:       g.CreateRole().Role().RoleID,
+	}
+
+	err = s.repo.Create(s.Ctx, &rm2)
+	require.NoError(s.T(), err)
+
+	mappings, err := s.repo.List(s.Ctx)
+	require.Nil(s.T(), err, "Could not list role mappings")
+
+	found1 := false
+	found2 := false
+
+	for _, mapping := range mappings {
+		if mapping.DefaultRoleMappingID == rm.DefaultRoleMappingID {
+			found1 = true
+		} else if mapping.DefaultRoleMappingID == rm2.DefaultRoleMappingID {
+			found2 = true
+		}
+	}
+
+	require.True(s.T(), found1, "first default role mapping not found")
+	require.True(s.T(), found2, "second default role mapping not found")
+
+	err = s.repo.Delete(s.Ctx, rm.DefaultRoleMappingID)
+	assert.Nil(s.T(), err)
+
+	mappings, err = s.repo.List(s.Ctx)
+	require.Nil(s.T(), err, "Could not list role mappings")
+
+	for _, data := range mappings {
+		// The default role mapping rm was deleted while rm2 was not deleted, hence we check
+		// that none of the role mappings returned include the deleted record.
+		require.NotEqual(s.T(), rm.DefaultRoleMappingID.String(), data.DefaultRoleMappingID.String())
+	}
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestOKToLoad() {
+	g := s.NewTestGraph()
+	rt := g.CreateResourceType()
+	rm := &rolerepo.DefaultRoleMapping{
+		ResourceTypeID: rt.ResourceType().ResourceTypeID,
+		FromRoleID:     g.CreateRole(rt).Role().RoleID,
+		ToRoleID:       g.CreateRole().Role().RoleID,
+	}
+
+	err := s.repo.Create(s.Ctx, rm)
+	require.NoError(s.T(), err)
+
+	_, err = s.repo.Load(s.Ctx, rm.DefaultRoleMappingID)
+	require.NoError(s.T(), err)
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestExistsDefaultRoleMapping() {
+	g := s.NewTestGraph()
+	rt := g.CreateResourceType()
+	rm := &rolerepo.DefaultRoleMapping{
+		ResourceTypeID: rt.ResourceType().ResourceTypeID,
+		FromRoleID:     g.CreateRole(rt).Role().RoleID,
+		ToRoleID:       g.CreateRole().Role().RoleID,
+	}
+
+	err := s.repo.Create(s.Ctx, rm)
+	require.NoError(s.T(), err)
+
+	_, err = s.repo.CheckExists(s.Ctx, rm.DefaultRoleMappingID)
+	require.NoError(s.T(), err)
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestOKToSave() {
+	g := s.NewTestGraph()
+	rt := g.CreateResourceType()
+	rm := &rolerepo.DefaultRoleMapping{
+		ResourceTypeID: rt.ResourceType().ResourceTypeID,
+		FromRoleID:     g.CreateRole(rt).Role().RoleID,
+		ToRoleID:       g.CreateRole().Role().RoleID,
+	}
+
+	err := s.repo.Create(s.Ctx, rm)
+	require.NoError(s.T(), err)
+
+	rm.ResourceTypeID = g.CreateResourceType().ResourceType().ResourceTypeID
+	err = s.repo.Save(s.Ctx, rm)
+	require.NoError(s.T(), err)
+
+	updated, err := s.repo.Load(s.Ctx, rm.DefaultRoleMappingID)
+	require.Nil(s.T(), err, "could not load default role mapping")
+	require.Equal(s.T(), rm.ResourceTypeID, updated.ResourceTypeID)
+}

--- a/authorization/role/repository/default_role_mapping_blackbox_test.go
+++ b/authorization/role/repository/default_role_mapping_blackbox_test.go
@@ -118,14 +118,31 @@ func (s *defaultRoleMappingBlackBoxTest) TestOKToSave() {
 		ToRoleID:       g.CreateRole().Role().RoleID,
 	}
 
+	otherRole := g.CreateRole()
+
 	err := s.repo.Create(s.Ctx, rm)
 	require.NoError(s.T(), err)
 
 	rm.ResourceTypeID = g.CreateResourceType().ResourceType().ResourceTypeID
+	rm.ToRoleID = otherRole.Role().RoleID
 	err = s.repo.Save(s.Ctx, rm)
 	require.NoError(s.T(), err)
 
 	updated, err := s.repo.Load(s.Ctx, rm.DefaultRoleMappingID)
 	require.Nil(s.T(), err, "could not load default role mapping")
 	require.Equal(s.T(), rm.ResourceTypeID, updated.ResourceTypeID)
+	require.Equal(s.T(), otherRole.Role().RoleID, updated.ToRoleID)
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestFindForResourceType() {
+	g := s.NewTestGraph()
+	rt := g.CreateResourceType()
+	rm := g.CreateDefaultRoleMapping(rt)
+	g.CreateDefaultRoleMapping()
+
+	mappings, err := s.repo.FindForResourceType(s.Ctx, rt.ResourceType().ResourceTypeID)
+	require.NoError(s.T(), err)
+
+	require.Len(s.T(), mappings, 1)
+	require.Equal(s.T(), mappings[0].DefaultRoleMappingID, rm.DefaultRoleMapping().DefaultRoleMappingID)
 }

--- a/authorization/role/repository/default_role_mapping_blackbox_test.go
+++ b/authorization/role/repository/default_role_mapping_blackbox_test.go
@@ -6,6 +6,8 @@ import (
 	rolerepo "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -69,7 +71,7 @@ func (s *defaultRoleMappingBlackBoxTest) TestOKToDelete() {
 	require.NoError(s.T(), err)
 
 	mappings, err = s.repo.List(s.Ctx)
-	require.Nil(s.T(), err, "Could not list role mappings")
+	require.NoError(s.T(), err, "Could not list role mappings")
 
 	for _, data := range mappings {
 		// The default role mapping rm was deleted while rm2 was not deleted, hence we check
@@ -79,9 +81,9 @@ func (s *defaultRoleMappingBlackBoxTest) TestOKToDelete() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestDeleteFailsForNonexistent() {
-	err := s.repo.Delete(s.Ctx, uuid.NewV4())
-	require.IsType(s.T(), errors.NotFoundError{}, err)
-	require.Error(s.T(), err)
+	id := uuid.NewV4()
+	err := s.repo.Delete(s.Ctx, id)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "default_role_mapping with id '%s' not found", id.String())
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestOKToLoad() {
@@ -105,8 +107,9 @@ func (s *defaultRoleMappingBlackBoxTest) TestOKToLoad() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestLoadFailsForNonexistent() {
-	_, err := s.repo.Load(s.Ctx, uuid.NewV4())
-	require.Error(s.T(), err)
+	id := uuid.NewV4()
+	_, err := s.repo.Load(s.Ctx, id)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "default_role_mapping with id '%s' not found", id.String())
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestExistsDefaultRoleMapping() {
@@ -121,8 +124,14 @@ func (s *defaultRoleMappingBlackBoxTest) TestExistsDefaultRoleMapping() {
 	err := s.repo.Create(s.Ctx, rm)
 	require.NoError(s.T(), err)
 
-	_, err = s.repo.CheckExists(s.Ctx, rm.DefaultRoleMappingID)
+	err = s.repo.CheckExists(s.Ctx, rm.DefaultRoleMappingID)
 	require.NoError(s.T(), err)
+}
+
+func (s *defaultRoleMappingBlackBoxTest) TestExistsUnknownDefaultRoleMappingFails() {
+	id := uuid.NewV4()
+	err := s.repo.CheckExists(s.Ctx, id)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "default_role_mapping with id '%s' not found", id.String())
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestOKToSave() {

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -16,6 +16,11 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+// RoleMapping is used to define a role mapping, allowing an identity with a certain role for the resource to
+// automatically inherit the privileges of another role for certain types of descendent resources.
+// For example, a role mapping for an organization resource that maps from the organization:admin role (FromRole)
+// to the space:admin role (ToRole) means that any identities that are assigned the admin role for the organization
+// also inherit the admin role for any space resources that are under that organization.
 type RoleMapping struct {
 	gormsupport.Lifecycle
 

--- a/authorization/role/repository/role_mapping.go
+++ b/authorization/role/repository/role_mapping.go
@@ -62,6 +62,7 @@ type RoleMappingRepository interface {
 	Save(ctx context.Context, u *RoleMapping) error
 	List(ctx context.Context) ([]RoleMapping, error)
 	Delete(ctx context.Context, ID uuid.UUID) error
+	FindForResource(ctx context.Context, resourceID string) ([]RoleMapping, error)
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name
@@ -185,4 +186,16 @@ func (m *GormRoleMappingRepository) Delete(ctx context.Context, id uuid.UUID) er
 	}, "Role mapping deleted!")
 
 	return nil
+}
+
+func (m *GormRoleMappingRepository) FindForResource(ctx context.Context, resourceID string) ([]RoleMapping, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "role_mapping", "FindForResource"}, time.Now())
+
+	var rows []RoleMapping
+
+	err := m.db.Model(&RoleMapping{}).Where("resource_id = ?", resourceID).Find(&rows).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, errs.WithStack(err)
+	}
+	return rows, nil
 }

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -140,3 +140,16 @@ func (s *roleMappingBlackBoxTest) TestOKToSave() {
 	require.Nil(s.T(), err, "Could not load role mapping")
 	require.Equal(s.T(), rm1.ResourceID, updatedRm.ResourceID)
 }
+
+func (s *roleMappingBlackBoxTest) TestFindForResource() {
+	g := s.NewTestGraph()
+
+	m := g.CreateRoleMapping(g.CreateResource(g.ID("r")))
+
+	mappings, err := s.repo.FindForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
+	require.NoError(s.T(), err)
+
+	require.Len(s.T(), mappings, 1)
+	require.Equal(s.T(), m.RoleMapping().FromRoleID, mappings[0].FromRoleID)
+	require.Equal(s.T(), m.RoleMapping().ToRoleID, mappings[0].ToRoleID)
+}

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -146,6 +146,11 @@ func (s *roleMappingBlackBoxTest) TestFindForResource() {
 
 	m := g.CreateRoleMapping(g.CreateResource(g.ID("r")))
 
+	// make some noise!!
+	for i := 0; i < 10; i++ {
+		g.CreateRoleMapping()
+	}
+
 	mappings, err := s.repo.FindForResource(s.Ctx, g.ResourceByID("r").Resource().ResourceID)
 	require.NoError(s.T(), err)
 

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -314,7 +314,7 @@ func (rest *TestResourceRolesRest) TestAssignRoleForbiddenNotAllowedToAssignRole
 
 	var identitiesToBeAssigned []*app.AssignRoleData
 	for i := 0; i <= 2; i++ {
-		testUser := g.CreateUser(g.ID("someusername"))
+		testUser := g.CreateUser()
 		res.AddViewer(testUser)
 		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
 	}

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -130,6 +130,14 @@ func (g *GormBase) IdentityRoleRepository() role.IdentityRoleRepository {
 	return role.NewIdentityRoleRepository(g.db)
 }
 
+func (g *GormBase) DefaultRoleMappingRepository() role.DefaultRoleMappingRepository {
+	return role.NewDefaultRoleMappingRepository(g.db)
+}
+
+func (g *GormBase) RoleMappingRepository() role.RoleMappingRepository {
+	return role.NewRoleMappingRepository(g.db)
+}
+
 func (g *GormDB) InvitationService() service.InvitationService {
 	return g.serviceFactory.InvitationService()
 }

--- a/test/graph/default_role_mapping_wrapper.go
+++ b/test/graph/default_role_mapping_wrapper.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+	"github.com/stretchr/testify/require"
+)
+
+// defaultRoleMappingWrapper represents a default role mapping domain object
+type defaultRoleMappingWrapper struct {
+	baseWrapper
+	mapping *role.DefaultRoleMapping
+}
+
+func newDefaultRoleMappingWrapper(g *TestGraph, params []interface{}) defaultRoleMappingWrapper {
+	w := defaultRoleMappingWrapper{baseWrapper: baseWrapper{g}}
+
+	var resourceType *resourceTypeWrapper
+	var fromRole *role.Role
+	var toRole *role.Role
+
+	for i := range params {
+		switch t := params[i].(type) {
+		case resourceTypeWrapper:
+			resourceType = &t
+		case roleWrapper:
+			if fromRole == nil {
+				fromRole = t.role
+			} else if toRole == nil {
+				toRole = t.role
+			}
+		}
+	}
+
+	if resourceType == nil {
+		resourceType = w.graph.CreateResourceType()
+	}
+
+	if fromRole == nil {
+		fromRole = w.graph.CreateRole(resourceType).Role()
+	}
+
+	if toRole == nil {
+		toRole = w.graph.CreateRole().Role()
+	}
+
+	w.mapping = &role.DefaultRoleMapping{
+		ResourceTypeID: resourceType.ResourceType().ResourceTypeID,
+		FromRole:       *fromRole,
+		ToRole:         *toRole,
+	}
+
+	err := g.app.DefaultRoleMappingRepository().Create(g.ctx, w.mapping)
+	require.NoError(g.t, err)
+
+	return w
+}
+
+func (g *defaultRoleMappingWrapper) DefaultRoleMapping() *role.DefaultRoleMapping {
+	return g.mapping
+}

--- a/test/graph/default_role_mapping_wrapper.go
+++ b/test/graph/default_role_mapping_wrapper.go
@@ -22,6 +22,8 @@ func newDefaultRoleMappingWrapper(g *TestGraph, params []interface{}) defaultRol
 		switch t := params[i].(type) {
 		case resourceTypeWrapper:
 			resourceType = &t
+		case *resourceTypeWrapper:
+			resourceType = t
 		case roleWrapper:
 			if fromRole == nil {
 				fromRole = t.role
@@ -45,8 +47,8 @@ func newDefaultRoleMappingWrapper(g *TestGraph, params []interface{}) defaultRol
 
 	w.mapping = &role.DefaultRoleMapping{
 		ResourceTypeID: resourceType.ResourceType().ResourceTypeID,
-		FromRole:       *fromRole,
-		ToRole:         *toRole,
+		FromRoleID:     fromRole.RoleID,
+		ToRoleID:       toRole.RoleID,
 	}
 
 	err := g.app.DefaultRoleMappingRepository().Create(g.ctx, w.mapping)

--- a/test/graph/role_mapping_wrapper.go
+++ b/test/graph/role_mapping_wrapper.go
@@ -1,0 +1,63 @@
+package graph
+
+import (
+	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+	"github.com/stretchr/testify/require"
+)
+
+// roleMappingWrapper represents a default role mapping domain object
+type roleMappingWrapper struct {
+	baseWrapper
+	mapping *role.RoleMapping
+}
+
+func newRoleMappingWrapper(g *TestGraph, params []interface{}) roleMappingWrapper {
+	w := roleMappingWrapper{baseWrapper: baseWrapper{g}}
+
+	var resource *resourceWrapper
+	var fromRole *role.Role
+	var toRole *role.Role
+
+	for i := range params {
+		switch t := params[i].(type) {
+		case resourceWrapper:
+			resource = &t
+		case *resourceWrapper:
+			resource = t
+		case roleWrapper:
+			if fromRole == nil {
+				fromRole = t.role
+			} else if toRole == nil {
+				toRole = t.role
+			}
+		}
+	}
+
+	if resource == nil {
+		resource = w.graph.CreateResource()
+	}
+
+	if fromRole == nil {
+		resourceType := w.graph.LoadResourceType(resource.Resource().ResourceTypeID)
+		fromRole = w.graph.CreateRole(resourceType).Role()
+	}
+
+	if toRole == nil {
+		toRole = w.graph.CreateRole().Role()
+	}
+
+	w.mapping = &role.RoleMapping{
+		ResourceID: resource.Resource().ResourceID,
+		FromRoleID: fromRole.RoleID,
+		ToRoleID:   toRole.RoleID,
+	}
+
+	err := g.app.RoleMappingRepository().Create(g.ctx, w.mapping)
+	require.NoError(g.t, err)
+
+	return w
+}
+
+func (g *roleMappingWrapper) RoleMapping() *role.RoleMapping {
+	return g.mapping
+}

--- a/test/graph/role_wrapper.go
+++ b/test/graph/role_wrapper.go
@@ -27,6 +27,10 @@ func newRoleWrapper(g *TestGraph, params []interface{}) roleWrapper {
 			resourceType = t.resourceType
 		case *resourceTypeWrapper:
 			resourceType = t.resourceType
+		case resourcetype.ResourceType:
+			resourceType = &t
+		case *resourcetype.ResourceType:
+			resourceType = t
 		}
 	}
 

--- a/test/graph/role_wrapper.go
+++ b/test/graph/role_wrapper.go
@@ -1,0 +1,55 @@
+package graph
+
+import (
+	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
+	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// roleWrapper represents a resource domain object
+type roleWrapper struct {
+	baseWrapper
+	role *role.Role
+}
+
+func newRoleWrapper(g *TestGraph, params []interface{}) roleWrapper {
+	w := roleWrapper{baseWrapper: baseWrapper{g}}
+
+	var roleName *string
+	var resourceType *resourcetype.ResourceType
+
+	for i := range params {
+		switch t := params[i].(type) {
+		case string:
+			roleName = &t
+		case resourceTypeWrapper:
+			resourceType = t.resourceType
+		case *resourceTypeWrapper:
+			resourceType = t.resourceType
+		}
+	}
+
+	if resourceType == nil {
+		resourceType = w.graph.CreateResourceType().ResourceType()
+	}
+
+	if roleName == nil {
+		nm := "Role-" + uuid.NewV4().String()
+		roleName = &nm
+	}
+
+	w.role = &role.Role{
+		Name:           *roleName,
+		ResourceTypeID: resourceType.ResourceTypeID,
+	}
+
+	err := g.app.RoleRepository().Create(g.ctx, w.role)
+	require.NoError(g.t, err)
+
+	return w
+}
+
+func (g *roleWrapper) Role() *role.Role {
+	return g.role
+}

--- a/test/graph/test_graph.go
+++ b/test/graph/test_graph.go
@@ -46,7 +46,11 @@ func NewTestGraph(t *testing.T, app application.Application, ctx context.Context
 
 // register registers a new wrapper object with the test graph's internal list of objects
 func (g *TestGraph) register(id string, wrapper interface{}) {
-	g.graphObjects[id] = wrapper
+	if _, found := g.graphObjects[id]; found {
+		require.True(g.t, false, "object identifier '%s' already registered", id)
+	} else {
+		g.graphObjects[id] = wrapper
+	}
 }
 
 func (g *TestGraph) generateIdentifier(params []interface{}) string {
@@ -108,11 +112,10 @@ func (g *TestGraph) LoadResourceType(params ...interface{}) *resourceTypeWrapper
 			resourceTypeName = &t
 		case *string:
 			resourceTypeName = t
-
 		}
 	}
 
-	require.True(g.t, resourceTypeID != nil || resourceTypeName != nil, "must specified either rresource_type_id or name parameter for the resource type to load")
+	require.True(g.t, resourceTypeID != nil || resourceTypeName != nil, "must specified either resource_type_id or name parameter for the resource type to load")
 
 	w := loadResourceTypeWrapper(g, resourceTypeID, resourceTypeName)
 	g.register(g.generateIdentifier(params), &w)
@@ -177,4 +180,24 @@ func (g *TestGraph) LoadIdentity(params ...interface{}) *identityWrapper {
 	w := loadIdentityWrapper(g, *identityID)
 	g.register(g.generateIdentifier(params), &w)
 	return &w
+}
+
+func (g *TestGraph) CreateRole(params ...interface{}) *roleWrapper {
+	obj := newRoleWrapper(g, params)
+	g.register(g.generateIdentifier(params), &obj)
+	return &obj
+}
+
+func (g *TestGraph) RoleByID(id string) *roleWrapper {
+	return g.graphObjects[id].(*roleWrapper)
+}
+
+func (g *TestGraph) CreateDefaultRoleMapping(params ...interface{}) *defaultRoleMappingWrapper {
+	obj := newDefaultRoleMappingWrapper(g, params)
+	g.register(g.generateIdentifier(params), &obj)
+	return &obj
+}
+
+func (g *TestGraph) DefaultRoleMappingByID(id string) *defaultRoleMappingWrapper {
+	return g.graphObjects[id].(*defaultRoleMappingWrapper)
 }

--- a/test/graph/test_graph.go
+++ b/test/graph/test_graph.go
@@ -201,3 +201,13 @@ func (g *TestGraph) CreateDefaultRoleMapping(params ...interface{}) *defaultRole
 func (g *TestGraph) DefaultRoleMappingByID(id string) *defaultRoleMappingWrapper {
 	return g.graphObjects[id].(*defaultRoleMappingWrapper)
 }
+
+func (g *TestGraph) CreateRoleMapping(params ...interface{}) *roleMappingWrapper {
+	obj := newRoleMappingWrapper(g, params)
+	g.register(g.generateIdentifier(params), &obj)
+	return &obj
+}
+
+func (g *TestGraph) RoleMappingByID(id string) *roleMappingWrapper {
+	return g.graphObjects[id].(*roleMappingWrapper)
+}


### PR DESCRIPTION
This PR fixes #472 

Creates role mapping records for resources during resource registration, based on the default role mappings for the resource type.

