### PR TITLE
Forward request ID when calling notification service

### DIFF
--- a/notification/service/notification.go
+++ b/notification/service/notification.go
@@ -79,7 +79,7 @@ func (s *notificationServiceImpl) send(ctx context.Context, c *client.Client, ms
 	msgID := uuid.UUID(msg.MessageID)
 
 	resp, err := c.SendNotify(
-		ctx,
+		goasupport.ForwardContextRequestID(ctx),
 		client.SendNotifyPath(),
 		&client.SendNotifyPayload{
 			Data: &client.Notification{


### PR DESCRIPTION
I noticed that we didn't set request ID in the notification service. This PR fixes that. 
It's very tricky to test this change though.
In our tests we set context via client package and it works. But in runtime a different key is used to store the request ID in the context (middleware vs. client).

So, no tests unfortunately. 