### PR TITLE
Refactor deprovisioning API

### DIFF
--- a/account/service/user.go
+++ b/account/service/user.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fabric8-services/fabric8-auth/account/repository"
+	"github.com/fabric8-services/fabric8-auth/application/service/base"
+	servicecontext "github.com/fabric8-services/fabric8-auth/application/service/context"
+	"github.com/fabric8-services/fabric8-auth/errors"
+)
+
+// NewUserService creates a new service to manage users
+func NewUserService(context *servicecontext.ServiceContext) *userServiceImpl {
+	return &userServiceImpl{base.NewBaseService(context)}
+}
+
+// userServiceImpl implements the UserService to manage users
+type userServiceImpl struct {
+	base.BaseService
+}
+
+func (s *userServiceImpl) DeprovisionUser(ctx context.Context, username string) (*repository.Identity, error) {
+
+	var identity *repository.Identity
+	err := s.ExecuteInTransaction(func() error {
+
+		identities, err := s.Repositories().Identities().Query(
+			repository.IdentityWithUser(),
+			repository.IdentityFilterByUsername(username),
+			repository.IdentityFilterByProviderType(repository.KeycloakIDP))
+		if err != nil {
+			return err
+		}
+		if len(identities) == 0 {
+			return errors.NewNotFoundErrorWithKey("user identity", "username", username)
+		}
+
+		identity = &identities[0]
+		identity.User.Deprovisioned = true
+
+		return s.Repositories().Users().Save(ctx, &identity.User)
+	})
+
+	return identity, err
+}

--- a/account/service/user_blackbox_test.go
+++ b/account/service/user_blackbox_test.go
@@ -1,0 +1,48 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type userServiceBlackboxTestSuite struct {
+	gormtestsupport.DBTestSuite
+}
+
+func TestRunUserServiceBlackboxTestSuite(t *testing.T) {
+	suite.Run(t, &userServiceBlackboxTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *userServiceBlackboxTestSuite) TestDeprovisionUnknownUserFails() {
+	username := uuid.NewV4().String()
+	_, err := s.Application.UserService().DeprovisionUser(s.Ctx, username)
+	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "user identity with username '%s' not found", username)
+}
+
+func (s *userServiceBlackboxTestSuite) TestDeprovisionOK() {
+	userToDeprovision := s.Graph.CreateUser()
+	userToStayIntact := s.Graph.CreateUser()
+
+	identity, err := s.Application.UserService().DeprovisionUser(s.Ctx, userToDeprovision.Identity().Username)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), true, identity.User.Deprovisioned)
+	assert.Equal(s.T(), userToDeprovision.User().ID, identity.User.ID)
+	assert.Equal(s.T(), userToDeprovision.IdentityID(), identity.ID)
+
+	loadedUser := s.Graph.LoadUser(userToDeprovision.IdentityID())
+	assert.Equal(s.T(), true, loadedUser.User().Deprovisioned)
+	userToDeprovision.Identity().User.Deprovisioned = true
+	testsupport.AssertIdentityEqual(s.T(), userToDeprovision.Identity(), loadedUser.Identity())
+
+	loadedUser = s.Graph.LoadUser(userToStayIntact.IdentityID())
+	assert.Equal(s.T(), false, loadedUser.User().Deprovisioned)
+	testsupport.AssertIdentityEqual(s.T(), userToStayIntact.Identity(), loadedUser.Identity())
+}

--- a/application/service/factory/service_factory.go
+++ b/application/service/factory/service_factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	userservice "github.com/fabric8-services/fabric8-auth/account/service"
 	"github.com/fabric8-services/fabric8-auth/application/repository"
 	"github.com/fabric8-services/fabric8-auth/application/service"
 	"github.com/fabric8-services/fabric8-auth/application/service/context"
@@ -157,4 +158,8 @@ func (f *ServiceFactory) TeamService() service.TeamService {
 
 func (f *ServiceFactory) SpaceService() service.SpaceService {
 	return spaceservice.NewSpaceService(f.getContext())
+}
+
+func (f *ServiceFactory) UserService() service.UserService {
+	return userservice.NewUserService(f.getContext())
 }

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -66,6 +66,10 @@ type SpaceService interface {
 	DeleteSpace(ctx context.Context, byIdentityID uuid.UUID, spaceID string) error
 }
 
+type UserService interface {
+	DeprovisionUser(ctx context.Context, username string) (*account.Identity, error)
+}
+
 //Services creates instances of service layer objects
 type Services interface {
 	InvitationService() InvitationService
@@ -75,4 +79,5 @@ type Services interface {
 	RoleManagementService() RoleManagementService
 	TeamService() TeamService
 	SpaceService() SpaceService
+	UserService() UserService
 }

--- a/controller/namedusers.go
+++ b/controller/namedusers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/sentry"
 	"github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/goadesign/goa"
@@ -56,6 +57,7 @@ func (c *NamedusersController) Deprovision(ctx *app.DeprovisionNamedusersContext
 				"identity_id": identity.ID,
 				"username":    ctx.Username,
 			}, "unable to delete tenant when deprovisioning user")
+			sentry.Sentry().CaptureError(ctx, err)
 			// Just log the error and proceed
 		}
 	}

