### PR TITLE
docs(#587): add documentation for deploying notification on minishift

### DIFF
--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -36,6 +36,11 @@ deploy-wit: deploy-wit-secrets deploy-wit-db
 	@echo "Deploying wit service"
 	@oc process -f $(TEMPLATE_DIR)/wit.app.yaml -o yaml | oc apply -f -
 
+.PHONY: deploy-notification
+deploy-notification: deploy-notification-secrets
+	@echo "Deploying notification service"
+	@oc process -f $(TEMPLATE_DIR)/f8notification.app.yaml -o yaml | oc apply -f -
+
 .PHONY: deploy-f8ui
 deploy-f8ui:
 	@echo "Deploying fabric8-ui service"
@@ -70,6 +75,10 @@ deploy-auth-secrets:
 deploy-wit-secrets:
 	oc process -f $(TEMPLATE_DIR)/wit.config.yaml -o yaml | oc apply -f -
 
+.PHONY: deploy-notification-secrets
+deploy-notification-secrets:
+	oc process -f $(TEMPLATE_DIR)/f8notification.config.yaml -o yaml | oc apply -f -
+
 .PHONY: clean-all
 clean-all:
 	oc delete all -l env=dev
@@ -86,6 +95,10 @@ clean-auth:
 .PHONY: clean-wit
 clean-wit:
 	oc delete all -l belongsTo=wit
+
+.PHONY: clean-notification
+clean-notification:
+	oc delete all -l belongsTo=f8notification
 
 .PHONY: clean-f8ui
 clean-f8ui:

--- a/.make/Makefile.dev
+++ b/.make/Makefile.dev
@@ -77,7 +77,10 @@ deploy-wit-secrets:
 
 .PHONY: deploy-notification-secrets
 deploy-notification-secrets:
-	oc process -f $(TEMPLATE_DIR)/f8notification.config.yaml -o yaml | oc apply -f -
+	@echo "Hint: set F8_MANDRILL_API_KEY env variable with your base64 encoded mandrill api key"
+	@oc process -f $(TEMPLATE_DIR)/f8notification.config.yaml \
+		-p F8_MANDRILL_API_KEY=$(F8_MANDRILL_API_KEY) \
+		-o yaml | oc apply -f -
 
 .PHONY: clean-all
 clean-all:

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -121,7 +121,7 @@ make deploy-notification
 Look for running pods using `oc get pods`. You should be able to see two pods(f8notification-*). First time it will take some time as it has download required container images.
 
 ##### Mandrill API key
-If you have mandrill api key. Make sure you updated secrets data by key `madrill.api` from `f8notification.config.yaml` with base64 encoded value of your key.
+If you have mandrill api key. Make sure that you set env variable by name `F8_MANDRILL_API_KEY` with base64 encoded value of your key.
 You can encode your mandrill api key using following command
 ```bash
 echo -n 'your_api_key' | base64

--- a/minishift/dev_setup.md
+++ b/minishift/dev_setup.md
@@ -110,6 +110,23 @@ You can try logging by hitting this in browser `http://f8ui-fabric8-services.${m
 Note: However if you are trying this first time you should approve your username from keycloak, so that you will be authenticated user.
 Also make sure to whitelist the domain which you are using for auth to work it as per expectation.
 
+#### Notification Service
+##### Deploying Notification Service
+
+To deploy Notification service, we have following make target which will deploy service.
+```bash
+make deploy-notification
+```
+
+Look for running pods using `oc get pods`. You should be able to see two pods(f8notification-*). First time it will take some time as it has download required container images.
+
+##### Mandrill API key
+If you have mandrill api key. Make sure you updated secrets data by key `madrill.api` from `f8notification.config.yaml` with base64 encoded value of your key.
+You can encode your mandrill api key using following command
+```bash
+echo -n 'your_api_key' | base64
+```
+
 #### Deploying Auth, WIT, UI together
 To deploy `auth`, `wit`, `fabric8-ui` together we have following target:
 ```bash
@@ -128,6 +145,11 @@ make clean-auth
 This removes both the `wit` and `db-wit` services from minishift.
 ```bash
 make clean-wit
+```
+##### Cleaning Notification
+This removes both the `notification` services from minishift.
+```bash
+make clean-notification
 ```
 
 ##### Cleaning Fabric8-ui

--- a/minishift/openshift/auth.config.yaml
+++ b/minishift/openshift/auth.config.yaml
@@ -32,3 +32,4 @@ objects:
   type: Opaque
   data:
     wit.url: http://wit
+    notification.serviceurl: http://f8notification

--- a/minishift/openshift/f8notification.app.yaml
+++ b/minishift/openshift/f8notification.app.yaml
@@ -1,38 +1,32 @@
-kind: Template
 apiVersion: v1
+kind: Template
 parameters:
-- name: DOCKER_REPO
-  required: true
-- name: IMAGE_NAME
-  required: true
+- name: IMAGE
+  value: quay.io/openshiftio/fabric8-services-fabric8-notification
 - name: IMAGE_TAG
-  required: true
-- name: REPLICAS
-  required: true
-  value: '1'
-- name: ENVIRONMENT
-  value: dev
+  value: latest
 - name: SERVICE_NAME
   required: true
-  value: auth
+  value: f8notification
 - name: MEMORY_LIMIT
   required: true
-  value: 1.5Gi
+  value: 1.0Gi
 metadata:
-  name: ${SERVICE_NAME}
+  name: fabric8-notification-service
 objects:
-- kind: DeploymentConfig
-  apiVersion: v1
+- apiVersion: v1
+  kind: DeploymentConfig
   metadata:
     labels:
+      service: ${SERVICE_NAME}
       belongsTo: ${SERVICE_NAME}
       env: ${ENVIRONMENT}
-      service: ${SERVICE_NAME}
     name: ${SERVICE_NAME}
   spec:
-    replicas: ${{REPLICAS}}
+    replicas: 1
     selector:
-      service: ${SERVICE_NAME}
+      app: ${SERVICE_NAME}
+      deploymentconfig: ${SERVICE_NAME}
     strategy:
       rollingParams:
         intervalSeconds: 1
@@ -45,45 +39,46 @@ objects:
       metadata:
         labels:
           service: ${SERVICE_NAME}
-          version: ${IMAGE_TAG}
+          deploymentconfig: ${SERVICE_NAME}
       spec:
         containers:
-        - image: ${DOCKER_REPO}/${IMAGE_NAME}:dev
-          env:
-          - name: AUTH_POSTGRES_HOST
+        - env:
+          - name: F8_MANDRILL_APIKEY
             valueFrom:
               secretKeyRef:
                 name: ${SERVICE_NAME}
-                key: db.host
-          - name: AUTH_POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: ${SERVICE_NAME}
-                key: db.port
-          - name: AUTH_DEVELOPER_MODE_ENABLED
-            valueFrom:
-              secretKeyRef:
-                name: ${SERVICE_NAME}
-                key: developer.mode.enabled
-          - name: AUTH_WIT_URL
+                key: madrill.api
+          - name: F8_WIT_URL
             valueFrom:
               configMapKeyRef:
                 name: ${SERVICE_NAME}
                 key: wit.url
-          - name: AUTH_NOTIFICATION_SERVICEURL
+          - name: F8_AUTH_URL
             valueFrom:
               configMapKeyRef:
                 name: ${SERVICE_NAME}
-                key: notification.serviceurl
+                key: auth.url
+          - name: F8_SERVICE_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: service.account.id
+          - name: F8_SERVICE_ACCOUNT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: ${SERVICE_NAME}
+                key: service.account.secret
+          image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: ${SERVICE_NAME}
           ports:
-          - containerPort: 8089
+          - containerPort: 8080
             protocol: TCP
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /api/status
-              port: 8089
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 10
@@ -93,7 +88,7 @@ objects:
             failureThreshold: 3
             httpGet:
               path: /api/status
-              port: 8089
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 10
@@ -106,51 +101,21 @@ objects:
             limits:
               cpu: 400m
               memory: ${MEMORY_LIMIT}
-          terminationMessagePath: /dev/termination-log
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-    test: false
     triggers:
     - type: ConfigChange
-  status:
-    details:
-      causes:
-      - type: ConfigChange
-- kind: Service
-  apiVersion: v1
+- apiVersion: v1
+  kind: Service
   metadata:
     name: ${SERVICE_NAME}
     labels:
+      service: ${SERVICE_NAME}
       belongsTo: ${SERVICE_NAME}
       env: ${ENVIRONMENT}
-      service: ${SERVICE_NAME}
   spec:
     ports:
-      - name: "8089"
-        protocol: TCP
+      - protocol: TCP
         port: 80
-        targetPort: 8089
+        targetPort: 8080
     selector:
-      service: ${SERVICE_NAME}
-    type: ClusterIP
-    sessionAffinity: null
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      service: ${SERVICE_NAME}
-      belongsTo: ${SERVICE_NAME}
-      env: ${ENVIRONMENT}
-    name: ${SERVICE_NAME}
-  spec:
-    host: ''
-    port:
-      targetPort: "8089"
-    to:
-      kind: Service
-      name: ${SERVICE_NAME}
-      weight: 100
-    wildcardPolicy: None
-  status: {}
+      deploymentconfig: ${SERVICE_NAME}
+

--- a/minishift/openshift/f8notification.config.yaml
+++ b/minishift/openshift/f8notification.config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: f8notification
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: f8notification
+  type: Opaque
+  data:
+    madrill.api: eHh4eHh4
+    service.account.id: NGM4M2NhMmQtNmRjYy00MWM5LWFjN2QtYjA2OGFkNGQxN2M1
+    service.account.secret: bm90aWZpY2F0aW9uc2VjcmV0
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: f8notification
+  type: Opaque
+  data:
+    wit.url: http://wit
+    auth.url: http://auth

--- a/minishift/openshift/f8notification.config.yaml
+++ b/minishift/openshift/f8notification.config.yaml
@@ -1,5 +1,8 @@
 apiVersion: v1
 kind: Template
+parameters:
+- name: F8_MANDRILL_API_KEY
+  required: true
 metadata:
   name: f8notification
 objects:
@@ -9,7 +12,7 @@ objects:
     name: f8notification
   type: Opaque
   data:
-    madrill.api: eHh4eHh4
+    madrill.api: ${F8_MANDRILL_API_KEY}
     service.account.id: NGM4M2NhMmQtNmRjYy00MWM5LWFjN2QtYjA2OGFkNGQxN2M1
     service.account.secret: bm90aWZpY2F0aW9uc2VjcmV0
 - apiVersion: v1


### PR DESCRIPTION
**Changes Proposed in this PR**

- Adds openshift template for notification
- Adds make target for `deploy-notification`, `clean-notification`.
- Adds documentation about the same

Fixes: #587