### PR TITLE
chore(#551): adds dev setup using openshift template and few make target

### DIFF
--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -70,7 +70,7 @@ deploy-auth-secrets:
 deploy-wit-secrets:
 	oc process -f $(TEMPLATE_DIR)/wit.config.yaml -o yaml | oc apply -f -
 
-.PHONY: clean-dev-all
+.PHONY: clean-all
 clean-dev-all:
 	oc delete all -l env=dev
 	oc delete project $(OC_PROJECT_NAME)
@@ -100,8 +100,8 @@ minishift-start:
 	./minishift/check_hosts.sh
 	-eval `minishift docker-env` && oc login -u developer -p developer
 
-.PHONY: dev-deploy-all
-dev-deploy-all: prebuild-check deps generate build init-project clean-all-dc deploy-auth deploy-wit deploy-f8ui
+.PHONY: deploy-all
+deploy-all: prebuild-check deps generate build init-project clean-all-resources deploy-auth deploy-wit deploy-f8ui
 
 OC_PROJECT_NAME?=fabric8-services
 .PHONY: init-project

--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -1,0 +1,107 @@
+DOCKER_REPO?=fabric8-services
+IMAGE_NAME?=fabric8-auth
+MINISHIFT_IP?=$(shell minishift ip)
+SHORT_COMMIT=$(shell git rev-parse --short HEAD)
+ifneq ($(GITUNTRACKEDCHANGES),)
+SHORT_COMMIT := $(SHORT_COMMIT)-dirty
+endif
+
+TIMESTAMP:=$(shell date +%s)
+TAG?=$(SHORT_COMMIT)-$(TIMESTAMP)
+
+TEMPLATE_DIR:=minishift/openshift
+POSTGRESQL_VERSION:=9.6
+
+.PHONY: deploy-auth
+deploy-auth: deploy-auth-secrets deploy-auth-db deploy-auth-only
+
+.PHONY: deploy-auth-only
+deploy-auth-only: build build-image
+	@echo "Deploys auth service ${TAG}"
+	@oc process -f $(TEMPLATE_DIR)/auth.app.yaml \
+		-p DOCKER_REPO=$(DOCKER_REPO) \
+		-p IMAGE_TAG=$(TAG) \
+		-p IMAGE_NAME=$(IMAGE_NAME) \
+		-o yaml | oc apply -f -
+
+.PHONY: deploy-auth-db
+deploy-auth-db:
+	@echo "Deploying auth-db service using postgresql:${POSTGRESQL_VERSION}"
+	@oc process -f $(TEMPLATE_DIR)/auth.db.yaml \
+		-p POSTGRESQL_VERSION=$(POSTGRESQL_VERSION) \
+		-o yaml | oc apply -f -
+
+.PHONY: deploy-wit
+deploy-wit: deploy-wit-secrets deploy-wit-db
+	@echo "Deploying wit service"
+	@oc process -f $(TEMPLATE_DIR)/wit.app.yaml -o yaml | oc apply -f -
+
+.PHONY: deploy-f8ui
+deploy-f8ui:
+	@echo "Deploying fabric8-ui service"
+	@oc process -f $(TEMPLATE_DIR)/fabric8-ui.app.yaml \
+	    -p FABRIC8_WIT_API_URL=http://wit-fabric8-services.${MINISHIFT_IP}.nip.io/api/ \
+	    -p FABRIC8_AUTH_API_URL=http://auth-fabric8-services.${MINISHIFT_IP}.nip.io/api/ \
+	    -p FABRIC8_REALM=fabric8-test \
+	    -p FABRIC8_FORGE_URL=https://forge.api.prod-preview.openshift.io/ \
+	    -p PROXY_PASS_URL="http://minishift.local:8443" \
+	    -o yaml | oc apply -f -
+
+.PHONY: deploy-wit-db
+deploy-wit-db:
+	@echo "Deploying wit-db service using postgresql:${POSTGRESQL_VERSION}"
+	@oc process -f $(TEMPLATE_DIR)/wit.db.yaml \
+		-p POSTGRESQL_VERSION=$(POSTGRESQL_VERSION) \
+		-o yaml | oc apply -f -
+
+.PHONY: build-image
+build-image: expose-minishift-docker-env
+	docker build -t $(DOCKER_REPO)/$(IMAGE_NAME):dev -f Dockerfile.dev .
+
+.PHONY: expose-minishift-docker-env
+expose-minishift-docker-env:
+	-eval `minishift docker-env`
+
+.PHONY: deploy-auth-secrets
+deploy-auth-secrets:
+	oc process -f $(TEMPLATE_DIR)/auth.config.yaml -o yaml | oc apply -f -
+
+.PHONY: deploy-wit-secrets
+deploy-wit-secrets:
+	oc process -f $(TEMPLATE_DIR)/wit.config.yaml -o yaml | oc apply -f -
+
+.PHONY: clean-dev-all
+clean-dev-all:
+	oc delete all -l env=dev
+	oc delete project $(OC_PROJECT_NAME)
+
+.PHONY: clean-auth
+clean-auth:
+	oc delete all -l belongsTo=auth
+
+.PHONY: clean-wit
+clean-wit:
+	oc delete all -l belongsTo=wit
+
+.PHONY: clean-f8ui
+clean-f8ui:
+	oc delete all -l belongsTo=f8ui
+
+.PHONY: redeploy-auth
+redeploy-auth: build build-image deploy-auth-only
+
+.PHONY: minishift-start
+minishift-start:
+	minishift start --cpus 4 --memory 8GB
+	./minishift/check_hosts.sh
+	-eval `minishift docker-env` && oc login -u developer -p developer
+
+.PHONY: dev-deploy-all
+dev-deploy-all: prebuild-check deps generate build init-project clean-dev-all deploy-auth deploy-wit deploy-f8ui
+
+OC_PROJECT_NAME?=fabric8-services
+.PHONY: init-project
+init-project: ## Initializes new project with secrets
+	@echo "Setting up project '$(OC_PROJECT_NAME)' in the cluster (ignoring potential errors if entries already exist)"
+	@oc new-project $(OC_PROJECT_NAME) || true \
+    @oc project $(OC_PROJECT_NAME)

--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -71,7 +71,7 @@ deploy-wit-secrets:
 	oc process -f $(TEMPLATE_DIR)/wit.config.yaml -o yaml | oc apply -f -
 
 .PHONY: clean-all
-clean-dev-all:
+clean-all:
 	oc delete all -l env=dev
 	oc delete project $(OC_PROJECT_NAME)
 

--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -75,8 +75,8 @@ clean-dev-all:
 	oc delete all -l env=dev
 	oc delete project $(OC_PROJECT_NAME)
 
-.PHONY: clean-all-dc
-clean-all-dc:
+.PHONY: clean-all-resources
+clean-all-resources:
 	oc delete all -l env=dev
 
 .PHONY: clean-auth

--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -75,6 +75,10 @@ clean-dev-all:
 	oc delete all -l env=dev
 	oc delete project $(OC_PROJECT_NAME)
 
+.PHONY: clean-all-dc
+clean-all-dc:
+	oc delete all -l env=dev
+
 .PHONY: clean-auth
 clean-auth:
 	oc delete all -l belongsTo=auth
@@ -97,7 +101,7 @@ minishift-start:
 	-eval `minishift docker-env` && oc login -u developer -p developer
 
 .PHONY: dev-deploy-all
-dev-deploy-all: prebuild-check deps generate build init-project clean-dev-all deploy-auth deploy-wit deploy-f8ui
+dev-deploy-all: prebuild-check deps generate build init-project clean-all-dc deploy-auth deploy-wit deploy-f8ui
 
 OC_PROJECT_NAME?=fabric8-services
 .PHONY: init-project

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM fabric8/fabric8-auth:v6a56c54
+FROM quay.io/openshiftio/fabric8-services-fabric8-auth:c9398c
 
-COPY fabric8-auth-linux /usr/local/auth/bin/auth
+COPY bin/auth /usr/local/auth/bin/auth
 RUN echo chmod +x /usr/local/auth/bin/auth

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ dev: prebuild-check deps generate $(FRESH_BIN)
 	AUTH_DEVELOPER_MODE_ENABLED=true $(FRESH_BIN)
 
 include ./.make/test.mk
+include ./.make/Makefile.dev
 
 ifneq ($(OS),Windows_NT)
 ifdef DOCKER_BIN

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -151,3 +151,14 @@ It won't deploy required secrets and postgres db again. It'll re-deploy auth ser
 ```bash
 make redeploy-auth
 ```
+
+#### Checking services logs
+
+List out all running services in MiniShift using
+```
+oc get pods
+```
+Wait until all pods are in running state and then copy pod name and use following command to see logs
+```
+oc logs <<pod name>> -f
+```

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -113,7 +113,7 @@ Also make sure to whitelist the domain which you are using for auth to work it a
 #### Deploying Auth, WIT, UI together
 To deploy `auth`, `wit`, `fabric8-ui` together we have following target:
 ```bash
-make deploy-dev-all
+make deploy-all
 ```
 
 #### Cleaning Up
@@ -139,7 +139,7 @@ make clean-f8ui
 ##### Cleaning Auth, WIT, Fabric8-UI
 This removes `auth`, `wit`, `fabric8-ui` services from minishift and deletes the `fabric8-services` project.
 ```bash
-make clean-dev-all
+make clean-all
 ```
 
 #### Redeploying Auth service

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -1,0 +1,153 @@
+## Running Auth, WIT, Fabric8 ui services on OpenShift
+
+These instructions will help you run your services on OpenShift using MiniShift.
+
+### Prerequisites
+
+[MiniShift v1.21.0](https://docs.openshift.org/latest/minishift/getting-started/installing.html)
+
+[oc 3.9.0](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+[KVM Hypervisor](https://www.linux-kvm.org/page/Downloads)
+
+#### Install Minishift
+
+Make sure you have all prerequisites installed. Please check the list [here](https://docs.openshift.org/latest/minishift/getting-started/installing.html#install-prerequisites)
+
+Download and put `minishift` in your $PATH by following steps [here](https://docs.openshift.org/latest/minishift/getting-started/installing.html#manually)
+
+Verify installation by running following command, you should get version number.
+```bash
+minishift version
+```
+
+#### Install oc
+Please install and set up oc on your machine by visiting [oc](https://docs.openshift.org/latest/cli_reference/get_started_cli.html#installing-the-cli)
+
+Verify installation by running following command, you should get version number.
+```bash
+oc version
+```
+
+### Deploying services on Minishift
+Here, we are going to deploy `auth`, `wit`, `fabric8-ui` services on minishift.
+
+#### Start Minishift
+We have make target defined to start minishift with reqquired cpu's and configuration.
+```bash
+make minishift-start
+```
+Please enter sudo password when prompted, it is needed in order to create an entry in the `/etc/hosts`.
+`minishift ip` gives the IP address on which MiniShift is running. This automation creates a host entry as `minishift.local` for that IP. This domain is whitelisted on fabric8-auth.
+
+Make sure to verify that your console is configured to reuse the Minishift Docker daemon by running `docker ps` command. You should be able to see running containers for origin.
+If not then follow [this](https://docs.openshift.org/latest/minishift/using/docker-daemon.html#docker-daemon-overview) guide to configure it.
+
+#### Create a Project
+Let's create a new project by executing following make target.
+```bash
+make init-project
+```
+
+This will create a new project with name `fabric8-services` with `developer:developer` account and switch to it. Make sure to verify that using `oc project`.
+
+#### Auth Service
+##### Deploying Auth
+
+To deploy auth service, we have following make target which will deploy required secrets, postgres DB and create routes for you.
+```
+make deploy-auth
+```
+
+Look for running pods using `oc get pods`. You should be able to see two pods(auth-*, db-auth-*). First time it will take some time as it has download required container images.
+
+##### Check auth service status
+You can get auth route by using `oc get routes`. It should be in format `auth-fabric8-services.${minishift ip}.nip.io`
+You can check status by hitting this in browser `http://auth-fabric8-services.${minishift ip}.nip.io/api/status`(e.g. `http://auth-fabric8-services.192.168.42.177.nip.io/api/status`).
+
+##### Connecting to Postgres DB
+If you wish to access the Postgres database, it is available on the same host but on port 31001.  Use the following command to connect with the Postgres client:
+
+```bash
+PGPASSWORD=mysecretpassword psql -h minishift.local -U postgres -d postgres -p 31001
+```
+
+#### WIT Service
+##### Deploying WIT
+
+To deploy wit service, we have following make target which will deploy required secrets, config map, postgres DB and create routes for you.
+```
+make deploy-wit
+```
+
+Look for running pods using `oc get pods`. You should be able to see two pods(wit-*, db-wit-*). First time it will take some time as it has download required container images.
+
+##### Check wit service status
+You can get auth route by using `oc get routes`. It should be in format `wit-fabric8-services.${minishift ip}.nip.io`
+You can check status by hitting this in browser `http://wit-fabric8-services.${minishift ip}.nip.io/api/status`(e.g. `http://wit-fabric8-services.192.168.42.177.nip.io/api/status`).
+
+##### Connecting to Postgres DB
+If you wish to access the Postgres database, it is available on the same host but on port 31002.  Use the following command to connect with the Postgres client:
+
+```bash
+PGPASSWORD=mysecretpassword psql -h minishift.local -U postgres -d postgres -p 31002
+```
+
+#### Fabric8 UI Service
+##### Deploying Fabric8 UI
+
+To deploy fabric8 UI service, we have following make target which will deploy service, and create routes for you.
+```bash
+make deploy-f8ui
+```
+
+Look for running pods using `oc get pods`. You should be able to see two pods(f8ui-*). First time it will take some time as it has download required container images.
+
+##### Check f8ui service status
+You can get f8ui route by using `oc get routes`. It should be in format `f8ui-fabric8-services.${minishift ip}.nip.io`
+You can try logging by hitting this in browser `http://f8ui-fabric8-services.${minishift ip}.nip.io`(e.g. `http://f8ui-fabric8-services.192.168.42.177.nip.io`).
+
+Note: However if you are trying this first time you should approve your username from keycloak, so that you will be authenticated user.
+Also make sure to whitelist the domain which you are using for auth to work it as per expectation.
+
+#### Deploying Auth, WIT, UI together
+To deploy `auth`, `wit`, `fabric8-ui` together we have following target:
+```bash
+make deploy-dev-all
+```
+
+#### Cleaning Up
+
+##### Cleaning Auth
+This removes both the `auth` and `db-auth` services from minishift.
+```bash
+make clean-auth
+```
+
+##### Cleaning WIT
+This removes both the `wit` and `db-wit` services from minishift.
+```bash
+make clean-wit
+```
+
+##### Cleaning Fabric8-ui
+This removes both the `fabric8-ui` service from minishift.
+```bash
+make clean-f8ui
+```
+
+##### Cleaning Auth, WIT, Fabric8-UI
+This removes `auth`, `wit`, `fabric8-ui` services from minishift and deletes the `fabric8-services` project.
+```bash
+make clean-dev-all
+```
+
+#### Redeploying Auth service
+However if you are working on auth service and wants to redeploy latest code change by building container with latest bniary. We have
+special target for it which will do that for you.
+
+It won't deploy required secrets and postgres db again. It'll re-deploy auth service only.
+
+```bash
+make redeploy-auth
+```

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -33,7 +33,7 @@ oc version
 Here, we are going to deploy `auth`, `wit`, `fabric8-ui` services on minishift.
 
 #### Start Minishift
-We have make target defined to start minishift with reqquired cpu's and configuration.
+We have make target defined to start minishift with required cpu's and configuration.
 ```bash
 make minishift-start
 ```
@@ -143,7 +143,7 @@ make clean-dev-all
 ```
 
 #### Redeploying Auth service
-However if you are working on auth service and wants to redeploy latest code change by building container with latest bniary. We have
+However if you are working on auth service and wants to redeploy latest code change by building container with latest binary. We have
 special target for it which will do that for you.
 
 It won't deploy required secrets and postgres db again. It'll re-deploy auth service only.

--- a/minishift/openshift/auth.app.yaml
+++ b/minishift/openshift/auth.app.yaml
@@ -62,6 +62,11 @@ objects:
               secretKeyRef:
                 name: ${SERVICE_NAME}
                 key: developer.mode.enabled
+          - name: AUTH_WIT_URL
+            valueFrom:
+              configMapKeyRef:
+                name: ${SERVICE_NAME}
+                key: wit.url
           name: ${SERVICE_NAME}
           ports:
           - containerPort: 8089

--- a/minishift/openshift/auth.app.yaml
+++ b/minishift/openshift/auth.app.yaml
@@ -15,6 +15,9 @@ parameters:
 - name: SERVICE_NAME
   required: true
   value: auth
+- name: MEMORY_LIMIT
+  required: true
+  value: 1.5Gi
 metadata:
   name: ${SERVICE_NAME}
 objects:
@@ -97,21 +100,8 @@ objects:
               memory: 10Mi
             limits:
               cpu: 400m
-              memory: 1.5Gi
+              memory: ${MEMORY_LIMIT}
           terminationMessagePath: /dev/termination-log
-#          volumeMounts:
-#          - mountPath: /etc/fabric8/
-#            name: auth-configs
-#            readOnly: true
-#        volumes:
-#        - name: auth-configs
-#          secret:
-#            secretName: auth-config-files
-#            items:
-#            - key: service.account.secrets
-#              path: service-account-secrets.conf
-#            - key: oso.clusters
-#              path: oso-clusters.conf
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}

--- a/minishift/openshift/auth.app.yaml
+++ b/minishift/openshift/auth.app.yaml
@@ -1,0 +1,156 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: DOCKER_REPO
+  required: true
+- name: IMAGE_NAME
+  required: true
+- name: IMAGE_TAG
+  required: true
+- name: REPLICAS
+  required: true
+  value: '1'
+- name: ENVIRONMENT
+  value: dev
+- name: SERVICE_NAME
+  required: true
+  value: auth
+metadata:
+  name: ${SERVICE_NAME}
+objects:
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+      service: ${SERVICE_NAME}
+    name: ${SERVICE_NAME}
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      service: ${SERVICE_NAME}
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          service: ${SERVICE_NAME}
+          version: ${IMAGE_TAG}
+      spec:
+        containers:
+        - image: ${DOCKER_REPO}/${IMAGE_NAME}:dev
+          env:
+          - name: AUTH_POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: db.host
+          - name: AUTH_POSTGRES_PORT
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: db.port
+          - name: AUTH_DEVELOPER_MODE_ENABLED
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: developer.mode.enabled
+          name: ${SERVICE_NAME}
+          ports:
+          - containerPort: 8089
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/status
+              port: 8089
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/status
+              port: 8089
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 0.1m
+              memory: 10Mi
+            limits:
+              cpu: 400m
+              memory: 1.5Gi
+          terminationMessagePath: /dev/termination-log
+#          volumeMounts:
+#          - mountPath: /etc/fabric8/
+#            name: auth-configs
+#            readOnly: true
+#        volumes:
+#        - name: auth-configs
+#          secret:
+#            secretName: auth-config-files
+#            items:
+#            - key: service.account.secrets
+#              path: service-account-secrets.conf
+#            - key: oso.clusters
+#              path: oso-clusters.conf
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status:
+    details:
+      causes:
+      - type: ConfigChange
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+      service: ${SERVICE_NAME}
+  spec:
+    ports:
+      - name: "8089"
+        protocol: TCP
+        port: 80
+        targetPort: 8089
+    selector:
+      service: ${SERVICE_NAME}
+    type: ClusterIP
+    sessionAffinity: null
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      service: ${SERVICE_NAME}
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+    name: ${SERVICE_NAME}
+  spec:
+    host: ''
+    port:
+      targetPort: "8089"
+    to:
+      kind: Service
+      name: ${SERVICE_NAME}
+      weight: 100
+    wildcardPolicy: None
+  status: {}

--- a/minishift/openshift/auth.config.yaml
+++ b/minishift/openshift/auth.config.yaml
@@ -22,3 +22,13 @@ objects:
     db.port: NTQzMg==
     developer.mode.enabled: dHJ1ZQ==
     db.admin.password: bXlzZWNyZXRwYXNzd29yZA==
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+  type: Opaque
+  data:
+    wit.url: http://wit

--- a/minishift/openshift/auth.config.yaml
+++ b/minishift/openshift/auth.config.yaml
@@ -1,0 +1,24 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: SERVICE_NAME
+  required: true
+  value: auth
+- name: ENVIRONMENT
+  value: dev
+metadata:
+  name: ${SERVICE_NAME}
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+  type: Opaque
+  data:
+    db.host: ZGItYXV0aA==
+    db.port: NTQzMg==
+    developer.mode.enabled: dHJ1ZQ==
+    db.admin.password: bXlzZWNyZXRwYXNzd29yZA==

--- a/minishift/openshift/auth.db.yaml
+++ b/minishift/openshift/auth.db.yaml
@@ -73,6 +73,10 @@ objects:
           resources:
             limits:
               memory: ${MEMORY_LIMIT}
+            resources:
+              requests:
+                cpu: 0.1m
+                memory: 10Mi
           securityContext:
             capabilities: {}
             privileged: false

--- a/minishift/openshift/auth.db.yaml
+++ b/minishift/openshift/auth.db.yaml
@@ -1,0 +1,103 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- name: DATABASE_SERVICE_NAME
+  required: true
+  value: db-auth
+- name: POSTGRESQL_VERSION
+  required: true
+  value: "9.6"
+- name: REPLICAS
+  required: true
+  value: '1'
+- name: ENVIRONMENT
+  value: dev  
+metadata:
+  name: ${DATABASE_SERVICE_NAME}
+objects:
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      belongsTo: auth
+      env: ${ENVIRONMENT}
+      service: ${DATABASE_SERVICE_NAME}
+      version: ${POSTGRESQL_VERSION}
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      service: ${DATABASE_SERVICE_NAME}
+    template:
+      metadata:
+        labels:
+          service: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - image: registry.centos.org/postgresql/postgresql:${POSTGRESQL_VERSION}
+          env:
+          - name: POSTGRESQL_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: auth
+                key: db.admin.password
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 1
+          name: ${DATABASE_SERVICE_NAME}
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - psql -h 127.0.0.1 -U postgres -q -d postgres -c
+                'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+    labels:
+      belongsTo: auth
+      env: ${ENVIRONMENT}
+      service: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+      - name: "5432"
+        nodePort: 31001
+        port: 5432
+        targetPort: 5432
+    selector:
+      service: ${DATABASE_SERVICE_NAME}
+    type: NodePort

--- a/minishift/openshift/fabric8-ui.app.yaml
+++ b/minishift/openshift/fabric8-ui.app.yaml
@@ -20,6 +20,9 @@ parameters:
   value: f8ui
 - name: ENVIRONMENT
   value: dev
+- name: MEMORY_LIMIT
+  required: true
+  value: 1.5Gi
 metadata:
   name: ${SERVICE_NAME}
 objects:
@@ -79,6 +82,13 @@ objects:
               port: 8080
             initialDelaySeconds: 120
             timeoutSeconds: 10
+          resources:
+            requests:
+              cpu: 0.1m
+              memory: 10Mi
+            limits:
+              cpu: 400m
+              memory: ${MEMORY_LIMIT}
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}

--- a/minishift/openshift/fabric8-ui.app.yaml
+++ b/minishift/openshift/fabric8-ui.app.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Template
+parameters:
+- name: IMAGE
+  value: quay.io/openshiftio/fabric8-ui-fabric8-ui
+- name: IMAGE_TAG
+  value: latest
+- name: FABRIC8_WIT_API_URL
+  required: true
+- name: FABRIC8_AUTH_API_URL
+  required: true
+- name: FABRIC8_REALM
+  required: true
+- name: FABRIC8_FORGE_URL
+  required: true
+- name: PROXY_PASS_URL
+  required: true
+- name: SERVICE_NAME
+  required: true
+  value: f8ui
+- name: ENVIRONMENT
+  value: dev
+metadata:
+  name: ${SERVICE_NAME}
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      service: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+      belongsto: ${SERVICE_NAME}
+    name: ${SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      service: ${SERVICE_NAME}
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          service: ${SERVICE_NAME}
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          name: ${SERVICE_NAME}
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          env:
+          - name: FABRIC8_WIT_API_URL
+            value: ${FABRIC8_WIT_API_URL}
+          - name: FABRIC8_AUTH_API_URL
+            value: ${FABRIC8_AUTH_API_URL}
+          - name: FABRIC8_REALM
+            value: ${FABRIC8_REALM}
+          - name: FABRIC8_FORGE_URL
+            value: ${FABRIC8_FORGE_URL}
+          - name: PROXY_PASS_URL
+            value: ${PROXY_PASS_URL}
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: ${SERVICE_NAME}
+      belongsTo: ${SERVICE_NAME}
+    name: ${SERVICE_NAME}
+  spec:
+    ports:
+    - name: "8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      service: ${SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      service: ${SERVICE_NAME}
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+    name: f8ui
+  spec:
+    host: ''
+    port:
+      targetPort: "8080"
+    to:
+      kind: Service
+      name: ${SERVICE_NAME}
+      weight: 100
+    wildcardPolicy: None
+  status: {}

--- a/minishift/openshift/wit.app.yaml
+++ b/minishift/openshift/wit.app.yaml
@@ -1,0 +1,146 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: IMAGE
+  value: quay.io/openshiftio/fabric8-services-fabric8-wit
+- name: IMAGE_TAG
+  value: latest
+- name: REPLICAS
+  required: true
+  value: '1'
+- name: SERVICE_NAME
+  required: true
+  value: wit
+- name: ENVIRONMENT
+  value: dev
+metadata:
+  name: ${SERVICE_NAME}
+objects:
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      service: ${SERVICE_NAME}
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+    name: ${SERVICE_NAME}
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      service: ${SERVICE_NAME}
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          service: ${SERVICE_NAME}
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: F8_POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: db.host
+          - name: F8_POSTGRES_PORT
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: db.port
+          - name: F8_DEVELOPER_MODE_ENABLED
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: developer.mode.enabled
+          - name: F8_AUTH_URL
+            valueFrom:
+              configMapKeyRef:
+                name: ${SERVICE_NAME}
+                key: auth.serviceurl
+          imagePullPolicy: IfNotPresent
+          name: ${SERVICE_NAME}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/status
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/status
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 0.1m
+              memory: 10Mi
+            limits:
+              cpu: 400m
+              memory: 1.5Gi
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status:
+    details:
+      causes:
+      - type: ConfigChange
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+      service: ${SERVICE_NAME}
+  spec:
+    ports:
+      - name: "8080"
+        protocol: TCP
+        port: 80
+        targetPort: 8080
+    selector:
+      service: ${SERVICE_NAME}
+    type: ClusterIP
+    sessionAffinity: null
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      service: ${SERVICE_NAME}
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+    name: ${SERVICE_NAME}
+  spec:
+    host: ''
+    port:
+      targetPort: "8080"
+    to:
+      kind: Service
+      name: ${SERVICE_NAME}
+      weight: 100
+    wildcardPolicy: None
+  status: {}

--- a/minishift/openshift/wit.app.yaml
+++ b/minishift/openshift/wit.app.yaml
@@ -13,6 +13,9 @@ parameters:
   value: wit
 - name: ENVIRONMENT
   value: dev
+- name: MEMORY_LIMIT
+  required: true
+  value: 1.5Gi
 metadata:
   name: ${SERVICE_NAME}
 objects:
@@ -95,7 +98,7 @@ objects:
               memory: 10Mi
             limits:
               cpu: 400m
-              memory: 1.5Gi
+              memory: ${MEMORY_LIMIT}
           terminationMessagePath: /dev/termination-log
         dnsPolicy: ClusterFirst
         restartPolicy: Always

--- a/minishift/openshift/wit.config.yaml
+++ b/minishift/openshift/wit.config.yaml
@@ -1,0 +1,34 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: SERVICE_NAME
+  required: true
+  value: wit
+- name: ENVIRONMENT
+  value: dev
+metadata:
+  name: ${SERVICE_NAME}
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+  type: Opaque
+  data:
+    db.host: ZGItd2l0
+    db.port: NTQzMg==
+    developer.mode.enabled: dHJ1ZQ==
+    db.admin.password: bXlzZWNyZXRwYXNzd29yZA==
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      belongsTo: ${SERVICE_NAME}
+      env: ${ENVIRONMENT}
+  type: Opaque
+  data:
+    auth.serviceurl: http://auth

--- a/minishift/openshift/wit.db.yaml
+++ b/minishift/openshift/wit.db.yaml
@@ -1,0 +1,103 @@
+kind: Template
+apiVersion: v1
+parameters:
+- name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- name: DATABASE_SERVICE_NAME
+  required: true
+  value: db-wit
+- name: POSTGRESQL_VERSION
+  required: true
+  value: "9.6"
+- name: REPLICAS
+  required: true
+  value: '1'
+- name: ENVIRONMENT
+  value: dev  
+metadata:
+  name: ${DATABASE_SERVICE_NAME}
+objects:
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      belongsTo: wit
+      env: ${ENVIRONMENT}
+      service: ${DATABASE_SERVICE_NAME}
+      version: ${POSTGRESQL_VERSION}
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      service: ${DATABASE_SERVICE_NAME}
+    template:
+      metadata:
+        labels:
+          service: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - image: registry.centos.org/postgresql/postgresql:${POSTGRESQL_VERSION}
+          env:
+          - name: POSTGRESQL_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wit
+                key: db.admin.password
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 1
+          name: ${DATABASE_SERVICE_NAME}
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - psql -h 127.0.0.1 -U postgres -q -d postgres -c
+                'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+    labels:
+      belongsTo: wit
+      env: ${ENVIRONMENT}
+      service: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+      - name: "5432"
+        nodePort: 31002
+        port: 5432
+        targetPort: 5432
+    selector:
+      service: ${DATABASE_SERVICE_NAME}
+    type: NodePort

--- a/minishift/openshift/wit.db.yaml
+++ b/minishift/openshift/wit.db.yaml
@@ -71,7 +71,11 @@ objects:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
+            requests:
+              cpu: 0.1m
+              memory: 10Mi
             limits:
+              cpu: 400m
               memory: ${MEMORY_LIMIT}
           securityContext:
             capabilities: {}


### PR DESCRIPTION
Adds following make target for minishift local setup for running auth,wit, ui
- **auth:**
  - `deploy-auth`
  - `deploy-auth-secrets`
  - `deploy-auth-db`
  - `deploy-auth-only`
  - `clean-auth`
  - `redeploy-auth`
 
- **wit:**
  - `deploy-wit`
  - `deploy-wit-secrets`
  - `deploy-wit-db`
  - `clean-wit`

- **f8ui**:
  - `deploy-f8ui`
  - `clean-f8ui`

- **all**:
  - `clean-all`
  - `clean-all-resources`

- **container/openshift**:
  - `build-image`
  - `expose-minishift-docker-env`
  - `init-project`

Fixes: #551