### PR TITLE
Updated SHA checksum for dep-darwin-amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ DOCKER_COMPOSE_BIN := $(shell command -v $(DOCKER_COMPOSE_BIN_NAME) 2> /dev/null
 DOCKER_BIN := $(shell command -v $(DOCKER_BIN_NAME) 2> /dev/null)
 ASCIIDOCTOR_BIN := $(shell command -v $(ASCIIDOCTOR_BIN_NAME) 2> /dev/null)
 
+# Define and get the vakue for UNAME_S variable from shell
+UNAME_S := $(shell uname -s)
+
 # This is a fix for a non-existing user in passwd file when running in a docker
 # container and trying to clone repos of dependencies
 GIT_COMMITTER_NAME ?= "user"

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ $(DEP_BIN):
 ifeq ($(UNAME_S),Darwin)
 	@curl -L -s https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-darwin-amd64 -o $(DEP_BIN)
 	@cd $(DEP_BIN_DIR) && \
-	echo "f170008e2bf8b196779c361a4eaece1b03450d23bbf32d1a0beaa9b00b6a5ab4  dep" > dep-darwin-amd64.sha256 && \
+	echo "1544afdd4d543574ef8eabed343d683f7211202a65380f8b32035d07ce0c45ef  dep" > dep-darwin-amd64.sha256 && \
 	shasum -a 256 --check dep-darwin-amd64.sha256
 else
 	@curl -L -s https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-linux-amd64 -o $(DEP_BIN)


### PR DESCRIPTION
- For macOS dep package was updated with a new SHA. This SHA value is checked in `Makefile` with a hardcoded SHA checksum to verify dep package. 
- Updated the SHA value to new one.
- Added initialization of `$(UNAME_S)` variable `UNAME_S=$(shell uname -s)` since it was being used but never set which lead to explicitly exporting the variable from shell.

Note: We can probably look into automating the process where SHA value is fetched dynamically instead of hard coding.