--- a/controller/namedusers.go
+++ b/controller/namedusers.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"github.com/fabric8-services/fabric8-auth/account/service"
+	"github.com/fabric8-services/fabric8-auth/app"
+	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/jsonapi"
+	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/token"
+
+	"github.com/goadesign/goa"
+)
+
+// NamedusersController implements the namedusers resource.
+type NamedusersController struct {
+	*goa.Controller
+	app           application.Application
+	config        UsersControllerConfiguration
+	tenantService service.Tenant
+}
+
+// NewNamedusersController creates a namedusers controller.
+func NewNamedusersController(service *goa.Service, app application.Application, config UsersControllerConfiguration, tenantService service.Tenant) *NamedusersController {
+	return &NamedusersController{
+		Controller:    service.NewController("NamedusersController"),
+		app:           app,
+		config:        config,
+		tenantService: tenantService,
+	}
+}
+
+// Deprovision runs the deprovision action.
+func (c *NamedusersController) Deprovision(ctx *app.DeprovisionNamedusersContext) error {
+	isSvcAccount := token.IsSpecificServiceAccount(ctx, token.OnlineRegistration)
+	if !isSvcAccount {
+		log.Error(ctx, nil, "the account is not an authorized service account allowed to deprovision users")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("account not authorized to deprovision users"))
+	}
+
+	identity, err := c.app.UserService().DeprovisionUser(ctx, ctx.Username)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":      err,
+			"username": ctx.Username,
+		}, "unable to deprovision user")
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	// Delete tenant
+	if c.tenantService != nil {
+		err := c.tenantService.Delete(ctx, identity.ID)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err":         err,
+				"identity_id": identity.ID,
+				"username":    ctx.Username,
+			}, "unable to delete tenant when deprovisioning user")
+			// Just log the error and proceed
+		}
+	}
+
+	return ctx.OK(ConvertToAppUser(ctx.RequestData, &identity.User, identity, true))
+}

