### PR TITLE
README: Update list of files which can be edited

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -233,9 +233,7 @@ coverage information for all tests.
 
 ==== Development
 
-Only files `+./*.go+`, `+./design/*.go+`, `+./models/*.go+` and `+./tool/wit-cli/main.go+` should be edited.
-
-These files and directory are generated:
+These files and directories are generated and should not be edited:
 
  * `./app/`
  * `./client/`


### PR DESCRIPTION
The list of files that can be edited is outdated. The README also lists files which are generated.

Instead of listing all the files that can be edited (I assume the list is longer now), this PR updates the instructions to not edit the generated files.
