### PR TITLE
temporarily support space creation using service account

### DIFF
--- a/configuration/conf-files/service-account-secrets.conf
+++ b/configuration/conf-files/service-account-secrets.conf
@@ -39,6 +39,11 @@
             "name":"rh-che",
             "id":"d6d5b568-8a3c-4e42-bcac-adeb14eb3b15",
             "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
+        },
+        {
+            "name":"space-migration",
+            "id":"d3170241-97cb-43e3-acee-41355ecc5edb",
+            "secrets":["$2a$10$GLPH8.d3V4vJ.M9l7BLmw.ExTyHJR.6J4W1B2rttQNr8xfzZC.eO."]
         }
     ]
 }

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -602,7 +602,7 @@ func (rest *TestCollaboratorsREST) createSpace() uuid.UUID {
 	require.NotNil(rest.T(), spaceCtrl)
 
 	id := uuid.NewV4()
-	test.CreateSpaceOK(rest.T(), svc.Context, svc, spaceCtrl, id)
+	test.CreateSpaceOK(rest.T(), svc.Context, svc, spaceCtrl, id, nil)
 	return id
 }
 
@@ -640,6 +640,7 @@ type DummyResourceManager struct {
 }
 
 func (m *DummyResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*auth.Resource, error) {
+
 	if m.ResourceID == nil {
 		return &auth.Resource{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}, nil
 	}

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -45,6 +45,7 @@ var _ = a.Resource("space", func() {
 		a.Description("Create a space resource for the giving space")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
+			a.Param("creator", d.UUID, "identity ID of the space creator")
 		})
 		a.Response(d.OK, spaceResource)
 		a.Response(d.BadRequest, JSONAPIErrors)


### PR DESCRIPTION
If the space creation API call is made using the `space-migration` service account, then the creator ID is passed as a parameter in the request `/api/spaces/spaceID?creator=creator-uuid`.

In this scenario, there would be no keycloak interactions, or `space_resources` table updation.

This commit can be reverted after migration of spaces is done.

Dependency of #365 