### PR TITLE
Use environment variables to log SQL queries in tests and keep data in DB (#591)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -178,6 +178,10 @@ $ cd $GOPATH/src/github.com/fabric8-services/fabric8-auth
 $ make test-all
 ----
 
+By default, test data is removed from the database after each test, unless the `AUTH_CLEAN_TEST_DATA` environment variable is set to `false`. This can be particularily useful to run queries on the test data after a test failure, in order to understand why the result did not match the expectations.
+
+Also, all SQL queries can be displayed in the output if the `AUTH_ENABLE_DB_LOGS` environment variable is set to `true. Beware that this can be very verbose, though ;)
+
 ===== Coverage [[coverage]]
 
 To visualize the coverage of unit, integration, or all tests you can run these

--- a/account/repository/verification_code_blackbox_test.go
+++ b/account/repository/verification_code_blackbox_test.go
@@ -26,7 +26,6 @@ func TestRunverificationCodeBlackboxTest(t *testing.T) {
 
 func (s *verificationCodeBlackboxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB = s.DB.Debug()
 	s.repo = repository.NewVerificationCodeRepository(s.DB)
 }
 

--- a/authorization/invitation/repository/invitation_blackbox_test.go
+++ b/authorization/invitation/repository/invitation_blackbox_test.go
@@ -26,7 +26,6 @@ func TestRunInvitationBlackBoxTest(t *testing.T) {
 
 func (s *invitationBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = invitationRepo.NewInvitationRepository(s.DB)
 }
 

--- a/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
+++ b/authorization/resourcetype/repository/resource_type_scope_blackbox_test.go
@@ -25,7 +25,6 @@ func TestRunResourceTypeScopeBlackBoxTest(t *testing.T) {
 
 func (s *resourceTypeScopeBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)
 }

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -37,7 +37,6 @@ func TestRunIdentityRoleBlackBoxTest(t *testing.T) {
 
 func (s *identityRoleBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = role.NewIdentityRoleRepository(s.DB)
 	s.identityRepo = account.NewIdentityRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)

--- a/authorization/role/repository/role_blackbox_test.go
+++ b/authorization/role/repository/role_blackbox_test.go
@@ -34,7 +34,6 @@ func TestRunRoleBlackBoxTest(t *testing.T) {
 
 func (s *roleBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = role.NewRoleRepository(s.DB)
 }
 

--- a/authorization/role/repository/role_scope_blackbox_test.go
+++ b/authorization/role/repository/role_scope_blackbox_test.go
@@ -26,7 +26,6 @@ func TestRunResourceTypeScopeBlackBoxTest(t *testing.T) {
 
 func (s *roleScopeBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = rolescope.NewRoleScopeRepository(s.DB)
 	s.resourceTypeScopeRepo = resourcetype.NewResourceTypeScopeRepository(s.DB)
 	s.resourceTypeRepo = resourcetype.NewResourceTypeRepository(s.DB)

--- a/authorization/token/repository/token_blackbox_test.go
+++ b/authorization/token/repository/token_blackbox_test.go
@@ -22,7 +22,6 @@ func TestRunTokenBlackBoxTest(t *testing.T) {
 
 func (s *tokenBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
-	s.DB.LogMode(true)
 	s.repo = tokenRepo.NewTokenRepository(s.DB)
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -41,6 +41,8 @@ const (
 	varHTTPAddress                     = "http.address"
 	varMetricsHTTPAddress              = "metrics.http.address"
 	varDeveloperModeEnabled            = "developer.mode.enabled"
+	varCleanTestDataEnabled            = "clean.test.data"
+	varDBLogsEnabled                   = "enable.db.logs"
 	varNotApprovedRedirect             = "notapproved.redirect"
 	varHeaderMaxLength                 = "header.maxlength"
 	varUsersListLimit                  = "users.listlimit"
@@ -700,6 +702,11 @@ func (c *ConfigurationData) setConfigDefaults() {
 
 	c.v.SetDefault(varLogLevel, defaultLogLevel)
 
+	// By default, test data should be cleaned from DB, unless explicitely said otherwise.
+	c.v.SetDefault(varCleanTestDataEnabled, true)
+	// By default, DB logs are not output in the console
+	c.v.SetDefault(varDBLogsEnabled, false)
+
 	// WIT related defaults
 	c.v.SetDefault(varWITDomainPrefix, defaultWITDomainPrefix)
 
@@ -856,6 +863,16 @@ func (c *ConfigurationData) GetHeaderMaxLength() int64 {
 // e.g. token generation endpoint are enabled
 func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
 	return c.v.GetBool(varDeveloperModeEnabled)
+}
+
+// IsCleanTestDataEnabled returns `true` if the test data should be cleaned after each test. (default: true)
+func (c *ConfigurationData) IsCleanTestDataEnabled() bool {
+	return c.v.GetBool(varCleanTestDataEnabled)
+}
+
+// IsDBLogsEnabled returns `true` if the DB logs (ie, SQL queries) should be output in the console. (default: false)
+func (c *ConfigurationData) IsDBLogsEnabled() bool {
+	return c.v.GetBool(varDBLogsEnabled)
 }
 
 // GetMaxUsersListLimit returns the max number of users returned when searching users

--- a/gormtestsupport/db_test_suite.go
+++ b/gormtestsupport/db_test_suite.go
@@ -58,8 +58,8 @@ func (s *DBTestSuite) SetupSuite() {
 			}, "failed to connect to the database")
 		}
 	}
-	// TODO(xcoulon): use an env variable to avoid systematic logging of all SQL requests?
-	s.DB = s.DB.Debug()
+	// configures the log mode for the SQL queries (by default, disabled)
+	s.DB.LogMode(s.Configuration.IsDBLogsEnabled())
 	s.Application = gormapplication.NewGormDB(s.DB, configuration)
 	s.Ctx = migration.NewMigrationContext(context.Background())
 	s.PopulateDBTestSuite(s.Ctx)
@@ -75,7 +75,12 @@ func (s *DBTestSuite) SetupTest() {
 
 // TearDownTest implements suite.TearDownTest
 func (s *DBTestSuite) TearDownTest() {
-	s.cleanTest()
+	// in some cases, we might need to keep the test data in the DB for inspecting/reproducing
+	// the SQL queries. In that case, the `AUTH_CLEAN_TEST_DATA` env variable should be set to `false`.
+	// By default, test data will be removed from the DB after each test
+	if s.Configuration.IsCleanTestDataEnabled() {
+		s.cleanTest()
+	}
 	s.Graph = nil
 }
 
@@ -85,7 +90,12 @@ func (s *DBTestSuite) PopulateDBTestSuite(ctx context.Context) {
 
 // TearDownSuite implements suite.TearDownAllSuite
 func (s *DBTestSuite) TearDownSuite() {
-	s.cleanSuite()
+	// in some cases, we might need to keep the test data in the DB for inspecting/reproducing
+	// the SQL queries. In that case, the `AUTH_CLEAN_TEST_DATA` env variable should be set to `false`.
+	// By default, test data will be removed from the DB after each test
+	if s.Configuration.IsCleanTestDataEnabled() {
+		s.cleanSuite()
+	}
 	s.DB.Close()
 }
 


### PR DESCRIPTION
Use `AUTH_CLEAN_TEST_DATA=false` to keep the DB data after the tests (by
 default, all data will be cleaned after each test)
Use `AUTH_ENABLE_DB_LOGS=true` to print all SQL queries in the console (by
 default, SQL queries won't be displayed anymore)

Fixes #591

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>