### PR TITLE
Support 409 error for creating a space with existing ID

### DIFF
--- a/authorization/resource/repository/resource.go
+++ b/authorization/resource/repository/resource.go
@@ -136,6 +136,9 @@ func (m *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 			}, "unable to create organization resource as an organization with the same name already exists")
 			return errors.NewDataConflictError(fmt.Sprintf("organization with same name already exists, '%s'", resource.Name))
 		}
+		if gormsupport.IsUniqueViolation(err, "resource_pkey") {
+			return errors.NewDataConflictError(fmt.Sprintf("resource with ID %s already exists", resource.ResourceID))
+		}
 
 		log.Error(ctx, map[string]interface{}{
 			"resource_id": resource.ResourceID,

--- a/authorization/resource/repository/resource_blackbox_test.go
+++ b/authorization/resource/repository/resource_blackbox_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 
 	"github.com/fabric8-services/fabric8-auth/authorization"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,7 +155,7 @@ func (s *resourceBlackBoxTest) TestCannotCreateDuplicateOrganizationNames() {
 
 func (s *resourceBlackBoxTest) TestCreateResourceDataConflict() {
 	resourceType, err := s.resourceTypeRepo.Lookup(s.Ctx, "openshift.io/resource/area")
-	require.Nil(s.T(), err, "Could not find resource type")
+	require.NoError(s.T(), err, "Could not find resource type")
 
 	resource := &resource.Resource{
 		ResourceID:     uuid.NewV4().String(),
@@ -163,11 +164,11 @@ func (s *resourceBlackBoxTest) TestCreateResourceDataConflict() {
 	}
 
 	err = s.repo.Create(s.Ctx, resource)
-	require.Nil(s.T(), err, "Could not create resource")
+	require.NoError(s.T(), err, "Could not create resource")
 
 	err = s.repo.Create(s.Ctx, resource)
-	require.Error(s.T(), err)
-	require.IsType(s.T(), errors.DataConflictError{}, err)
+	testsupport.AssertError(s.T(), err, errors.DataConflictError{}, "resource with ID %s already exists", resource.ResourceID)
+	//require.IsType(s.T(), errors.DataConflictError{}, err)
 }
 
 func createAndLoadResource(s *resourceBlackBoxTest, parentResourceID *string) *resource.Resource {

--- a/authorization/resource/repository/resource_blackbox_test.go
+++ b/authorization/resource/repository/resource_blackbox_test.go
@@ -152,6 +152,24 @@ func (s *resourceBlackBoxTest) TestCannotCreateDuplicateOrganizationNames() {
 	require.IsType(s.T(), errors.DataConflictError{}, err)
 }
 
+func (s *resourceBlackBoxTest) TestCreateResourceDataConflict() {
+	resourceType, err := s.resourceTypeRepo.Lookup(s.Ctx, "openshift.io/resource/area")
+	require.Nil(s.T(), err, "Could not find resource type")
+
+	resource := &resource.Resource{
+		ResourceID:     uuid.NewV4().String(),
+		ResourceType:   *resourceType,
+		ResourceTypeID: resourceType.ResourceTypeID,
+	}
+
+	err = s.repo.Create(s.Ctx, resource)
+	require.Nil(s.T(), err, "Could not create resource")
+
+	err = s.repo.Create(s.Ctx, resource)
+	require.Error(s.T(), err)
+	require.IsType(s.T(), errors.DataConflictError{}, err)
+}
+
 func createAndLoadResource(s *resourceBlackBoxTest, parentResourceID *string) *resource.Resource {
 	resourceType, err := s.resourceTypeRepo.Lookup(s.Ctx, "openshift.io/resource/area")
 	require.Nil(s.T(), err, "Could not find resource type")

--- a/authorization/space/service/space_service_blackbox_test.go
+++ b/authorization/space/service/space_service_blackbox_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/authorization"
@@ -8,7 +9,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/fabric8-services/fabric8-auth/test"
 
-	"github.com/lib/pq"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +52,7 @@ func (s *spaceServiceBlackBoxTest) TestCreateOK() {
 
 	// If we try to create another space with the same ID it should fail
 	err = s.Application.SpaceService().CreateSpace(s.Ctx, creator.Identity().ID, spaceID)
-	test.AssertError(s.T(), err, &pq.Error{}, "pq: duplicate key value violates unique constraint \"resource_pkey\"")
+	test.AssertError(s.T(), err, errors.DataConflictError{}, fmt.Sprintf("resource with ID %s already exists", spaceID))
 }
 
 func (s *spaceServiceBlackBoxTest) TestDeleteUnknownSpaceFails() {

--- a/authorization/space/service/space_service_blackbox_test.go
+++ b/authorization/space/service/space_service_blackbox_test.go
@@ -1,7 +1,6 @@
 package service_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/authorization"
@@ -52,7 +51,7 @@ func (s *spaceServiceBlackBoxTest) TestCreateOK() {
 
 	// If we try to create another space with the same ID it should fail
 	err = s.Application.SpaceService().CreateSpace(s.Ctx, creator.Identity().ID, spaceID)
-	test.AssertError(s.T(), err, errors.DataConflictError{}, fmt.Sprintf("resource with ID %s already exists", spaceID))
+	test.AssertError(s.T(), err, errors.DataConflictError{}, "resource with ID %s already exists", spaceID)
 }
 
 func (s *spaceServiceBlackBoxTest) TestDeleteUnknownSpaceFails() {

--- a/controller/space.go
+++ b/controller/space.go
@@ -121,7 +121,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 			}
 		}
 
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
 	if resource != nil { // for migration = true, resource is nil

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -128,6 +128,9 @@ func (rest *TestSpaceREST) TestCreateSpaceWithServiceAccountOK() {
 	require.Len(rest.T(), assignedRoles, 1)
 	assert.Equal(rest.T(), creator.ID, assignedRoles[0].Identity.ID)
 	assert.Equal(rest.T(), authorization.SpaceAdminRole, assignedRoles[0].Role.Name)
+
+	// Now try to create a space with the same ID
+	test.CreateSpaceConflict(rest.T(), svc.Context, svc, ctrl, spaceID, &creator.ID)
 }
 
 func (rest *TestSpaceREST) TestCreateSpaceOK() {
@@ -164,7 +167,7 @@ func (rest *TestSpaceREST) TestKeycloakResourceCreationRollBack() {
 	require.NoError(rest.T(), err)
 
 	// Should fail because the space already exists.
-	test.CreateSpaceInternalServerError(rest.T(), svc.Context, svc, ctrl, spaceID, nil)
+	test.CreateSpaceConflict(rest.T(), svc.Context, svc, ctrl, spaceID, nil)
 
 	// Check that no keycloak resource exist for this space ID
 	_, err = rest.Application.SpaceResources().LoadBySpace(svc.Context, &spaceID)

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -51,6 +51,7 @@ var _ = a.Resource("space", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
 	a.Action("delete", func() {


### PR DESCRIPTION
Return 409 if a space is being created with an existing resource ID