### PR TITLE
Pass service account token to notification service client/req

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -449,6 +449,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "591223576391fb12b07f9f4d3e829efe50be9a8e46eac1875cfd7aeaf0b5fd65"
+  inputs-digest = "f9ae70a421ff438b6fba3b3902de326a3e8b79ec5dd098a849fccbb3a4722b9f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/notification/service/notification_whitebox_test.go
+++ b/notification/service/notification_whitebox_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/configuration"
-
 	autherrors "github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/notification"
 	"github.com/fabric8-services/fabric8-auth/rest"
@@ -17,7 +16,6 @@ import (
 	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
 	"github.com/fabric8-services/fabric8-auth/test/token"
 	tokentestsupport "github.com/fabric8-services/fabric8-auth/test/token"
-
 	tokenutil "github.com/fabric8-services/fabric8-auth/token"
 
 	"github.com/satori/go.uuid"

--- a/test/token/token.go
+++ b/test/token/token.go
@@ -196,6 +196,7 @@ func ContextWithRequest(ctx context.Context) context.Context {
 
 func ContextWithTokenAndRequestID(t *testing.T) (context.Context, string, string) {
 	ctx, ctxToken, err := EmbedTokenInContext(uuid.NewV4().String(), uuid.NewV4().String())
+	ctx = tokencontext.ContextWithTokenManager(ctx, TokenManager)
 	require.NoError(t, err)
 
 	reqID := uuid.NewV4().String()


### PR DESCRIPTION
Notification service needs to be called using a service account token, instead of a user account token - for the user's email updation verification email.

This is needed because of notification-service side changes in https://openshift.io/openshiftio/openshiftio/plan/detail/2646