### PR TITLE
 Allow assignment of role even if user not in space, using service account

### DIFF
--- a/controller/resource_roles.go
+++ b/controller/resource_roles.go
@@ -3,11 +3,15 @@ package controller
 import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/authorization"
+	resource "github.com/fabric8-services/fabric8-auth/authorization/resource/repository"
+	resourcetype "github.com/fabric8-services/fabric8-auth/authorization/resourcetype/repository"
 	role "github.com/fabric8-services/fabric8-auth/authorization/role/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/login"
+	"github.com/fabric8-services/fabric8-auth/token"
 	"github.com/satori/go.uuid"
 
 	"github.com/goadesign/goa"
@@ -92,6 +96,8 @@ func (c *ResourceRolesController) ListAssignedByRoleName(ctx *app.ListAssignedBy
 // AssignRole assigns a specific role for a resource, to one or more identities.
 func (c *ResourceRolesController) AssignRole(ctx *app.AssignRoleResourceRolesContext) error {
 
+	isMigration := token.IsSpecificServiceAccount(ctx, "space-migration")
+
 	currentUser, err := login.ContextIdentity(ctx)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -120,7 +126,26 @@ func (c *ResourceRolesController) AssignRole(ctx *app.AssignRoleResourceRolesCon
 			}
 		}
 	}
-	err = c.app.RoleManagementService().Assign(ctx, *currentUser, roleAssignments, ctx.ResourceID, false)
+	if isMigration {
+		// Temporary: During migration, if the service account token to call this API,
+		// then the 'contributor' role can be added to existing space collaborators.
+		// without this, the Assign() service will not allow a role to be assigned since the user does not have a prior
+		// associattion with this space
+		res := resource.Resource{
+			ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace},
+			ResourceID:   ctx.ResourceID,
+		}
+		for rolename, assignedTo := range roleAssignments {
+			for _, assignee := range assignedTo {
+				err = c.app.RoleManagementService().ForceAssign(ctx, assignee, rolename, res)
+				if err != nil {
+					return jsonapi.JSONErrorResponse(ctx, err)
+				}
+			}
+		}
+	} else {
+		err = c.app.RoleManagementService().Assign(ctx, *currentUser, roleAssignments, ctx.ResourceID, false)
+	}
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/controller/resource_roles.go
+++ b/controller/resource_roles.go
@@ -126,11 +126,12 @@ func (c *ResourceRolesController) AssignRole(ctx *app.AssignRoleResourceRolesCon
 			}
 		}
 	}
+
+	// Temporary: During migration, if the service account token is used to call this API,
+	// then the 'contributor' role can be added to existing space collaborators.
+	// Without this, the Assign() service method will not allow a role to be assigned since the user does not have a prior
+	// associattion with this space
 	if isMigration {
-		// Temporary: During migration, if the service account token to call this API,
-		// then the 'contributor' role can be added to existing space collaborators.
-		// without this, the Assign() service will not allow a role to be assigned since the user does not have a prior
-		// associattion with this space
 		res := resource.Resource{
 			ResourceType: resourcetype.ResourceType{Name: authorization.ResourceTypeSpace},
 			ResourceID:   ctx.ResourceID,

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -41,6 +41,14 @@ func (rest *TestResourceRolesRest) UnSecuredController() (*goa.Service, *Resourc
 	return svc, NewResourceRolesController(svc, rest.Application)
 }
 
+func (rest *TestResourceRolesRest) SecuredControllerWithServiceAccount(serviceAccountName string) (*goa.Service, *ResourceRolesController) {
+	identity, err := testsupport.CreateTestIdentityAndUser(rest.DB, serviceAccountName, "KC")
+	require.NoError(rest.T(), err)
+
+	svc := testsupport.ServiceAsServiceAccountUser(serviceAccountName, identity)
+	return svc, NewResourceRolesController(svc, rest.Application)
+}
+
 func TestRunResourceRolesRest(t *testing.T) {
 	suite.Run(t, &TestResourceRolesRest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
@@ -306,6 +314,26 @@ func (rest *TestResourceRolesRest) TestAssignRoleBadRequestUserNotInSpace() {
 	}
 
 	test.AssignRoleResourceRolesBadRequest(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
+}
+
+func (rest *TestResourceRolesRest) TestAssignRoleUserNotInSpaceOK() {
+	g := rest.DBTestSuite.NewTestGraph()
+	res := g.CreateSpace()
+
+	var identitiesToBeAssigned []*app.AssignRoleData
+
+	// don't have any role assigned.
+	for i := 0; i <= 2; i++ {
+		testUser := g.CreateUser()
+		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
+	}
+
+	svc, ctrl := rest.SecuredControllerWithServiceAccount("space-migration")
+	payload := &app.AssignRoleResourceRolesPayload{
+		Data: identitiesToBeAssigned,
+	}
+
+	test.AssignRoleResourceRolesNoContent(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
 }
 
 func (rest *TestResourceRolesRest) TestAssignRoleForbiddenNotAllowedToAssignRoles() {


### PR DESCRIPTION
During migration, the script will be adding a contributor role for every collaborator in a space. However, the existing design disallows use of Assign API if the user isn't already a part of the space.

This PR adds an exception to the above rule if the service account token is passed. After migration, these changes can be safely reverted.