### PR TITLE
Add WWW-Authenticate: LOGIN header to the error response when login is required

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -85,6 +85,7 @@ func (c *TokenController) Refresh(ctx *app.RefreshTokenContext) error {
 
 	t, err := c.Auth.ExchangeRefreshToken(ctx, *refreshToken, endpoint, c.Configuration)
 	if err != nil {
+		c.TokenManager.AddLoginRequiredHeaderToUnauthorizedError(err, ctx.ResponseData)
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
@@ -183,7 +184,7 @@ func (c *TokenController) getKeycloakIdentityProviderURL(identityID string, prov
 func (c *TokenController) Retrieve(ctx *app.RetrieveTokenContext) error {
 	appToken, errorResponse, err := c.retrieveToken(ctx, ctx.For, ctx.RequestData, ctx.ForcePull)
 	if errorResponse != nil {
-		ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+		ctx.ResponseData.Header().Add("Access-Control-Expose-Headers", "WWW-Authenticate")
 		ctx.ResponseData.Header().Set("WWW-Authenticate", *errorResponse)
 	}
 	if err != nil {
@@ -196,7 +197,7 @@ func (c *TokenController) Retrieve(ctx *app.RetrieveTokenContext) error {
 func (c *TokenController) Status(ctx *app.StatusTokenContext) error {
 	appToken, errorResponse, err := c.retrieveToken(ctx, ctx.For, ctx.RequestData, ctx.ForcePull)
 	if errorResponse != nil {
-		ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+		ctx.ResponseData.Header().Add("Access-Control-Expose-Headers", "WWW-Authenticate")
 		ctx.ResponseData.Header().Set("WWW-Authenticate", *errorResponse)
 	}
 	if err != nil {
@@ -408,6 +409,7 @@ func (c *TokenController) exchangeWithGrantTypeRefreshToken(ctx *app.ExchangeTok
 
 	t, err := c.Auth.ExchangeRefreshToken(ctx, *refreshToken, endpoint, c.Configuration)
 	if err != nil {
+		c.TokenManager.AddLoginRequiredHeaderToUnauthorizedError(err, ctx.ResponseData)
 		return nil, err
 	}
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")

--- a/controller/user.go
+++ b/controller/user.go
@@ -47,7 +47,7 @@ func (c *UserController) Show(ctx *app.ShowUserContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	if user.Deprovisioned {
-		ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+		ctx.ResponseData.Header().Add("Access-Control-Expose-Headers", "WWW-Authenticate")
 		ctx.ResponseData.Header().Set("WWW-Authenticate", "DEPROVISIONED description=\"Account has been deprovisioned\"")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("Account has been deprovisioned"))
 	}

--- a/controller/userinfo.go
+++ b/controller/userinfo.go
@@ -37,7 +37,7 @@ func (c *UserinfoController) Show(ctx *app.ShowUserinfoContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	if user.Deprovisioned {
-		ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+		ctx.ResponseData.Header().Add("Access-Control-Expose-Headers", "WWW-Authenticate")
 		ctx.ResponseData.Header().Set("WWW-Authenticate", "DEPROVISIONED description=\"Account has been deprovisioned\"")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("Account has been deprovisioned"))
 	}

--- a/controller/users.go
+++ b/controller/users.go
@@ -91,7 +91,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 		if tenantSA && identity.User.Deprovisioned {
 			// Don't return deprovisioned users for calls made by Tenant SA
 			// TODO we should disable notifications for such users too but if we just return 401 for notification service request we may break it
-			ctx.ResponseData.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+			ctx.ResponseData.Header().Add("Access-Control-Expose-Headers", "WWW-Authenticate")
 			ctx.ResponseData.Header().Set("WWW-Authenticate", "DEPROVISIONED description=\"Account has been deprovisioned\"")
 			return errors.NewUnauthorizedError("Account has been deprovisioned")
 		}

--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -17,30 +17,35 @@ import (
 // Authorization header when possible. If the Authorization header is missing in the request,
 // no error is returned. However, if the Authorization header contains a
 // token, it will be stored it in the context.
-func TokenContext(tokenManager token.Parser, scheme *goa.JWTSecurity) goa.Middleware {
+func TokenContext(tokenManager token.Manager, scheme *goa.JWTSecurity) goa.Middleware {
 	errUnauthorized := goa.NewErrorClass("token_validation_failed", 401)
 	return func(nextHandler goa.Handler) goa.Handler {
-		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-			// TODO: implement the QUERY string handler too
-			if scheme.In != goa.LocHeader {
-				log.Error(ctx, nil, fmt.Sprintf("whoops, security scheme with location (in) %q not supported", scheme.In))
-				return fmt.Errorf("whoops, security scheme with location (in) %q not supported", scheme.In)
-			}
-			val := req.Header.Get(scheme.Name)
-			if val != "" && strings.HasPrefix(strings.ToLower(val), "bearer ") {
-				log.Debug(ctx, nil, "found header 'Authorization: Bearer JWT-token...'")
-				incomingToken := strings.Split(val, " ")[1]
-				log.Debug(ctx, nil, "extracted the incoming token %v ", incomingToken)
+		return handler(tokenManager, scheme, nextHandler, errUnauthorized)
+	}
+}
 
-				token, err := tokenManager.Parse(ctx, incomingToken)
-				if err != nil {
-					log.Error(ctx, map[string]interface{}{"error": err}, "failed to handle JSON Web Token in TokenContext middleware")
-					return errUnauthorized("token is invalid")
-				}
-				ctx = jwt.WithJWT(ctx, token)
-			}
-
-			return nextHandler(ctx, rw, req)
+func handler(tokenManager token.Manager, scheme *goa.JWTSecurity, nextHandler goa.Handler, errUnauthorized goa.ErrorClass) goa.Handler {
+	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// TODO: implement the QUERY string handler too
+		if scheme.In != goa.LocHeader {
+			log.Error(ctx, nil, fmt.Sprintf("whoops, security scheme with location (in) %q not supported", scheme.In))
+			return fmt.Errorf("whoops, security scheme with location (in) %q not supported", scheme.In)
 		}
+		val := req.Header.Get(scheme.Name)
+		if val != "" && strings.HasPrefix(strings.ToLower(val), "bearer ") {
+			log.Debug(ctx, nil, "found header 'Authorization: Bearer JWT-token...'")
+			incomingToken := strings.Split(val, " ")[1]
+			log.Debug(ctx, nil, "extracted the incoming token %v ", incomingToken)
+
+			token, err := tokenManager.Parse(ctx, incomingToken)
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{"error": err}, "failed to handle JSON Web Token in TokenContext middleware")
+				tokenManager.AddLoginRequiredHeader(rw)
+				return errUnauthorized("token is invalid")
+			}
+			ctx = jwt.WithJWT(ctx, token)
+		}
+
+		return nextHandler(ctx, rw, req)
 	}
 }

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -1,0 +1,77 @@
+package goamiddleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"testing"
+
+	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
+
+	"github.com/goadesign/goa"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestJWTokenContext(t *testing.T) {
+	suite.Run(t, &TestJWTokenContextSuite{})
+}
+
+type TestJWTokenContextSuite struct {
+	testsuite.UnitTestSuite
+}
+
+func (s *TestJWTokenContextSuite) TestHandler() {
+	schema := &goa.JWTSecurity{}
+	errUnauthorized := goa.NewErrorClass("token_validation_failed", 401)
+
+	rw := httptest.NewRecorder()
+	rq := &http.Request{Header: make(map[string][]string)}
+	h := handler(testtoken.TokenManager, schema, dummyHandler, errUnauthorized)
+
+	err := h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "whoops, security scheme with location (in) \"\" not supported", err.Error())
+
+	// OK if no Authorization header
+	schema.In = "header"
+	err = h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "next-handler-error", err.Error())
+
+	// OK if not bearer
+	schema.Name = "Authorization"
+	rq.Header.Set("Authorization", "something")
+	err = h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "next-handler-error", err.Error())
+
+	// Get 401 if token is invalid
+	rq.Header.Set("Authorization", "bearer token")
+	err = h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "401 token_validation_failed: token is invalid", err.Error())
+	assert.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
+	assert.Contains(s.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
+
+	// OK if token is valid
+	rw = httptest.NewRecorder()
+	t, err := testtoken.TokenManager.GenerateServiceAccountToken(uuid.NewV4().String(), "sa-name")
+	require.NoError(s.T(), err)
+	rq.Header.Set("Authorization", "bearer "+t)
+	err = h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "next-handler-error", err.Error())
+	header := textproto.MIMEHeader(rw.Header())
+	assert.NotContains(s.T(), header, "WWW-Authenticate")
+	assert.NotContains(s.T(), header, "Access-Control-Expose-Headers")
+}
+
+func dummyHandler(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+	return errors.New("next-handler-error")
+}


### PR DESCRIPTION
- [x] `WWW-Authenticate: LOGIN ur="https://auth.openshift.io/api/login" description="re-login is required"` header is added if any request to Auth contains an invalid bearer token: `Authorization: bearer ${token}`
- [x] The same `WWW-Authenticate: LOGIN` header added to the 401 response if https://auth.openshift.io/api/token/refresh endpoint got 401 from Keycloak

This PR is required to fix the backend side of https://github.com/openshiftio/openshift.io/issues/3746
Also part of https://github.com/openshiftio/openshift.io/issues/3736