### PR TITLE
Use keycloak permissions for List Collaborators API

### DIFF
--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -47,14 +47,6 @@ func NewCollaboratorsController(service *goa.Service, app application.Applicatio
 func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error {
 	isServiceAccount := token.IsSpecificServiceAccount(ctx, token.Notification)
 
-	found, err := c.checkSpaceExist(ctx, ctx.SpaceID.String())
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, err)
-	}
-	if found {
-		return c.listCollaborators(ctx, isServiceAccount)
-	}
-
 	policy, _, err := c.getPolicy(ctx, ctx.RequestData, ctx.SpaceID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -146,18 +146,16 @@ func (rest *TestCollaboratorsREST) TestListCollaboratorsWithRandomSpaceIDNotFoun
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsOK() {
-	admin := rest.Graph.CreateUser()
-	contr := rest.Graph.CreateUser()
-	space := rest.Graph.CreateSpace().AddAdmin(admin).AddContributor(contr)
+	// given
+	svc, ctrl := rest.SecuredControllerForIdentity(&testsupport.TestIdentity)
+	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
+	rest.policy.AddUserToPolicy(rest.testIdentity2.ID.String())
 
-	// noise
-	rest.Graph.CreateSpace().AddAdmin(rest.Graph.CreateUser()).AddContributor(rest.Graph.CreateUser())
-
-	svc, ctrl := rest.SecuredControllerForIdentity(admin.Identity())
-	spaceID, err := uuid.FromString(space.SpaceID())
-	require.NoError(rest.T(), err)
-	_, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, nil, nil, nil)
-	rest.checkCollaborators([]uuid.UUID{admin.IdentityID(), contr.IdentityID()}, actualUsers)
+	// when
+	res, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, nil, nil)
+	// then
+	assertResponseHeaders(rest.T(), res)
+	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID}, actualUsers)
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsPrivateEmailsOK() {

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -237,38 +237,26 @@ func (rest *TestCollaboratorsREST) TestListCollaboratorsByPagesOK() {
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsOKUsingExpiredIfModifiedSinceHeader() {
-	admin := rest.Graph.CreateUser()
-	contr := rest.Graph.CreateUser()
-	space := rest.Graph.CreateSpace().AddAdmin(admin).AddContributor(contr)
-
-	// noise
-	rest.Graph.CreateSpace().AddAdmin(rest.Graph.CreateUser()).AddContributor(rest.Graph.CreateUser())
-
-	svc, ctrl := rest.SecuredControllerForIdentity(admin.Identity())
-	spaceID, err := uuid.FromString(space.SpaceID())
-	require.NoError(rest.T(), err)
+	// given
+	svc, ctrl := rest.SecuredControllerForIdentity(&testsupport.TestIdentity)
+	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
+	rest.policy.AddUserToPolicy(rest.testIdentity2.ID.String())
 
 	ifModifiedSince := app.ToHTTPTime(rest.testIdentity1.User.UpdatedAt.Add(-1 * time.Hour))
-	res, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, nil, &ifModifiedSince, nil)
-	rest.checkCollaborators([]uuid.UUID{admin.IdentityID(), contr.IdentityID()}, actualUsers)
+	res, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, &ifModifiedSince, nil)
+	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID}, actualUsers)
 	assertResponseHeaders(rest.T(), res)
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsOKUsingExpiredIfNoneMatchHeader() {
-	admin := rest.Graph.CreateUser()
-	contr := rest.Graph.CreateUser()
-	space := rest.Graph.CreateSpace().AddAdmin(admin).AddContributor(contr)
-
-	// noise
-	rest.Graph.CreateSpace().AddAdmin(rest.Graph.CreateUser()).AddContributor(rest.Graph.CreateUser())
-
-	svc, ctrl := rest.SecuredControllerForIdentity(admin.Identity())
-	spaceID, err := uuid.FromString(space.SpaceID())
-	require.NoError(rest.T(), err)
+	// given
+	svc, ctrl := rest.SecuredControllerForIdentity(&testsupport.TestIdentity)
+	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
+	rest.policy.AddUserToPolicy(rest.testIdentity2.ID.String())
 
 	ifNoneMatch := "foo"
-	res, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, nil, nil, &ifNoneMatch)
-	rest.checkCollaborators([]uuid.UUID{admin.IdentityID(), contr.IdentityID()}, actualUsers)
+	res, actualUsers := test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, nil, &ifNoneMatch)
+	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID}, actualUsers)
 	assertResponseHeaders(rest.T(), res)
 }
 
@@ -413,6 +401,10 @@ func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsUnauthorizedWithDepro
 	test.AddManyCollaboratorsUnauthorized(rest.T(), svc.Context, svc, ctrl, rest.spaceID, payload)
 }
 
+/*
+
+// Commented out till the migration is complete, aftert this we will remove KC.
+
 func (rest *TestCollaboratorsREST) TestManageCollaboratorsFailsIfCurrentUserLacksPermissions() {
 
 	ownerIdentity := rest.Graph.CreateUser().Identity()
@@ -442,6 +434,7 @@ func (rest *TestCollaboratorsREST) TestManageCollaboratorsFailsIfCurrentUserLack
 	rPayload := &app.RemoveManyCollaboratorsPayload{Data: []*app.UpdateUserID{{ID: toRemoveIdentity.ID.String(), Type: idnType}}}
 	test.RemoveManyCollaboratorsForbidden(rest.T(), svc.Context, svc, ctrl, spaceID, rPayload)
 }
+*/
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsUnauthorizedIfNoToken() {
 	// given

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -68,6 +68,21 @@ func (rest *TestResourceRolesRest) TestListAssignedRolesOK() {
 	rest.checkExists([]uuid.UUID{admin.IdentityID(), viewer.IdentityID()}, []string{"admin", "viewer"}, returnedIdentityRoles)
 }
 
+func (rest *TestResourceRolesRest) TestListAssignedRolesUsingServiceAccountOK() {
+	admin := rest.Graph.CreateUser()
+	viewer := rest.Graph.CreateUser()
+	space := rest.Graph.CreateSpace().AddAdmin(admin).AddViewer(viewer)
+
+	// noise
+	rest.Graph.CreateSpace().AddViewer(rest.Graph.CreateUser())
+
+	// Check available roles
+	svc, ctrl := rest.SecuredControllerWithServiceAccount("space-migration")
+	_, returnedIdentityRoles := test.ListAssignedResourceRolesOK(rest.T(), svc.Context, svc, ctrl, space.SpaceID())
+	require.Len(rest.T(), returnedIdentityRoles.Data, 2)
+	rest.checkExists([]uuid.UUID{admin.IdentityID(), viewer.IdentityID()}, []string{"admin", "viewer"}, returnedIdentityRoles)
+}
+
 func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameOK() {
 	admin := rest.Graph.CreateUser()
 	viewer := rest.Graph.CreateUser()


### PR DESCRIPTION
- This temporary change ensures that for spaces created between 
https://github.com/fabric8-services/fabric8-auth/commit/d79703ccb0f5215d9d077eaf3c1c1705701914a5
and 
https://github.com/fabric8-services/fabric8-auth/commit/837cd5e7b3c976fc18a31d05c475b81db2b82e4c
'List Collaborators' works normally.

- This PR also takes care of https://github.com/fabric8-services/fabric8-auth/pull/512#discussion_r194866234 in the same PR

Even though the changes are semi-related, they would both be reverted after the space migration is complete.