### PR TITLE
If user is already a collaborator, log and move on

### DIFF
--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -357,9 +357,8 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminOK() {
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminFailsExistingAssignment() {
-	g := s.DBTestSuite.NewTestGraph()
-	newSpace := g.CreateSpace()
-	spaceCreator := g.CreateUser()
+	newSpace := s.Graph.CreateSpace()
+	spaceCreator := s.Graph.CreateUser()
 	s.addNoisyAssignments()
 
 	err := s.repo.ForceAssign(context.Background(), spaceCreator.Identity().ID, authorization.SpaceAdminRole, *newSpace.Resource())

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -16,6 +16,8 @@ import (
 	"github.com/fabric8-services/fabric8-auth/login"
 	"github.com/fabric8-services/fabric8-auth/token"
 
+	errs "github.com/pkg/errors"
+
 	"fmt"
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
@@ -199,7 +201,18 @@ func (c *CollaboratorsController) addContributors(ctx context.Context, currentId
 		// Have to use ForceAssign() because Assign() requires assignees to already have any role in the space
 		err = c.app.RoleManagementService().ForceAssign(ctx, identityID, authorization.SpaceContributorRole, res)
 		if err != nil {
-			return err
+
+			if _, ok := errs.Cause(err).(autherrors.DataConflictError); ok {
+				// If the error occured because the user is already a contributor
+				// we log the error, and proceed - instead of returning a non-200 response.
+				log.Warn(ctx, map[string]interface{}{
+					"err":      err,
+					"identity": contributor.ID,
+					"resource": res.ResourceID,
+				}, "identity already has the contributor role(s) associated with the resource")
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -278,6 +278,10 @@ func (rest *TestCollaboratorsREST) TestAddCollaboratorsOk() {
 	_, actualUsers = test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, nil, nil)
 	// then
 	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID}, actualUsers)
+
+	// try adding again, should still return OK
+	test.AddCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, rest.testIdentity2.ID.String())
+
 }
 
 func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsOk() {
@@ -294,6 +298,19 @@ func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsOk() {
 	_, actualUsers = test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, nil, nil)
 	// then
 	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID, rest.testIdentity3.ID}, actualUsers)
+
+	// If an identity is already a contibutor, do not bother.
+
+	// given
+	identity4 := rest.Graph.CreateUser().Identity()
+	payload = &app.AddManyCollaboratorsPayload{Data: []*app.UpdateUserID{{ID: rest.testIdentity1.ID.String(), Type: idnType}, {ID: rest.testIdentity2.ID.String(), Type: idnType}, {ID: identity4.ID.String(), Type: idnType}}}
+	test.AddManyCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, payload)
+
+	// when
+	_, actualUsers = test.ListCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, nil, nil, nil, nil)
+	// then
+	rest.checkCollaborators([]uuid.UUID{rest.testIdentity1.ID, rest.testIdentity2.ID, rest.testIdentity3.ID, identity4.ID}, actualUsers)
+
 }
 
 func (rest *TestCollaboratorsREST) TestAddCollaboratorsUnauthorizedIfNoToken() {


### PR DESCRIPTION
The `Add Collaborators` used to return an error ( non 200 ) if one or more users being added was already a contributor. 

This PR ensures that if a user is already a contributor, the API does not complain and returns a 200, after logging the info that the user is already a contributor. This is analogous to any update API which overwrites existing data even if nothing has changed.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/556
Related to https://github.com/openshiftio/openshift.io/issues/4011