### PR TITLE
Temporary whitelist of dev cluster url

### DIFF
--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -108,7 +108,7 @@ vwIDAQAB
 	// DefaultValidRedirectURLs is a regex to be used to whitelist redirect URL for auth
 	// If the AUTH_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
 	// In prod mode the following regex will be used by default:
-	DefaultValidRedirectURLs = "^(https|http)://(([^/?#]+[.])?(?i:openshift[.]io)|localhost)((/|:).*)?$" // *.openshift.io/* and localhost
+	DefaultValidRedirectURLs = "^(https|http)://(([^/?#]+[.])?(?i:openshift[.]io)|localhost|(?i:rhche-dfestal-preview-che[.]dev[.]rdu2c[.]fabric8[.]io))((/|:).*)?$" //"^(https|http)://(([^/?#]+[.])?(?i:openshift[.]io)|localhost)((/|:).*)?$" // *.openshift.io/* and localhost
 	devModeValidRedirectURLs = ".*"
 
 	serviceAccountConfigFileName    = "service-account-secrets.conf"


### PR DESCRIPTION
Needed to be able to test the che login workflow using the devcluster che deployment which @davidfestal is working on. 

This would be used in prod for a short while. prod-preview doesn't help because account provisioning is not automatic.

Change will be reverted.