### PR TITLE
docs(#541): update go dependency tool from glide to dep

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,10 +109,9 @@ $ cd $GOPATH/src/github.com/fabric8-services/fabric8-auth
 $ make deps
 ----
 
-For dependency management of `go` packages we use `glide`.
-The file `glide.yaml` contains all dependencies.
-It is not suggested that you edit the file by hand but if you want to
-understand the format for this file, look link:https://glide.readthedocs.io/en/latest/glide.yaml/[here].
+For dependency management of `go` packages we use https://github.com/golang/dep[`dep`].
+
+The file `Gopkg.toml` contains all dependencies. If you want to understand the format for this file, look link:https://golang.github.io/dep/docs/Gopkg.toml.html[here].
 
 ===== Generate GOA sources [[generate-code]]
 


### PR DESCRIPTION
Recently we migrated from `glide` to `dep`. At that time we forget to update README description.

This PR brings updated usage of dependency management tool i.e. `dep`

Fixes: #541 