--- a/controller/namedusers_blackbox_test.go
+++ b/controller/namedusers_blackbox_test.go
@@ -1,0 +1,98 @@
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/account/repository"
+	"github.com/fabric8-services/fabric8-auth/app/test"
+	. "github.com/fabric8-services/fabric8-auth/controller"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
+
+	"github.com/goadesign/goa"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestNamedUsersController(t *testing.T) {
+	suite.Run(t, &NamedUsersControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+type NamedUsersControllerTestSuite struct {
+	gormtestsupport.DBTestSuite
+	tenantService *dummyTenantService
+}
+
+func (s *NamedUsersControllerTestSuite) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.tenantService = &dummyTenantService{}
+}
+
+func (s *NamedUsersControllerTestSuite) SecuredServiceAccountController(identity repository.Identity) (*goa.Service, *NamedusersController) {
+	svc := testsupport.ServiceAsServiceAccountUser("Namedusers-ServiceAccount-Service", identity)
+	controller := NewNamedusersController(svc, s.Application, s.Configuration, s.tenantService)
+	return svc, controller
+}
+
+func (s *NamedUsersControllerTestSuite) SecuredController(identity repository.Identity) (*goa.Service, *NamedusersController) {
+	svc := testsupport.ServiceAsUser("Users-Service", identity)
+	controller := NewNamedusersController(svc, s.Application, s.Configuration, s.tenantService)
+	return svc, controller
+}
+
+func (s *NamedUsersControllerTestSuite) TestDeprovisionOK() {
+	// OK if tenant service succeed
+	s.checkDeprovisionOK()
+
+	// OK if tenant service failed
+	s.tenantService.identityID = uuid.NewV4()
+	s.tenantService.error = errors.NewInternalErrorFromString(nil, "tenant service failed")
+	s.checkDeprovisionOK()
+}
+
+func (s *NamedUsersControllerTestSuite) TestDeprovisionFailsForUnknownUser() {
+	svc, controller := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
+	test.DeprovisionNamedusersNotFound(s.T(), svc.Context, svc, controller, uuid.NewV4().String())
+}
+
+func (s *NamedUsersControllerTestSuite) TestDeprovisionFailsForUnauthorizedIdentity() {
+	userToDeprovision := s.Graph.CreateUser()
+
+	// Another service account can't deprovision
+	svc, controller := s.SecuredServiceAccountController(testsupport.TestTenantIdentity)
+	test.DeprovisionNamedusersForbidden(s.T(), svc.Context, svc, controller, userToDeprovision.Identity().Username)
+
+	// Regular user can't deprovision either
+	svc, controller = s.SecuredController(*s.Graph.CreateUser().Identity())
+	test.DeprovisionNamedusersForbidden(s.T(), svc.Context, svc, controller, userToDeprovision.Identity().Username)
+
+	// If no token present in the context then fails too
+	_, controller = s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
+	test.DeprovisionNamedusersForbidden(s.T(), nil, nil, controller, userToDeprovision.Identity().Username)
+}
+
+func (s *NamedUsersControllerTestSuite) checkDeprovisionOK() {
+	userToDeprovision := s.Graph.CreateUser()
+	userToStayIntact := s.Graph.CreateUser()
+
+	svc, controller := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
+	_, result := test.DeprovisionNamedusersOK(s.T(), svc.Context, svc, controller, userToDeprovision.Identity().Username)
+
+	// Check if tenant service was called
+	assert.Equal(s.T(), userToDeprovision.IdentityID(), s.tenantService.identityID)
+	assert.Equal(s.T(), userToDeprovision.User().ID.String(), *result.Data.Attributes.UserID)
+	assert.Equal(s.T(), userToDeprovision.IdentityID().String(), *result.Data.Attributes.IdentityID)
+
+	// Check if user was deprovisioned
+	loadedUser := s.Graph.LoadUser(userToDeprovision.IdentityID())
+	assert.Equal(s.T(), true, loadedUser.User().Deprovisioned)
+	userToDeprovision.Identity().User.Deprovisioned = true
+	testsupport.AssertIdentityEqual(s.T(), userToDeprovision.Identity(), loadedUser.Identity())
+
+	// Check the other user was not deprovisioned
+	loadedUser = s.Graph.LoadUser(userToStayIntact.IdentityID())
+	assert.Equal(s.T(), false, loadedUser.User().Deprovisioned)
+	testsupport.AssertIdentityEqual(s.T(), userToStayIntact.Identity(), loadedUser.Identity())
+}

--- a/design/account.go
+++ b/design/account.go
@@ -226,24 +226,6 @@ var _ = a.Resource("users", func() {
 		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
-	a.Action("updateByServiceAccount", func() {
-		a.Security("jwt")
-		a.Routing(
-			a.PATCH(":id"),
-		)
-		a.Description("update the user")
-		a.Params(func() {
-			a.Param("id", d.String, "Identity ID")
-		})
-		a.Payload(updateUser)
-		a.Response(d.OK, func() {
-			a.Media(user)
-		})
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-	})
-
 	a.Action("list", func() {
 		a.Routing(
 			a.GET(""),
@@ -259,6 +241,27 @@ var _ = a.Resource("users", func() {
 		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
+var _ = a.Resource("namedusers", func() {
+	a.BasePath("/namedusers")
+	a.Action("deprovision", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PATCH("/:username/deprovision"),
+		)
+		a.Description("deprovision the user")
+		a.Params(func() {
+			a.Param("username", d.String, "Username")
+		})
+		a.Response(d.OK, func() {
+			a.Media(user)
+		})
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 })
 

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -166,6 +166,10 @@ func (g *GormDB) SpaceService() service.SpaceService {
 	return g.serviceFactory.SpaceService()
 }
 
+func (g *GormDB) UserService() service.UserService {
+	return g.serviceFactory.UserService()
+}
+
 func (g *GormBase) DB() *gorm.DB {
 	return g.db
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
 	accountservice "github.com/fabric8-services/fabric8-auth/account/service"
 	"github.com/fabric8-services/fabric8-auth/app"
+	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/fabric8-services/fabric8-auth/auth"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/controller"
@@ -28,7 +29,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/token/keycloak"
 	"github.com/fabric8-services/fabric8-auth/token/link"
 
-	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/logging/logrus"
 	"github.com/goadesign/goa/middleware"
@@ -255,9 +255,13 @@ func main() {
 	keycloakLinkAPIService := keycloaklink.NewKeycloakIDPServiceClient()
 
 	emailVerificationService := accountservice.NewEmailVerificationClient(appDB, notificationChannel)
-	usersCtrl := controller.NewUsersController(service, appDB, config, keycloakProfileService, keycloakLinkAPIService, tenantService)
+	usersCtrl := controller.NewUsersController(service, appDB, config, keycloakProfileService, keycloakLinkAPIService)
 	usersCtrl.EmailVerificationService = emailVerificationService
 	app.MountUsersController(service, usersCtrl)
+
+	// Mount "namedusers" controlller
+	namedusersCtrl := controller.NewNamedusersController(service, appDB, config, tenantService)
+	app.MountNamedusersController(service, namedusersCtrl)
 
 	//Mount "userinfo" controller
 	userInfoCtrl := controller.NewUserinfoController(service, userInfoProvider, appDB, tokenManager)

--- a/test/account.go
+++ b/test/account.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-
 	"database/sql"
 
 	account "github.com/fabric8-services/fabric8-auth/account/repository"
@@ -12,8 +11,11 @@ import (
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/models"
 	"github.com/fabric8-services/fabric8-auth/test/token"
+
 	"github.com/jinzhu/gorm"
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUser only creates in memory obj for testing purposes
@@ -277,4 +279,31 @@ func CreateTestIdentityAndUserInDB(db *gorm.DB, identity *account.Identity) erro
 		return err
 	})
 	return transactionError
+}
+
+func AssertIdentityEqual(t require.TestingT, expected, actual *account.Identity) {
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	require.NotEmpty(t, expected.User)
+	require.NotEmpty(t, actual.User)
+
+	assert.Equal(t, expected.ID, actual.ID)
+	assert.Equal(t, expected.Username, actual.Username)
+	assert.Equal(t, expected.UserID, actual.UserID)
+	assert.Equal(t, expected.ProfileURL, actual.ProfileURL)
+	assert.Equal(t, expected.ProviderType, actual.ProviderType)
+	assert.Equal(t, expected.RegistrationCompleted, actual.RegistrationCompleted)
+	assert.Equal(t, expected.User.ID, actual.User.ID)
+	assert.Equal(t, expected.User.Deprovisioned, actual.User.Deprovisioned)
+	assert.Equal(t, expected.User.Bio, actual.User.Bio)
+	assert.Equal(t, expected.User.Cluster, actual.User.Cluster)
+	assert.Equal(t, expected.User.Company, actual.User.Company)
+	assert.Equal(t, expected.User.ContextInformation, actual.User.ContextInformation)
+	assert.Equal(t, expected.User.Email, actual.User.Email)
+	assert.Equal(t, expected.User.EmailPrivate, actual.User.EmailPrivate)
+	assert.Equal(t, expected.User.EmailVerified, actual.User.EmailVerified)
+	assert.Equal(t, expected.User.FeatureLevel, actual.User.FeatureLevel)
+	assert.Equal(t, expected.User.FullName, actual.User.FullName)
+	assert.Equal(t, expected.User.ImageURL, actual.User.ImageURL)
+	assert.Equal(t, expected.User.URL, actual.User.URL)
 }

--- a/test/graph/test_graph.go
+++ b/test/graph/test_graph.go
@@ -212,6 +212,22 @@ func (g *TestGraph) LoadIdentity(params ...interface{}) *identityWrapper {
 	return &w
 }
 
+func (g *TestGraph) LoadUser(params ...interface{}) *userWrapper {
+	var identityID *uuid.UUID
+	for i := range params {
+		switch t := params[i].(type) {
+		case *uuid.UUID:
+			identityID = t
+		case uuid.UUID:
+			identityID = &t
+		}
+	}
+	require.NotNil(g.t, identityID, "Must specify a uuid parameter for the identity ID")
+	w := loadUserWrapper(g, *identityID)
+	g.register(g.generateIdentifier(params), &w)
+	return &w
+}
+
 func (g *TestGraph) LoadResource(params ...interface{}) *resourceWrapper {
 	var resourceID *string
 	for i := range params {

--- a/test/graph/user_wrapper.go
+++ b/test/graph/user_wrapper.go
@@ -13,6 +13,19 @@ type userWrapper struct {
 	identity *account.Identity
 }
 
+func loadUserWrapper(g *TestGraph, identityID uuid.UUID) userWrapper {
+	w := userWrapper{baseWrapper: baseWrapper{g}}
+
+	var native account.Identity
+	err := w.graph.db.Table("identities").Where("ID = ?", identityID).Preload("User").Find(&native).Error
+	require.NoError(w.graph.t, err)
+
+	w.identity = &native
+	w.user = &w.identity.User
+
+	return w
+}
+
 func newUserWrapper(g *TestGraph, params []interface{}) userWrapper {
 	w := userWrapper{baseWrapper: baseWrapper{g}}
 


### PR DESCRIPTION
Old (being removed) API - https://github.com/fabric8-services/fabric8-auth/pull/354:
```
PATCH /api/users/:id
{
  "data": {
    "type": "identities",
    "attributes": {
      "deprovisioned": true
    }
}
```
New API:
```
PATCH /api/namedusers/:username/deprovision
Authorization: bearer ${oso_reg_sa_token}
(No Payload)
```
Returns 200 OK if succeed.

Example:
```
PATCH https://auth.openshift.io/api/namedusers/johnsmith/deprovision
Authorization: bearer ${oso_reg_sa_token}

```
This refactoring is needed because the OSO reg app doesn't have OSIO Identity ID available. So, we have to look up the identity by username.
