### PR TITLE
During oauth2 code-token exchange, handle user-not-provisioned scenario

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -367,12 +367,13 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 
 	var err error
 	var token *app.OauthToken
+	var notApprovedRedirect *string
 
 	switch payload.GrantType {
 	case "client_credentials":
 		token, err = c.exchangeWithGrantTypeClientCredentials(ctx)
 	case "authorization_code":
-		token, err = c.exchangeWithGrantTypeAuthorizationCode(ctx)
+		notApprovedRedirect, token, err = c.exchangeWithGrantTypeAuthorizationCode(ctx)
 	case "refresh_token":
 		token, err = c.exchangeWithGrantTypeRefreshToken(ctx)
 	default:
@@ -381,6 +382,11 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	if notApprovedRedirect != nil {
+		ctx.ResponseData.Header().Set("Location", *notApprovedRedirect)
+		ctx.TemporaryRedirect()
 	}
 
 	return ctx.OK(token)
@@ -432,24 +438,24 @@ func (c *TokenController) exchangeWithGrantTypeRefreshToken(ctx *app.ExchangeTok
 	return token, nil
 }
 
-func (c *TokenController) exchangeWithGrantTypeAuthorizationCode(ctx *app.ExchangeTokenContext) (*app.OauthToken, error) {
+func (c *TokenController) exchangeWithGrantTypeAuthorizationCode(ctx *app.ExchangeTokenContext) (*string, *app.OauthToken, error) {
 	payload := ctx.Payload
 	if payload.Code == nil {
-		return nil, errors.NewBadParameterError("code", "nil").Expected("authorization code")
+		return nil, nil, errors.NewBadParameterError("code", "nil").Expected("authorization code")
 	}
 	// Default value of this public client id is set to "740650a2-9c44-4db5-b067-a3d1b2cd2d01"
 	if payload.ClientID != c.Configuration.GetPublicOauthClientID() {
 		log.Error(ctx, map[string]interface{}{
 			"client_id": payload.ClientID,
 		}, "unknown oauth client id")
-		return nil, errors.NewUnauthorizedError("invalid oauth client id")
+		return nil, nil, errors.NewUnauthorizedError("invalid oauth client id")
 	}
 	authEndpoint, err := c.Configuration.GetKeycloakEndpointAuth(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get keycloak auth endpoint url")
-		return nil, errors.NewInternalErrorFromString(ctx, "unable to get keycloak auth endpoint url")
+		return nil, nil, errors.NewInternalErrorFromString(ctx, "unable to get keycloak auth endpoint url")
 	}
 
 	tokenEndpoint, err := c.Configuration.GetKeycloakEndpointToken(ctx.RequestData)
@@ -457,7 +463,7 @@ func (c *TokenController) exchangeWithGrantTypeAuthorizationCode(ctx *app.Exchan
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get keycloak token endpoint url")
-		return nil, errors.NewInternalErrorFromString(ctx, "unable to get keycloak token endpoint url")
+		return nil, nil, errors.NewInternalErrorFromString(ctx, "unable to get keycloak token endpoint url")
 	}
 
 	oauth := &oauth2.Config{
@@ -472,7 +478,7 @@ func (c *TokenController) exchangeWithGrantTypeAuthorizationCode(ctx *app.Exchan
 	keycloakToken, err := c.Auth.Exchange(ctx, *payload.Code, oauth)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	redirectURL, err := url.Parse(oauth.RedirectURL)
@@ -481,34 +487,38 @@ func (c *TokenController) exchangeWithGrantTypeAuthorizationCode(ctx *app.Exchan
 			"redirectURL": oauth.RedirectURL,
 			"err":         err,
 		}, "failed to parse referrer")
-		return nil, errors.NewInternalError(ctx, err)
+		return nil, nil, errors.NewInternalError(ctx, err)
 	}
 
-	_, userToken, err := c.Auth.CreateOrUpdateIdentityAndUser(ctx, redirectURL, keycloakToken, ctx.RequestData, c.Configuration)
+	notApprovedRedirectURL, userToken, err := c.Auth.CreateOrUpdateIdentityAndUser(ctx, redirectURL, keycloakToken, ctx.RequestData, c.Configuration)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Convert expiry to expire_in
-	expiry := userToken.Expiry
-	var expireIn *string
-	if expiry != *new(time.Time) {
-		exp := expiry.Sub(time.Now())
-		if exp > 0 {
-			seconds := strconv.FormatInt(int64(exp/time.Second), 10)
-			expireIn = &seconds
+	var token *app.OauthToken
+
+	if userToken != nil {
+		// Convert expiry to expire_in
+		expiry := userToken.Expiry
+		var expireIn *string
+		if expiry != *new(time.Time) {
+			exp := expiry.Sub(time.Now())
+			if exp > 0 {
+				seconds := strconv.FormatInt(int64(exp/time.Second), 10)
+				expireIn = &seconds
+			}
+		}
+
+		token = &app.OauthToken{
+			AccessToken:  &userToken.AccessToken,
+			ExpiresIn:    expireIn,
+			RefreshToken: &userToken.RefreshToken,
+			TokenType:    &userToken.TokenType,
 		}
 	}
 
-	token := &app.OauthToken{
-		AccessToken:  &userToken.AccessToken,
-		ExpiresIn:    expireIn,
-		RefreshToken: &userToken.RefreshToken,
-		TokenType:    &userToken.TokenType,
-	}
-
-	return token, nil
+	return notApprovedRedirectURL, token, nil
 }
 
 func (c *TokenController) exchangeWithGrantTypeClientCredentials(ctx *app.ExchangeTokenContext) (*app.OauthToken, error) {

--- a/design/token.go
+++ b/design/token.go
@@ -111,6 +111,7 @@ var _ = a.Resource("token", func() {
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.TemporaryRedirect)
 	})
 
 	a.Action("keys", func() {


### PR DESCRIPTION
For the OAuth2 workflow of the login scenario, we already check if the user is provisioned, however, we were not redirecting the user to the 'not-approved' page if user wasn't provisioned in OSO via the reg-app.

This PR fixes that.
This specific workflow is used only by  che.openshift.io 

So if a user tried to login to che.openshift.io , the server returned a 500 which was a panic caused by a missing nil check - this PR introduces the necessary nil check, and the redirect.

```

{"POST":"/api/token","action":"Exchange","ctrl":"token","from":"106.201.115.98","level":"info","msg":"request started","pkg":"log.LogRequest.func1","req_id":"hhoGiRGUbb-20628","time":"2018-07-25 02:58:23"}
--
  | {"err":"user 'shbose-24062018' is not approved","file":"/tmp/go/src/github.com/fabric8-services/fabric8-auth/login/service.go","func":"github.com/fabric8-services/fabric8-auth/login.(*KeycloakOAuthProvider).CreateOrUpdateIdentityAndUser","level":"error","line":289,"msg":"failed to create a user and keycloak identity ","pid":1,"pkg":"login","req_headers":{"Accept":["*/*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9,mt;q=0.8"],"Content-Length":["262"],"Content-Type":["application/x-www-form-urlencoded"],"Forwarded":["for=106.201.115.98;host=auth.openshift.io;proto=https"],"Origin":["https://che.openshift.io"],"Referer":["https://che.openshift.io/dashboard/"],"User-Agent":["Mozilla/5.0  (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"],"X-Forwarded-For":["106.201.115.98"],"X-Forwarded-Host":["auth.openshift.io"],"X-Forwarded-Port":["443"],"X-Forwarded-Proto":["https"]},"req_id":"hhoGiRGUbb-20628","req_payload":"{\"client_id\":\"740650a2-9c44-4db5-b067-a3d1b2cd2d01\",\"code\":\"uss.USprt----------------E.f7c21210-6ca7-4d4d-84d7-1b95c48176a0.98447a27-40de-450b-a987-1ddc97730839\",\"grant_type\":\"authorization_code\",\"redirect_uri\":\"https://che.openshift.io/dashboard/\"}","time":"2018-07-25  02:58:23"}
  | {"err":"panic: runtime error: invalid memory address or nil pointer dereference\npanic(0xbc79c0, 0x11aeb30)\n\t/usr/lib/golang/src/runtime/panic.go:491 +0x283\ngithub.com/fabric8-services/fabric8-auth/controller.(*TokenController).exchangeWithGrantTypeAuthorizationCode(0xc4201401c0, 0xc420a9c030, 0xcb7c2d, 0x12, 0x1)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/controller/token.go:494 +0xd1e\ngithub.com/fabric8-services/fabric8-auth/controller.(*TokenController).Exchange(0xc4201401c0, 0xc420a9c030, 0xc4202fc200, 0xc4200621e0)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/controller/token.go:375 +0x5a0\ngithub.com/fabric8-services/fabric8-auth/app.MountTokenController.func2(0x1165400, 0xc420a9c000, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0x1165400, 0xc420a9c000)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/app/controllers.go:1407 +0x11f\ngithub.com/fabric8-services/fabric8-auth/app.handleTokenOrigin.func1(0x1165400, 0xc420a9c000, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0x0, 0x0)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/app/controllers.go:1556 +0x344\ngithub.com/fabric8-services/fabric8-auth/vendor/github.com/goadesign/goa.(*Controller).MuxHandler.func1.1(0x1165400, 0xc420819d10, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0x0, 0x0)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/vendor/github.com/goadesign/goa/service.go:270 +0xaa\ngithub.com/fabric8-services/fabric8-auth/log.LogRequest.func1.1(0x1165400, 0xc420819d10, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0xc420819c20, 0x0)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/log/log_request.go:90 +0xcfc\ngithub.com/fabric8-services/fabric8-auth/login.InjectTokenManager.func1.1(0x1165400, 0xc420819a10, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0xce, 0xc420cfaf90)\n\t/tmp/go/src/github.com/fabric8-services/fabric8-auth/login/service.go:960 +0x98\ngithub.com/fabric8-services/fabric8-auth/goamiddleware.handler.func1(0x1165400, 0xc420819a10, 0x1162f40, 0xc4202ab580, 0xc4207f6d00, 0x8819ddf6, 0xc420cfb060)\n\t/tmp/go/sr
```

