### PR TITLE
Add API to to check if a user has a specific scope (#492)

### DIFF
--- a/account/repository/identity_blackbox_test.go
+++ b/account/repository/identity_blackbox_test.go
@@ -58,7 +58,7 @@ func (s *identityBlackBoxTest) TestOKToDelete() {
 
 func (s *identityBlackBoxTest) TestOKToDeleteForResource() {
 
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	team := g.CreateTeam()
 	err := s.Application.Identities().CheckExists(s.Ctx, team.TeamID().String())
 	require.NoError(s.T(), err)
@@ -210,7 +210,7 @@ func (s *identityBlackBoxTest) TestFindIdentityMemberships() {
 }
 
 func (s *identityBlackBoxTest) TestFindIdentityTeamMemberships() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	g.CreateTeam(g.ID("tm"), g.CreateSpace(g.ID("spc"))).AddMember(g.CreateUser(g.ID("m")))
 
 	// Find the member's memberships
@@ -227,7 +227,7 @@ func (s *identityBlackBoxTest) TestFindIdentityTeamMemberships() {
 
 // TestFindIdentitiesByResourceTypeWithParentResource creates a combination of spaces/teams and then uses the finder method to find them
 func (s *identityBlackBoxTest) TestFindIdentitiesByResourceTypeWithParentResource() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	spc := g.CreateSpace(g.ID("spc"))
 	t1 := g.CreateTeam(g.ID("t1"), spc)
 	t2 := g.CreateTeam(g.ID("t2"), spc)
@@ -268,7 +268,7 @@ func (s *identityBlackBoxTest) TestFindIdentitiesByResourceTypeWithParentResourc
 }
 
 func (s *identityBlackBoxTest) TestAddMember() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	team := g.CreateTeam()
 	user := g.CreateUser()
 
@@ -304,7 +304,7 @@ func (s *identityBlackBoxTest) TestAddMemberFailsForNonMemberIdentity() {
 }
 
 func (s *identityBlackBoxTest) TestAddMemberFailsForDuplicateMembership() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	team := g.CreateTeam()
 	user := g.CreateUser()
 

--- a/application/application_db_calls_bench_test.go
+++ b/application/application_db_calls_bench_test.go
@@ -58,7 +58,7 @@ func (s *BenchDbOperations) SetupSuite() {
 }
 
 func (s *BenchDbOperations) SetupBenchmark() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.Clean = cleaner.DeleteCreatedEntities(s.DB)
 	s.repo = account.NewIdentityRepository(s.DB)
 	s.appDB = gormapplication.NewGormDB(s.DB)
 
@@ -74,7 +74,7 @@ func (s *BenchDbOperations) SetupBenchmark() {
 }
 
 func (s *BenchDbOperations) TearDownBenchmark() {
-	s.clean()
+	s.Clean()
 }
 
 func (s *BenchDbOperations) BenchmarkPqSelectOneQuery() {

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -50,6 +50,7 @@ type PermissionService interface {
 type ResourceService interface {
 	Delete(ctx context.Context, resourceID string) error
 	Read(ctx context.Context, resourceID string) (*app.Resource, error)
+	CheckExists(ctx context.Context, resourceID string) error
 	Register(ctx context.Context, resourceTypeName string, resourceID, parentResourceID *string) (*resource.Resource, error)
 }
 
@@ -60,6 +61,7 @@ type RoleManagementService interface {
 	Assign(ctx context.Context, assignedBy uuid.UUID, roleAssignments map[string][]uuid.UUID, resourceID string, appendToExistingRoles bool) error
 	ForceAssign(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error
 	RevokeResourceRoles(ctx context.Context, currentIdentity uuid.UUID, identities []uuid.UUID, resourceID string) error
+	ListByIdentityAndResource(ctx context.Context, currentIdentity uuid.UUID, resourceID string) ([]role.RoleDescriptor, error)
 }
 
 type TeamService interface {

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -61,7 +61,6 @@ type RoleManagementService interface {
 	Assign(ctx context.Context, assignedBy uuid.UUID, roleAssignments map[string][]uuid.UUID, resourceID string, appendToExistingRoles bool) error
 	ForceAssign(ctx context.Context, assignedTo uuid.UUID, roleName string, res resource.Resource) error
 	RevokeResourceRoles(ctx context.Context, currentIdentity uuid.UUID, identities []uuid.UUID, resourceID string) error
-	ListByIdentityAndResource(ctx context.Context, currentIdentity uuid.UUID, resourceID string) ([]role.RoleDescriptor, error)
 }
 
 type TeamService interface {

--- a/application/transaction/transaction_bench_test.go
+++ b/application/transaction/transaction_bench_test.go
@@ -42,7 +42,7 @@ func (s *BenchTransactional) SetupSuite() {
 }
 
 func (s *BenchTransactional) SetupBenchmark() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.Clean = cleaner.DeleteCreatedEntities(s.DB)
 	s.repo = account.NewIdentityRepository(s.DB)
 	s.app = gormapplication.NewGormDB(s.DB)
 
@@ -58,7 +58,7 @@ func (s *BenchTransactional) SetupBenchmark() {
 }
 
 func (s *BenchTransactional) TearDownBenchmark() {
-	s.clean()
+	s.Clean()
 }
 
 func (s *BenchTransactional) transactionLoadSpace() {

--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -46,8 +46,8 @@ const (
 	// SpaceViewerRole is the constant used to denote the name of the space's viewer role
 	SpaceViewerRole = viewerRole
 
-	// viewSpaceScope is a general scope required to perform many space-related operations
-	viewSpaceScope = viewScope
+	// ViewSpaceScope is a general scope required to perform many space-related operations
+	ViewSpaceScope = viewScope
 
 	// viewOrganizationScope is a general scope required to perform many org-related operations
 	viewOrganizationScope = viewScope
@@ -58,11 +58,11 @@ const (
 	// viewSecurityGroupScope is a general scope required to perform many group-related operations
 	viewSecurityGroupScope = viewScope
 
-	// manageSpaceScope is a general scope required to perform operations for managing a space
-	manageSpaceScope = manageScope
+	// ManageSpaceScope is a general scope required to perform operations for managing a space
+	ManageSpaceScope = manageScope
 
-	// contributeSpaceScope is a general scope required to perform many space-related operations
-	contributeSpaceScope = contributeScope
+	// ContributeSpaceScope is a general scope required to perform many space-related operations
+	ContributeSpaceScope = contributeScope
 
 	// ManageTeamsInSpaceScope is the scope required for users wishing to manage teams for a space
 	ManageTeamsInSpaceScope = manageScope
@@ -77,24 +77,24 @@ const (
 	ManageSecurityGroupMembersScope = manageScope
 
 	// ViewTeamsInSpaceScope is the scope required for users wishing to view the teams in a space
-	ViewTeamsInSpaceScope = viewSpaceScope
+	ViewTeamsInSpaceScope = ViewSpaceScope
 
 	// ManageRoleAssignmentsInSpaceScope is the scope required for managing role assignments in a space
 	ManageRoleAssignmentsInSpaceScope = manageScope
 
 	// DeleteSpaceScope is the scope required for deleting a space. It's a space level scope.
-	DeleteSpaceScope = manageSpaceScope
+	DeleteSpaceScope = ManageSpaceScope
 
 	// ViewRoleAssignmentsInSpaceScope is the scope required for viewing role assignments in a space
-	ViewRoleAssignmentsInSpaceScope = viewSpaceScope
+	ViewRoleAssignmentsInSpaceScope = ViewSpaceScope
 
-	// ViewRoleAssignmentsInSpaceScope is the scope required for viewing organization members
+	// ViewOrganizationMembersScope is the scope required for viewing organization members
 	ViewOrganizationMembersScope = viewOrganizationScope
 
-	// ViewRoleAssignmentsInSpaceScope is the scope required for viewing team members
+	// ViewTeamMembersScope is the scope required for viewing team members
 	ViewTeamMembersScope = viewTeamScope
 
-	// ViewRoleAssignmentsInSpaceScope is the scope required for viewing security group members
+	// ViewSecurityGroupMembersScope is the scope required for viewing security group members
 	ViewSecurityGroupMembersScope = viewSecurityGroupScope
 )
 

--- a/authorization/invitation/repository/invitation_blackbox_test.go
+++ b/authorization/invitation/repository/invitation_blackbox_test.go
@@ -189,7 +189,7 @@ func (s *invitationBlackBoxTest) TestAddRoleFailsForInvalidRoleID() {
 }
 
 func (s *invitationBlackBoxTest) TestFindByAcceptCode() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	i := g.CreateInvitation()
 
 	// Create a couple more invitations for some noise
@@ -203,7 +203,7 @@ func (s *invitationBlackBoxTest) TestFindByAcceptCode() {
 }
 
 func (s *invitationBlackBoxTest) TestFindByAcceptCodeNotFound() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	i := g.CreateInvitation()
 
 	// Create a couple more invitations for some noise

--- a/authorization/invitation/service/invitation_service_blackbox_test.go
+++ b/authorization/invitation/service/invitation_service_blackbox_test.go
@@ -38,7 +38,7 @@ func (s *invitationServiceBlackBoxTest) SetupTest() {
 }
 
 func (s *invitationServiceBlackBoxTest) TestIssueInvitationByIdentityID() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 
 	// Create a test user - this will be the team admin
 	teamAdmin := g.CreateUser()

--- a/authorization/resource/service/resource_service.go
+++ b/authorization/resource/service/resource_service.go
@@ -106,6 +106,12 @@ func (s *resourceServiceImpl) Read(ctx context.Context, resourceID string) (*app
 	}, nil
 }
 
+// Checks if the resource with the given ID exists. Returns an `error.NotFoundError` if the resource does not exists,
+// or an `error.InternalServerError` if an error occurred
+func (s *resourceServiceImpl) CheckExists(ctx context.Context, resourceID string) error {
+	return s.Repositories().ResourceRepository().CheckExists(ctx, resourceID)
+}
+
 // Register registers/creates a new resource
 // IMPORTANT: This is a transactional method, which manages its own transaction/s internally
 func (s *resourceServiceImpl) Register(ctx context.Context, resourceTypeName string, resourceID, parentResourceID *string) (*resource.Resource, error) {

--- a/authorization/resource/service/resource_service_blackbox_test.go
+++ b/authorization/resource/service/resource_service_blackbox_test.go
@@ -75,7 +75,7 @@ func (s *resourceServiceBlackBoxTest) TestRegisterReadDeleteResourceWithParentOK
 	resourceID := uuid.NewV4().String()
 
 	// With parent resource
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	g.CreateResource(g.ID("myparentresource"))
 	parent := g.ResourceByID("myparentresource").Resource()
 	resource, err := s.resourceService.Register(context.Background(), authorization.ResourceTypeSpace, &resourceID, &parent.ResourceID)
@@ -108,7 +108,7 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceOK() {
 
 	// Create test data
 
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	org := g.CreateOrganization()
 
 	spaceToDelete := g.CreateSpace(org)
@@ -181,7 +181,7 @@ func (s *resourceServiceBlackBoxTest) TestDeleteResourceOK() {
 }
 
 func (s *resourceServiceBlackBoxTest) TestDeleteResourceWithCycleReferencesFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	parent := g.CreateResource()
 	child := g.CreateResource(parent)
 	childResourceID := child.ResourceID()
@@ -231,15 +231,17 @@ func (s *resourceServiceBlackBoxTest) TestReadUnknownResourceFails() {
 }
 
 func (s *resourceServiceBlackBoxTest) TestRoleMappingsCreated() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	// Create a default role mapping for a new resource type
-	m := g.CreateDefaultRoleMapping(g.CreateResourceType(g.ID("rt")))
+	rtID := uuid.NewV4()
+	m := g.CreateDefaultRoleMapping(g.CreateResourceType(g.ID(rtID.String())))
 
+	rtID2 := uuid.NewV4()
 	// Create another default role mapping for a different resource type
-	g.CreateDefaultRoleMapping(g.CreateResourceType(g.ID("rt2")))
+	g.CreateDefaultRoleMapping(g.CreateResourceType(g.ID(rtID2.String())))
 
 	// Register a resource with the same resource type as the default role mapping
-	r, err := s.resourceService.Register(s.Ctx, g.ResourceTypeByID("rt").ResourceType().Name, nil, nil)
+	r, err := s.resourceService.Register(s.Ctx, g.ResourceTypeByID(rtID).ResourceType().Name, nil, nil)
 	require.NoError(s.T(), err)
 
 	// Find the mappings for the new resource

--- a/authorization/role/repository/default_role_mapping_blackbox_test.go
+++ b/authorization/role/repository/default_role_mapping_blackbox_test.go
@@ -28,7 +28,7 @@ func (s *defaultRoleMappingBlackBoxTest) SetupTest() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestOKToDelete() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 
 	rt := g.CreateResourceType()
 	rm := rolerepo.DefaultRoleMapping{
@@ -87,7 +87,7 @@ func (s *defaultRoleMappingBlackBoxTest) TestDeleteFailsForNonexistent() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestOKToLoad() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	rt := g.CreateResourceType()
 	rm := &rolerepo.DefaultRoleMapping{
 		ResourceTypeID: rt.ResourceType().ResourceTypeID,
@@ -113,7 +113,7 @@ func (s *defaultRoleMappingBlackBoxTest) TestLoadFailsForNonexistent() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestExistsDefaultRoleMapping() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	rt := g.CreateResourceType()
 	rm := &rolerepo.DefaultRoleMapping{
 		ResourceTypeID: rt.ResourceType().ResourceTypeID,
@@ -135,7 +135,7 @@ func (s *defaultRoleMappingBlackBoxTest) TestExistsUnknownDefaultRoleMappingFail
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestOKToSave() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	rt := g.CreateResourceType()
 	rm := &rolerepo.DefaultRoleMapping{
 		ResourceTypeID: rt.ResourceType().ResourceTypeID,
@@ -160,7 +160,7 @@ func (s *defaultRoleMappingBlackBoxTest) TestOKToSave() {
 }
 
 func (s *defaultRoleMappingBlackBoxTest) TestFindForResourceType() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 	rt := g.CreateResourceType()
 	rm := g.CreateDefaultRoleMapping(rt)
 

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -21,7 +21,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type identityRoleBlackBoxTest struct {
+func TestIdentityRoleRepository(t *testing.T) {
+	suite.Run(t, &IdentityRoleRepositoryTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+type IdentityRoleRepositoryTestSuite struct {
 	gormtestsupport.DBTestSuite
 	repo                  role.IdentityRoleRepository
 	identityRepo          account.IdentityRepository
@@ -31,11 +35,7 @@ type identityRoleBlackBoxTest struct {
 	roleRepo              role.RoleRepository
 }
 
-func TestRunIdentityRoleBlackBoxTest(t *testing.T) {
-	suite.Run(t, &identityRoleBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
-}
-
-func (s *identityRoleBlackBoxTest) SetupTest() {
+func (s *IdentityRoleRepositoryTestSuite) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.repo = role.NewIdentityRoleRepository(s.DB)
 	s.identityRepo = account.NewIdentityRepository(s.DB)
@@ -44,7 +44,7 @@ func (s *identityRoleBlackBoxTest) SetupTest() {
 	s.roleRepo = role.NewRoleRepository(s.DB)
 }
 
-func (s *identityRoleBlackBoxTest) TestOKToDelete() {
+func (s *IdentityRoleRepositoryTestSuite) TestOKToDelete() {
 	// create 2 identity roles, where the first one would be deleted.
 	identityRole := createAndLoadIdentityRole(s)
 	createAndLoadIdentityRole(s)
@@ -64,7 +64,7 @@ func (s *identityRoleBlackBoxTest) TestOKToDelete() {
 	}
 }
 
-func (s *identityRoleBlackBoxTest) TestDeleteUnknownFails() {
+func (s *IdentityRoleRepositoryTestSuite) TestDeleteUnknownFails() {
 	identityRoleID := uuid.NewV4()
 
 	err := s.repo.Delete(s.Ctx, identityRoleID)
@@ -72,8 +72,8 @@ func (s *identityRoleBlackBoxTest) TestDeleteUnknownFails() {
 	assert.Equal(s.T(), fmt.Sprintf("identity_role with id '%s' not found", identityRoleID), err.Error())
 }
 
-func (s *identityRoleBlackBoxTest) TestOKToDeleteForResource() {
-	g := s.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestOKToDeleteForResource() {
+	g := s.NewTestGraph(s.T())
 
 	// Test space
 	space := g.CreateSpace()
@@ -116,7 +116,7 @@ func (s *identityRoleBlackBoxTest) TestOKToDeleteForResource() {
 	assert.Len(s.T(), idRoles, 5)
 }
 
-func (s *identityRoleBlackBoxTest) TestDeleteForIdentityAndResourceOK() {
+func (s *IdentityRoleRepositoryTestSuite) TestDeleteForIdentityAndResourceOK() {
 	// Test space
 	space := s.Graph.CreateSpace()
 	// One viewer/contributor in the space to stay
@@ -162,13 +162,13 @@ func (s *identityRoleBlackBoxTest) TestDeleteForIdentityAndResourceOK() {
 	assert.Len(s.T(), idRoles, 10)
 }
 
-func (s *identityRoleBlackBoxTest) TestOKToDeleteForUnknownResource() {
+func (s *IdentityRoleRepositoryTestSuite) TestOKToDeleteForUnknownResource() {
 	err := s.repo.DeleteForResource(s.Ctx, uuid.NewV4().String())
 	require.NoError(s.T(), err)
 }
 
-func (s *identityRoleBlackBoxTest) TestDeleteForUnknownIdentityAndResourceFails() {
-	g := s.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestDeleteForUnknownIdentityAndResourceFails() {
+	g := s.NewTestGraph(s.T())
 	space := g.CreateSpace()
 	//space.AddViewer(g.CreateUser())
 
@@ -188,11 +188,11 @@ func (s *identityRoleBlackBoxTest) TestDeleteForUnknownIdentityAndResourceFails(
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "identity_role with resource_id '%s' and identity_id '%s' not found", space.SpaceID(), identityID)
 }
 
-func (s *identityRoleBlackBoxTest) TestOKToLoad() {
+func (s *IdentityRoleRepositoryTestSuite) TestOKToLoad() {
 	createAndLoadIdentityRole(s)
 }
 
-func (s *identityRoleBlackBoxTest) TestExistsRole() {
+func (s *IdentityRoleRepositoryTestSuite) TestExistsRole() {
 	t := s.T()
 
 	t.Run("identity role exists", func(t *testing.T) {
@@ -211,13 +211,13 @@ func (s *identityRoleBlackBoxTest) TestExistsRole() {
 	})
 }
 
-func (s *identityRoleBlackBoxTest) TestExistsUnknownIdentityRoleFails() {
+func (s *IdentityRoleRepositoryTestSuite) TestExistsUnknownIdentityRoleFails() {
 	id := uuid.NewV4().String()
 	err := s.repo.CheckExists(s.Ctx, id)
 	testsupport.AssertError(s.T(), err, errors.NotFoundError{}, "identity_role with id '%s' not found", id)
 }
 
-func (s *identityRoleBlackBoxTest) TestFindPermissions() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindPermissions() {
 	// Create a new resource type
 	resourceType, err := testsupport.CreateTestResourceType(s.Ctx, s.DB, "identity_role_test/test_resource_type")
 	require.NoError(s.T(), err)
@@ -266,7 +266,7 @@ func (s *identityRoleBlackBoxTest) TestFindPermissions() {
 	require.Len(s.T(), identityRoles, 0)
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesForIdentity() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesForIdentity() {
 	identityRole := createAndLoadIdentityRole(s)
 	createAndLoadIdentityRole(s)
 
@@ -279,7 +279,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesForIdentity() {
 	require.Equal(s.T(), identityRole.Role.Name, associations[0].Roles[0])
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceAndRoleName() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesByResourceAndRoleName() {
 	orgAdmin := s.Graph.CreateUser()
 	org := s.Graph.CreateOrganization(orgAdmin)
 
@@ -311,7 +311,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceAndRoleName() 
 	validateAssignee(s.T(), []uuid.UUID{spaceAdmin.IdentityID()}, space.SpaceID(), identityRoles)
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceAndRoleNameOrder() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesByResourceAndRoleNameOrder() {
 	org := s.Graph.CreateOrganization(s.Graph.CreateUser())
 	space := s.Graph.CreateSpace(org)
 	for i := 0; i < 10; i++ {
@@ -341,7 +341,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceAndRoleNameOrd
 	}
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceOrder() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesByResourceOrder() {
 	org := s.Graph.CreateOrganization(s.Graph.CreateUser())
 	space := s.Graph.CreateSpace(org)
 	for i := 0; i < 10; i++ {
@@ -370,7 +370,7 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResourceOrder() {
 	}
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResource() {
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesByResource() {
 	orgAdmin := s.Graph.CreateUser()
 	org := s.Graph.CreateOrganization(orgAdmin)
 
@@ -401,8 +401,8 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByResource() {
 	validateAssignee(s.T(), []uuid.UUID{orgAdmin.IdentityID()}, org.ResourceID(), identityRoles)
 }
 
-func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByIdentityAndResource() {
-	g := s.DBTestSuite.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestFindIdentityRolesByIdentityAndResource() {
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 
 	var createdIdentities []uuid.UUID
@@ -428,8 +428,8 @@ func (s *identityRoleBlackBoxTest) TestFindIdentityRolesByIdentityAndResource() 
 	}
 }
 
-func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownIdentity() {
-	g := s.DBTestSuite.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestCreateIdentityRolesUnknownIdentity() {
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 
 	knownRoleID := getKnownRoleIDForSpace(s)
@@ -444,8 +444,8 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownIdentity() {
 	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
-func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownRole() {
-	g := s.DBTestSuite.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestCreateIdentityRolesUnknownRole() {
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	existingUser := g.CreateUser()
 
@@ -459,8 +459,8 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownRole() {
 	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
-func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownResource() {
-	g := s.DBTestSuite.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestCreateIdentityRolesUnknownResource() {
+	g := s.DBTestSuite.NewTestGraph(s.T())
 
 	existingUser := g.CreateUser()
 	knownRoleID := getKnownRoleIDForSpace(s)
@@ -475,8 +475,8 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityRolesUnknownResource() {
 	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
-func (s *identityRoleBlackBoxTest) TestCreateIdentityExistingAssignmentFails() {
-	g := s.DBTestSuite.NewTestGraph()
+func (s *IdentityRoleRepositoryTestSuite) TestCreateIdentityExistingAssignmentFails() {
+	g := s.DBTestSuite.NewTestGraph(s.T())
 
 	existingUser := g.CreateUser()
 	knownRoleID := getKnownRoleIDForSpace(s)
@@ -496,7 +496,7 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityExistingAssignmentFails() {
 	require.IsType(s.T(), errors.DataConflictError{}, errs.Cause(err))
 }
 
-func getKnownRoleIDForSpace(s *identityRoleBlackBoxTest) uuid.UUID {
+func getKnownRoleIDForSpace(s *IdentityRoleRepositoryTestSuite) uuid.UUID {
 	roles, err := s.roleRepo.FindRolesByResourceType(context.Background(), authorization.ResourceTypeSpace)
 	require.Nil(s.T(), err)
 	require.Len(s.T(), roles, 3)
@@ -506,7 +506,7 @@ func getKnownRoleIDForSpace(s *identityRoleBlackBoxTest) uuid.UUID {
 	return knownRoleID
 }
 
-func createAndLoadIdentityRole(s *identityRoleBlackBoxTest) *role.IdentityRole {
+func createAndLoadIdentityRole(s *IdentityRoleRepositoryTestSuite) *role.IdentityRole {
 	ir, err := testsupport.CreateRandomIdentityRole(s.Ctx, s.DB)
 	require.NoError(s.T(), err)
 	return ir

--- a/authorization/role/repository/role_mapping_blackbox_test.go
+++ b/authorization/role/repository/role_mapping_blackbox_test.go
@@ -59,7 +59,7 @@ func (s *roleMappingBlackBoxTest) TestOKToDelete() {
 }
 
 func (s *roleMappingBlackBoxTest) TestOKToDeleteForResource() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 
 	// Create 5 role mappings
 	r := g.CreateResource()
@@ -184,7 +184,7 @@ func (s *roleMappingBlackBoxTest) TestOKToSave() {
 }
 
 func (s *roleMappingBlackBoxTest) TestFindForResource() {
-	g := s.NewTestGraph()
+	g := s.NewTestGraph(s.T())
 
 	m := g.CreateRoleMapping(g.CreateResource(g.ID("r")))
 

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -46,11 +46,6 @@ func (s *roleManagementServiceImpl) ListByResource(ctx context.Context, currentI
 	return s.Repositories().IdentityRoleRepository().FindIdentityRolesByResource(ctx, resourceID, false)
 }
 
-// ListByResource lists all identity roles for the resource if the current user has permissions to view the roles
-func (s *roleManagementServiceImpl) ListByIdentityAndResource(ctx context.Context, currentIdentity uuid.UUID, resourceID string) ([]role.RoleDescriptor, error) {
-	return s.ListByIdentityAndResource(ctx, currentIdentity, resourceID)
-}
-
 func (s *roleManagementServiceImpl) requireViewRolesScope(ctx context.Context, currentIdentity uuid.UUID, resourceID string) error {
 	// Lookup the resourceID and ensure the resource is valid
 	rt, err := s.Repositories().ResourceRepository().Load(ctx, resourceID)

--- a/authorization/role/service/role_management_service.go
+++ b/authorization/role/service/role_management_service.go
@@ -46,6 +46,11 @@ func (s *roleManagementServiceImpl) ListByResource(ctx context.Context, currentI
 	return s.Repositories().IdentityRoleRepository().FindIdentityRolesByResource(ctx, resourceID, false)
 }
 
+// ListByResource lists all identity roles for the resource if the current user has permissions to view the roles
+func (s *roleManagementServiceImpl) ListByIdentityAndResource(ctx context.Context, currentIdentity uuid.UUID, resourceID string) ([]role.RoleDescriptor, error) {
+	return s.ListByIdentityAndResource(ctx, currentIdentity, resourceID)
+}
+
 func (s *roleManagementServiceImpl) requireViewRolesScope(ctx context.Context, currentIdentity uuid.UUID, resourceID string) error {
 	// Lookup the resourceID and ensure the resource is valid
 	rt, err := s.Repositories().ResourceRepository().Load(ctx, resourceID)

--- a/authorization/role/service/role_management_service_blackbox_test.go
+++ b/authorization/role/service/role_management_service_blackbox_test.go
@@ -202,7 +202,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssertRolesWithReplacingExisting
 }
 
 func (s *roleManagementServiceBlackboxTest) checkAssignRoleOK(appendToExistingRoles bool) {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	adminUser := g.CreateUser("adminuser-who-adds-the-others")
 	newSpace.AddAdmin(adminUser)
@@ -269,7 +269,7 @@ func (s *roleManagementServiceBlackboxTest) checkRoleAssignments(identities []uu
 }
 
 func (s *roleManagementServiceBlackboxTest) addNoisyAssignments() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	for i := 0; i < 10; i++ {
 		randomAssignee := g.CreateUser()
 		g.CreateSpace().AddContributor(randomAssignee)
@@ -277,7 +277,7 @@ func (s *roleManagementServiceBlackboxTest) addNoisyAssignments() {
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithLackOfPermissionsFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	viewer := g.CreateUser("viewer-who-tries-to-assign-roles")
 	newSpace.AddViewer(viewer)
@@ -293,7 +293,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithLackOfPermissionsF
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleAlreadyExists() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	spaceAdmin := g.CreateUser("adminuser")
 	newSpace := g.CreateSpace().AddAdmin(spaceAdmin)
 
@@ -309,7 +309,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAlreadyExists() {
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleResourceNotFound() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	identityID := g.CreateUser().Identity().ID
 	userToBeAdded := []uuid.UUID{g.CreateUser("randomuser").Identity().ID}
 	roleAssignments := make(map[string][]uuid.UUID)
@@ -320,7 +320,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleResourceNotFound() {
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithRoleNotFound() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	adminUser := g.CreateUser()
 	newSpace := g.CreateSpace().AddAdmin(adminUser)
 	userToBeAdded := []uuid.UUID{g.CreateUser("randomuser").Identity().ID}
@@ -332,7 +332,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithRoleNotFound() {
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithIdentityNotFound() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	adminUser := g.CreateUser()
 	newSpace := g.CreateSpace().AddAdmin(adminUser)
 	userToBeAdded := []uuid.UUID{uuid.NewV4()}
@@ -344,7 +344,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleWithIdentityNotFound()
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminOK() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	spaceCreator := g.CreateUser()
 	s.addNoisyAssignments()
@@ -374,7 +374,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminFailsExistingAs
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignUnknownRoleAsAdminFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	spaceCreator := g.CreateUser()
 
@@ -383,7 +383,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignUnknownRoleAsAdminFails() 
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminToUnknownIdentityFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	newSpace := g.CreateSpace()
 	id := uuid.NewV4()
 
@@ -392,7 +392,7 @@ func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminToUnknownIdenti
 }
 
 func (s *roleManagementServiceBlackboxTest) TestAssignRoleAsAdminForUnknownResourceFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	spaceCreator := g.CreateUser()
 	id := uuid.NewV4().String()
 

--- a/authorization/space/service/space_service_blackbox_test.go
+++ b/authorization/space/service/space_service_blackbox_test.go
@@ -30,7 +30,7 @@ func (s *spaceServiceBlackBoxTest) TestCreateByUnknownUserFails() {
 
 func (s *spaceServiceBlackBoxTest) TestCreateOK() {
 	spaceID := uuid.NewV4().String()
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	creator := g.CreateUser()
 
 	err := s.Application.SpaceService().CreateSpace(s.Ctx, creator.Identity().ID, spaceID)
@@ -55,7 +55,7 @@ func (s *spaceServiceBlackBoxTest) TestCreateOK() {
 }
 
 func (s *spaceServiceBlackBoxTest) TestDeleteUnknownSpaceFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	spaceID := uuid.NewV4().String()
 
 	err := s.Application.SpaceService().DeleteSpace(s.Ctx, g.CreateUser().Identity().ID, spaceID)
@@ -63,7 +63,7 @@ func (s *spaceServiceBlackBoxTest) TestDeleteUnknownSpaceFails() {
 }
 
 func (s *spaceServiceBlackBoxTest) TestByUnauthorizedUserFails() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	space := g.CreateSpace()
 	user := g.CreateUser()
 
@@ -80,7 +80,7 @@ func (s *spaceServiceBlackBoxTest) TestByUnauthorizedUserFails() {
 }
 
 func (s *spaceServiceBlackBoxTest) TestDeleteOK() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	user := g.CreateUser()
 	space := g.CreateSpace().AddAdmin(user)
 

--- a/authorization/team/service/team_service_blackbox_test.go
+++ b/authorization/team/service/team_service_blackbox_test.go
@@ -20,7 +20,7 @@ func TestRunTeamServiceBlackBoxTest(t *testing.T) {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateAndListTeamsSuccessful() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	g.CreateSpace(g.ID("myspace")).AddAdmin(g.CreateUser(g.ID("foo")))
 
 	teamName := "TestTeam" + uuid.NewV4().String()
@@ -61,7 +61,7 @@ func (s *teamServiceBlackBoxTest) TestCreateAndListTeamsSuccessful() {
 }
 
 func (s *teamServiceBlackBoxTest) TestListTeamsInSpaceForDifferentRoles() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	g.CreateSpace(g.ID("spc")).
 		AddAdmin(g.CreateUser(g.ID("admin"))).
 		AddContributor(g.CreateUser(g.ID("contributor"))).
@@ -94,7 +94,7 @@ func (s *teamServiceBlackBoxTest) TestListTeamsInSpaceForDifferentRoles() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForNonSpaceUser() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	space := g.CreateSpace()
 	user := g.CreateUser()
 
@@ -104,7 +104,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForNonSpaceUser() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForContributor() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	space := g.CreateSpace().AddContributor(g.CreateUser(g.ID("user")))
 
 	teamName := "TestTeam" + uuid.NewV4().String()
@@ -113,7 +113,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForContributor() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForViewer() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	space := g.CreateSpace().AddViewer(g.CreateUser(g.ID("user")))
 
 	teamName := "TestTeam" + uuid.NewV4().String()
@@ -122,7 +122,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForViewer() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForUnknownUser() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	userIdentityID := uuid.NewV4()
 	space := g.CreateSpace()
 
@@ -132,7 +132,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForUnknownUser() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForUnknownSpace() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	user := g.CreateUser()
 	spaceID := uuid.NewV4().String()
 
@@ -142,7 +142,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForUnknownSpace() {
 }
 
 func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForNonSpaceResource() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	user := g.CreateUser()
 	resource := g.CreateResource()
 
@@ -152,7 +152,7 @@ func (s *teamServiceBlackBoxTest) TestCreateTeamFailsForNonSpaceResource() {
 }
 
 func (s *teamServiceBlackBoxTest) TestListTeamsForIdentity() {
-	g := s.DBTestSuite.NewTestGraph()
+	g := s.DBTestSuite.NewTestGraph(s.T())
 	g.CreateSpace(g.ID("spc")).AddAdmin(g.CreateUser(g.ID("u1")))
 	g.CreateSpace(g.ID("spc2")).AddAdmin(g.UserByID("u1"))
 

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -14,245 +14,384 @@ import (
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type TestResourceRolesRest struct {
+func TestResourceRolesController(t *testing.T) {
+	suite.Run(t, &ResourceRolesControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+type ResourceRolesControllerTestSuite struct {
 	gormtestsupport.DBTestSuite
 }
 
-func (s *TestResourceRolesRest) SetupSuite() {
+func (s *ResourceRolesControllerTestSuite) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 }
 
-func (rest *TestResourceRolesRest) SecuredControllerWithIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
+func (s *ResourceRolesControllerTestSuite) SecuredControllerWithIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
 	svc := testsupport.ServiceAsUser("Resource-roles-Service", identity)
-	return svc, NewResourceRolesController(svc, rest.Application)
+	return svc, NewResourceRolesController(svc, s.Application)
 }
 
-func (rest *TestResourceRolesRest) SecuredControllerWithIncompleteIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
+func (s *ResourceRolesControllerTestSuite) SecuredControllerWithIncompleteIdentity(identity account.Identity) (*goa.Service, *ResourceRolesController) {
 	svc := testsupport.ServiceAsUserWithIncompleteClaims("Resource-roles-Service", identity)
-	return svc, NewResourceRolesController(svc, rest.Application)
+	return svc, NewResourceRolesController(svc, s.Application)
 }
 
-func (rest *TestResourceRolesRest) UnSecuredController() (*goa.Service, *ResourceRolesController) {
+func (s *ResourceRolesControllerTestSuite) UnsecuredController() (*goa.Service, *ResourceRolesController) {
 	svc := testsupport.UnsecuredService("Resource-roles-Service")
-	return svc, NewResourceRolesController(svc, rest.Application)
+	return svc, NewResourceRolesController(svc, s.Application)
 }
 
-func TestRunResourceRolesRest(t *testing.T) {
-	suite.Run(t, &TestResourceRolesRest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+func (s *ResourceRolesControllerTestSuite) TestListAssignedRoles() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		admin := s.Graph.CreateUser()
+		viewer := s.Graph.CreateUser()
+		space := s.Graph.CreateSpace().AddAdmin(admin).AddViewer(viewer)
+
+		// noise
+		s.Graph.CreateSpace().AddViewer(s.Graph.CreateUser())
+
+		// Check available roles
+		svc, ctrl := s.SecuredControllerWithIdentity(*viewer.Identity())
+		_, returnedIdentityRoles := test.ListAssignedResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID())
+		require.Len(t, returnedIdentityRoles.Data, 2)
+		s.checkExists(t, []uuid.UUID{admin.IdentityID(), viewer.IdentityID()}, []string{"admin", "viewer"}, returnedIdentityRoles)
+	})
+
+	s.T().Run("forbidden", func(t *testing.T) {
+		svc, ctrl := s.SecuredControllerWithIdentity(*s.Graph.CreateUser().Identity())
+		space := s.Graph.CreateSpace()
+		test.ListAssignedResourceRolesForbidden(t, svc.Context, svc, ctrl, space.SpaceID())
+	})
+
+	s.T().Run("not found", func(t *testing.T) {
+		svc, ctrl := s.SecuredControllerWithIdentity(*s.Graph.CreateUser().Identity())
+		test.ListAssignedResourceRolesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String())
+	})
+
 }
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesOK() {
-	admin := rest.Graph.CreateUser()
-	viewer := rest.Graph.CreateUser()
-	space := rest.Graph.CreateSpace().AddAdmin(admin).AddViewer(viewer)
+func (s *ResourceRolesControllerTestSuite) TestListAssignedRolesByRoleName() {
 
-	// noise
-	rest.Graph.CreateSpace().AddViewer(rest.Graph.CreateUser())
+	s.T().Run("ok", func(t *testing.T) {
+		admin := s.Graph.CreateUser()
+		viewer := s.Graph.CreateUser()
+		space := s.Graph.CreateSpace().AddAdmin(admin).AddViewer(viewer)
 
-	// Check available roles
-	svc, ctrl := rest.SecuredControllerWithIdentity(*viewer.Identity())
-	_, returnedIdentityRoles := test.ListAssignedResourceRolesOK(rest.T(), svc.Context, svc, ctrl, space.SpaceID())
-	require.Len(rest.T(), returnedIdentityRoles.Data, 2)
-	rest.checkExists([]uuid.UUID{admin.IdentityID(), viewer.IdentityID()}, []string{"admin", "viewer"}, returnedIdentityRoles)
+		// noise
+		s.Graph.CreateSpace().AddAdmin(s.Graph.CreateUser())
+
+		// Check available roles
+		svc, ctrl := s.SecuredControllerWithIdentity(*viewer.Identity())
+		_, returnedIdentityRoles := test.ListAssignedByRoleNameResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), "admin")
+		require.Len(t, returnedIdentityRoles.Data, 1)
+		s.checkExists(t, []uuid.UUID{admin.IdentityID()}, []string{"admin"}, returnedIdentityRoles)
+	})
+
+	s.T().Run("forbidden", func(t *testing.T) {
+		svc, ctrl := s.SecuredControllerWithIdentity(*s.Graph.CreateUser().Identity())
+		space := s.Graph.CreateSpace()
+		test.ListAssignedByRoleNameResourceRolesForbidden(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.SpaceViewerRole)
+	})
+
+	s.T().Run("not found", func(t *testing.T) {
+		svc, ctrl := s.SecuredControllerWithIdentity(*s.Graph.CreateUser().Identity())
+		test.ListAssignedByRoleNameResourceRolesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), authorization.SpaceViewerRole)
+	})
+
 }
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameOK() {
-	admin := rest.Graph.CreateUser()
-	viewer := rest.Graph.CreateUser()
-	space := rest.Graph.CreateSpace().AddAdmin(admin).AddViewer(viewer)
+func (s *ResourceRolesControllerTestSuite) TestAssignRole() {
 
-	// noise
-	rest.Graph.CreateSpace().AddAdmin(rest.Graph.CreateUser())
+	s.T().Run("ok", func(t *testing.T) {
+		g := s.DBTestSuite.NewTestGraph(s.T())
+		res := g.CreateSpace()
 
-	// Check available roles
-	svc, ctrl := rest.SecuredControllerWithIdentity(*viewer.Identity())
-	_, returnedIdentityRoles := test.ListAssignedByRoleNameResourceRolesOK(rest.T(), svc.Context, svc, ctrl, space.SpaceID(), "admin")
-	require.Len(rest.T(), returnedIdentityRoles.Data, 1)
-	rest.checkExists([]uuid.UUID{admin.IdentityID()}, []string{"admin"}, returnedIdentityRoles)
-}
+		var identitiesToBeAssigned []string
+		for i := 0; i <= 10; i++ {
+			testUser := g.CreateUser()
+			res.AddViewer(testUser)
+			identitiesToBeAssigned = append(identitiesToBeAssigned, testUser.Identity().ID.String())
+		}
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesUnauthorized() {
-	svc, ctrl := rest.SecuredControllerWithIdentity(*rest.Graph.CreateUser().Identity())
-	space := rest.Graph.CreateSpace()
-	test.ListAssignedResourceRolesForbidden(rest.T(), svc.Context, svc, ctrl, space.SpaceID())
-}
+		roleAssignment := &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: identitiesToBeAssigned}
+		assignments := []*app.AssignRoleData{roleAssignment}
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesNotFound() {
-	svc, ctrl := rest.SecuredControllerWithIdentity(*rest.Graph.CreateUser().Identity())
-	test.ListAssignedResourceRolesNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String())
-}
+		// Create a user who has the privileges to assign roles
+		adminUser := g.CreateUser("adminuser")
+		res.AddAdmin(adminUser)
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameUnauthorized() {
-	svc, ctrl := rest.SecuredControllerWithIdentity(*rest.Graph.CreateUser().Identity())
-	space := rest.Graph.CreateSpace()
-	test.ListAssignedByRoleNameResourceRolesForbidden(rest.T(), svc.Context, svc, ctrl, space.SpaceID(), authorization.SpaceViewerRole)
-}
+		svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+		payload := &app.AssignRoleResourceRolesPayload{
+			Data: assignments,
+		}
 
-func (rest *TestResourceRolesRest) TestListAssignedRolesByRoleNameNotFound() {
-	svc, ctrl := rest.SecuredControllerWithIdentity(*rest.Graph.CreateUser().Identity())
-	test.ListAssignedByRoleNameResourceRolesNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), authorization.SpaceViewerRole)
-}
+		test.AssignRoleResourceRolesNoContent(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+	})
 
-func (rest *TestResourceRolesRest) TestAssignRoleOK() {
+	s.T().Run("conflict", func(t *testing.T) {
+		g := s.DBTestSuite.NewTestGraph(s.T())
+		res := g.CreateSpace()
 
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace()
-
-	var identitiesToBeAssigned []string
-	for i := 0; i <= 10; i++ {
 		testUser := g.CreateUser()
 		res.AddViewer(testUser)
-		identitiesToBeAssigned = append(identitiesToBeAssigned, testUser.Identity().ID.String())
-	}
 
-	roleAssignment := &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: identitiesToBeAssigned}
-	assignments := []*app.AssignRoleData{roleAssignment}
+		// Create a user who has the privileges to assign roles
+		adminUser := g.CreateUser("adminuser")
+		res.AddAdmin(adminUser)
 
-	// Create a user who has the privileges to assign roles
-	adminUser := g.CreateUser("adminuser")
-	res.AddAdmin(adminUser)
-
-	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: assignments,
-	}
-
-	test.AssignRoleResourceRolesNoContent(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-}
-
-func (rest *TestResourceRolesRest) TestAssignRoleConflict() {
-
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace()
-
-	testUser := g.CreateUser()
-	res.AddViewer(testUser)
-
-	// Create a user who has the privileges to assign roles
-	adminUser := g.CreateUser("adminuser")
-	res.AddAdmin(adminUser)
-
-	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: []*app.AssignRoleData{
-			{
-				Role: authorization.SpaceContributorRole,
-				Ids:  []string{testUser.Identity().ID.String()},
+		svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+		payload := &app.AssignRoleResourceRolesPayload{
+			Data: []*app.AssignRoleData{
+				{
+					Role: authorization.SpaceContributorRole,
+					Ids:  []string{testUser.Identity().ID.String()},
+				},
 			},
-		},
-	}
+		}
 
-	test.AssignRoleResourceRolesNoContent(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-	test.AssignRoleResourceRolesConflict(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
+		test.AssignRoleResourceRolesNoContent(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		test.AssignRoleResourceRolesConflict(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+	})
+
+	s.T().Run("unauthorized", func(t *testing.T) {
+
+		t.Run("incompete claims", func(t *testing.T) {
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			res := g.CreateSpace(g.ID("somespacename"))
+
+			var identitiesToBeAssigned []*app.AssignRoleData
+			for i := 0; i <= 2; i++ {
+				identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{uuid.NewV4().String() + "#$%"}})
+			}
+			adminUser := g.CreateUser("adminuser")
+			res.AddContributor(adminUser) //not really an admin
+
+			svc, ctrl := s.SecuredControllerWithIncompleteIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: identitiesToBeAssigned,
+			}
+
+			test.AssignRoleResourceRolesUnauthorized(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		})
+
+		t.Run("missing data", func(t *testing.T) {
+			svc, ctrl := s.UnsecuredController()
+			payload := app.AssignRoleResourceRolesPayload{
+				Data: []*app.AssignRoleData{},
+			}
+			test.AssignRoleResourceRolesUnauthorized(t, s.Ctx, svc, ctrl, uuid.NewV4().String(), &payload)
+		})
+	})
+
+	s.T().Run("bad request", func(t *testing.T) {
+
+		t.Run("invalid identity", func(t *testing.T) {
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			res := g.CreateSpace(g.ID("somespacename"))
+
+			var identitiesToBeAssigned []*app.AssignRoleData
+			for i := 0; i <= 2; i++ {
+				identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{uuid.NewV4().String() + "#$%"}})
+			}
+
+			// Create a user who has the privileges to assign roles
+			adminUser := g.CreateUser("adminuser")
+			res.AddAdmin(adminUser)
+
+			svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: identitiesToBeAssigned,
+			}
+
+			test.AssignRoleResourceRolesBadRequest(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		})
+
+		t.Run("user not in space", func(t *testing.T) {
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			res := g.CreateSpace()
+
+			var identitiesToBeAssigned []*app.AssignRoleData
+
+			// some already have roles assigned
+			for i := 0; i <= 2; i++ {
+				testUser := g.CreateUser()
+				identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
+				res.AddViewer(testUser)
+			}
+
+			// while others don't have any role assigned.
+			for i := 0; i <= 2; i++ {
+				testUser := g.CreateUser()
+				identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
+			}
+
+			// Create a user who has the privileges to assign roles
+			adminUser := g.CreateUser("adminuser")
+			res.AddAdmin(adminUser)
+
+			svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: identitiesToBeAssigned,
+			}
+
+			test.AssignRoleResourceRolesBadRequest(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		})
+
+	})
+
+	s.T().Run("forbidden", func(t *testing.T) {
+
+		t.Run("not allowed to assign roles", func(t *testing.T) {
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			res := g.CreateSpace(g.ID("somespacename"))
+
+			var identitiesToBeAssigned []*app.AssignRoleData
+			for i := 0; i <= 2; i++ {
+				testUser := g.CreateUser()
+				res.AddViewer(testUser)
+				identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
+			}
+
+			// Create a user who has the privileges to assign roles
+			adminUser := g.CreateUser("adminuser")
+			res.AddContributor(adminUser) //not really an admin
+
+			svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: identitiesToBeAssigned,
+			}
+
+			test.AssignRoleResourceRolesForbidden(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		})
+	})
+
 }
 
-func (rest *TestResourceRolesRest) TestAssignRoleUnauthorized() {
-	svc, ctrl := rest.UnSecuredController()
-	payload := app.AssignRoleResourceRolesPayload{
-		Data: []*app.AssignRoleData{},
-	}
-	test.AssignRoleResourceRolesUnauthorized(rest.T(), rest.Ctx, svc, ctrl, uuid.NewV4().String(), &payload)
+func (s *ResourceRolesControllerTestSuite) TestListScopes() {
+
+	s.T().Run("ok", func(t *testing.T) {
+
+		t.Run("user has no role on space", func(t *testing.T) {
+			// given
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			user := g.CreateUser(g.ID("m"))
+			space := g.CreateSpace(g.ID("space")) // user has no role on this space
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when
+			_, scopes := test.HasScopeResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.ManageSpaceScope)
+			// then
+			require.NotNil(t, scopes)
+			require.NotNil(t, scopes.Data)
+			assert.Equal(t, scopes.Data.ScopeName, authorization.ManageSpaceScope)
+			assert.Equal(t, scopes.Data.HasScope, false)
+		})
+
+		t.Run("user is admin on space", func(t *testing.T) {
+			// given
+			g := s.DBTestSuite.NewTestGraph(s.T())
+			user := g.CreateUser(g.ID("m"))
+			space := g.CreateSpace(g.ID("space")).AddAdmin(user)
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when
+			_, scopes := test.HasScopeResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.ManageSpaceScope)
+			// then
+			require.NotNil(t, scopes)
+			require.NotNil(t, scopes.Data)
+			assert.Equal(t, scopes.Data.ScopeName, authorization.ManageSpaceScope)
+			assert.Equal(t, scopes.Data.HasScope, true)
+		})
+
+		t.Run("user is in admin team on space", func(t *testing.T) {
+			// given
+			g := s.DBTestSuite.NewTestGraph(t)
+			user := g.CreateUser()
+			team := g.CreateTeam().AddMember(user)
+			space := g.CreateSpace().AddAdmin(team)
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when
+			_, scopes := test.HasScopeResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.ManageSpaceScope)
+			// then
+			require.NotNil(t, scopes)
+			require.NotNil(t, scopes.Data)
+			assert.Equal(t, scopes.Data.ScopeName, authorization.ManageSpaceScope)
+			assert.Equal(t, scopes.Data.HasScope, true)
+		})
+
+		t.Run("user is in admin on space org with default role mapping", func(t *testing.T) {
+			defer s.CleanTest() // make sure that the default role mapping is removed after this test
+			// given
+			g := s.DBTestSuite.NewTestGraph(t)
+			user := g.CreateUser()
+			team := g.CreateTeam().AddMember(user)
+			org := g.CreateOrganization().AddAdmin(team)
+			space := g.CreateSpace().AddAdmin(team)
+			orgAdminRole := g.RoleByNameAndResourceType(authorization.OrganizationAdminRole, org.Resource().ResourceType.Name)
+			spaceContributorRole := g.RoleByNameAndResourceType(authorization.SpaceContributorRole, space.Resource().ResourceType.Name)
+			spaceType := g.ResourceTypeByID(space.Resource().ResourceType.ResourceTypeID)
+			g.CreateDefaultRoleMapping(spaceType, orgAdminRole, spaceContributorRole)
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when
+			_, scopes := test.HasScopeResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.ManageSpaceScope)
+			// then
+			require.NotNil(t, scopes)
+			require.NotNil(t, scopes.Data)
+			assert.Equal(t, scopes.Data.ScopeName, authorization.ManageSpaceScope)
+			assert.Equal(t, scopes.Data.HasScope, true)
+		})
+
+		t.Run("user is in admin on space org with custom role mapping", func(t *testing.T) {
+			// given
+			g := s.DBTestSuite.NewTestGraph(t)
+			user := g.CreateUser()
+			team := g.CreateTeam().AddMember(user)
+			org := g.CreateOrganization().AddAdmin(team)
+			space := g.CreateSpace().AddAdmin(team)
+			orgAdminRole := g.RoleByNameAndResourceType(authorization.OrganizationAdminRole, org.Resource().ResourceType.Name)
+			spaceContributorRole := g.RoleByNameAndResourceType(authorization.SpaceContributorRole, space.Resource().ResourceType.Name)
+			g.CreateRoleMapping(space, orgAdminRole, spaceContributorRole)
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when
+			_, scopes := test.HasScopeResourceRolesOK(t, svc.Context, svc, ctrl, space.SpaceID(), authorization.ManageSpaceScope)
+			// then
+			require.NotNil(t, scopes)
+			require.NotNil(t, scopes.Data)
+			assert.Equal(t, scopes.Data.ScopeName, authorization.ManageSpaceScope)
+			assert.Equal(t, scopes.Data.HasScope, true)
+		})
+
+	})
+
+	s.T().Run("unauthorized", func(t *testing.T) {
+
+		t.Run("missing token", func(t *testing.T) {
+			// given
+			svc, ctrl := s.UnsecuredController()
+			// when/then
+			test.HasScopeResourceRolesUnauthorized(t, svc.Context, svc, ctrl, "", authorization.ManageSpaceScope)
+		})
+	})
+
+	s.T().Run("not found", func(t *testing.T) {
+
+		t.Run("resource does not exist", func(t *testing.T) {
+			// given
+			g := s.DBTestSuite.NewTestGraph(t)
+			user := g.CreateUser()
+			svc, ctrl := s.SecuredControllerWithIdentity(*user.Identity())
+			// when/then
+			test.HasScopeResourceRolesNotFound(t, svc.Context, svc, ctrl, "foo", authorization.ManageSpaceScope)
+		})
+	})
+
 }
 
-func (rest *TestResourceRolesRest) TestAssignRoleBadRequestUserNotInSpace() {
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace()
-
-	var identitiesToBeAssigned []*app.AssignRoleData
-
-	// some already have roles assigned
-	for i := 0; i <= 2; i++ {
-		testUser := g.CreateUser()
-		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
-		res.AddViewer(testUser)
-	}
-
-	// while others don't have any role assigned.
-	for i := 0; i <= 2; i++ {
-		testUser := g.CreateUser()
-		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
-	}
-
-	// Create a user who has the privileges to assign roles
-	adminUser := g.CreateUser("adminuser")
-	res.AddAdmin(adminUser)
-
-	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: identitiesToBeAssigned,
-	}
-
-	test.AssignRoleResourceRolesBadRequest(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-}
-
-func (rest *TestResourceRolesRest) TestAssignRoleForbiddenNotAllowedToAssignRoles() {
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace(g.ID("somespacename"))
-
-	var identitiesToBeAssigned []*app.AssignRoleData
-	for i := 0; i <= 2; i++ {
-		testUser := g.CreateUser()
-		res.AddViewer(testUser)
-		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{testUser.Identity().ID.String()}})
-	}
-
-	// Create a user who has the privileges to assign roles
-	adminUser := g.CreateUser("adminuser")
-	res.AddContributor(adminUser) //not really an admin
-
-	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: identitiesToBeAssigned,
-	}
-
-	test.AssignRoleResourceRolesForbidden(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-}
-
-func (rest *TestResourceRolesRest) TestAssignRoleWithInvalidIdentityIDBadRequest() {
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace(g.ID("somespacename"))
-
-	var identitiesToBeAssigned []*app.AssignRoleData
-	for i := 0; i <= 2; i++ {
-		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{uuid.NewV4().String() + "#$%"}})
-	}
-
-	// Create a user who has the privileges to assign roles
-	adminUser := g.CreateUser("adminuser")
-	res.AddAdmin(adminUser)
-
-	svc, ctrl := rest.SecuredControllerWithIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: identitiesToBeAssigned,
-	}
-
-	test.AssignRoleResourceRolesBadRequest(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-}
-
-func (rest *TestResourceRolesRest) TestAssignRoleWithIncompleteTokenClaims() {
-	g := rest.DBTestSuite.NewTestGraph()
-	res := g.CreateSpace(g.ID("somespacename"))
-
-	var identitiesToBeAssigned []*app.AssignRoleData
-	for i := 0; i <= 2; i++ {
-		identitiesToBeAssigned = append(identitiesToBeAssigned, &app.AssignRoleData{Role: authorization.SpaceContributorRole, Ids: []string{uuid.NewV4().String() + "#$%"}})
-	}
-	adminUser := g.CreateUser("adminuser")
-	res.AddContributor(adminUser) //not really an admin
-
-	svc, ctrl := rest.SecuredControllerWithIncompleteIdentity(*adminUser.Identity())
-	payload := &app.AssignRoleResourceRolesPayload{
-		Data: identitiesToBeAssigned,
-	}
-
-	test.AssignRoleResourceRolesUnauthorized(rest.T(), svc.Context, svc, ctrl, res.SpaceID(), payload)
-}
-
-func (rest *TestResourceRolesRest) checkExists(identities []uuid.UUID, roleNames []string, pool *app.Identityroles) {
+func (s *ResourceRolesControllerTestSuite) checkExists(t *testing.T, identities []uuid.UUID, roleNames []string, pool *app.Identityroles) {
 	for _, retrievedRole := range pool.Data {
 		var foundUser bool
 		for i, idn := range identities {
@@ -261,20 +400,20 @@ func (rest *TestResourceRolesRest) checkExists(identities []uuid.UUID, roleNames
 				break
 			}
 		}
-		require.True(rest.T(), foundUser)
+		require.True(t, foundUser)
 	}
 }
 
-func (rest *TestResourceRolesRest) compare(createdRole role.IdentityRole, retrievedRole app.IdentityRolesData, isInherited bool) bool {
-	require.Equal(rest.T(), createdRole.IdentityID.String(), retrievedRole.AssigneeID)
-	require.Equal(rest.T(), createdRole.Role.Name, retrievedRole.RoleName)
-	require.Equal(rest.T(), "user", retrievedRole.AssigneeType)
+func (s *ResourceRolesControllerTestSuite) compare(t *testing.T, createdRole role.IdentityRole, retrievedRole app.IdentityRolesData, isInherited bool) bool {
+	require.Equal(t, createdRole.IdentityID.String(), retrievedRole.AssigneeID)
+	require.Equal(t, createdRole.Role.Name, retrievedRole.RoleName)
+	require.Equal(t, "user", retrievedRole.AssigneeType)
 	if isInherited {
-		require.True(rest.T(), retrievedRole.Inherited)
-		require.NotNil(rest.T(), createdRole.Resource.ParentResourceID)
-		require.Equal(rest.T(), *createdRole.Resource.ParentResourceID, *createdRole.Resource.ParentResourceID)
+		require.True(t, retrievedRole.Inherited)
+		require.NotNil(t, createdRole.Resource.ParentResourceID)
+		require.Equal(t, *createdRole.Resource.ParentResourceID, *createdRole.Resource.ParentResourceID)
 	} else {
-		require.False(rest.T(), retrievedRole.Inherited)
+		require.False(t, retrievedRole.Inherited)
 	}
 	return true
 }

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -156,7 +156,7 @@ func (rest *TestSpaceREST) TestDeleteSpaceIfUserIsNotSpaceOwnerForbidden() {
 * This test will attempt to list teams for a space
  */
 func (rest *TestSpaceREST) TestListTeamOK() {
-	g := rest.DBTestSuite.NewTestGraph()
+	g := rest.DBTestSuite.NewTestGraph(rest.T())
 	g.CreateTeam(g.ID("t1"), g.CreateSpace(g.ID("space")).
 		AddAdmin(g.CreateUser(g.ID("admin"))).
 		AddContributor(g.CreateUser(g.ID("contributor"))).
@@ -195,7 +195,7 @@ func (rest *TestSpaceREST) TestListTeamOK() {
 }
 
 func (rest *TestSpaceREST) TestListTeamUnauthorized() {
-	g := rest.DBTestSuite.NewTestGraph()
+	g := rest.DBTestSuite.NewTestGraph(rest.T())
 	g.CreateTeam(g.ID("t1"), g.CreateSpace(g.ID("space")))
 	g.CreateTeam(g.ID("t2"), g.SpaceByID("space"))
 

--- a/controller/team_blackbox_test.go
+++ b/controller/team_blackbox_test.go
@@ -50,7 +50,7 @@ func (rest *TestTeamREST) UnsecuredController() (*goa.Service, *TeamController) 
 func (rest *TestTeamREST) TestCreateTeamSuccess() {
 	service, controller := rest.SecuredController(rest.testIdentity)
 
-	g := rest.DBTestSuite.NewTestGraph()
+	g := rest.DBTestSuite.NewTestGraph(rest.T())
 	spc := g.CreateSpace().AddAdmin(g.LoadIdentity(rest.testIdentity.ID))
 
 	teamName := "Team-" + uuid.NewV4().String()
@@ -81,7 +81,7 @@ func (rest *TestTeamREST) TestCreateTeamUnauthorized() {
 func (rest *TestTeamREST) TestCreateTeamEmptyNameFail() {
 
 	service, controller := rest.SecuredController(rest.testIdentity)
-	g := rest.DBTestSuite.NewTestGraph()
+	g := rest.DBTestSuite.NewTestGraph(rest.T())
 	spc := g.CreateSpace().AddAdmin(g.LoadIdentity(rest.testIdentity.ID))
 
 	teamName := ""
@@ -103,7 +103,7 @@ func (rest *TestTeamREST) TestListTeamSuccess() {
 
 	service, controller := rest.SecuredController(rest.testIdentity)
 
-	g := rest.DBTestSuite.NewTestGraph()
+	g := rest.DBTestSuite.NewTestGraph(rest.T())
 	g.CreateTeam(g.ID("t")).AddMember(g.LoadIdentity(&rest.testIdentity.ID))
 
 	_, teams := test.ListTeamOK(rest.T(), service.Context, service, controller)

--- a/design/role.go
+++ b/design/role.go
@@ -87,6 +87,21 @@ var _ = a.Resource("resource_roles", func() {
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.Conflict, JSONAPIErrors)
 	})
+	a.Action("hasScope", func() {
+		a.Routing(
+			a.GET("/:resourceId/scopes/:scopeName"),
+		)
+		a.Params(func() {
+			a.Param("resourceId", d.String, "The identifier of the resource to check for a user scope")
+			a.Param("scopeName", d.String, "The name of the scope to check for the user")
+		})
+		a.Description("Checks if the user has the given scope on the requested resource")
+		a.Response(d.OK, identityResourceScope)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+
 })
 
 // ResourceMedia represents a protected resource
@@ -131,4 +146,26 @@ var assignRoleData = a.Type("AssignRoleData", func() {
 	a.Attribute("role", d.String, "name of the role to assign")
 	a.Attribute("ids", a.ArrayOf(d.String), "identity ids to assign role to")
 	a.Required("role", "ids")
+})
+
+// identityResourceScopes represents a response to a permission/scope check for a user on a given resource
+var identityResourceScope = a.MediaType("application/vnd.resource.scopes+json", func() {
+	a.UseTrait("jsonapi-media-type")
+	a.TypeName("IdentityResourceScope")
+	a.Description("HasScopes for a user on a resource")
+	a.Attributes(func() {
+		a.Attribute("data", identityResourceScopeData)
+		a.Required("data")
+	})
+	a.View("default", func() {
+		a.Attribute("data")
+		a.Required("data")
+	})
+})
+
+// identityResourceScopeData
+var identityResourceScopeData = a.Type("identityResourceScopeData", func() {
+	a.Attribute("scopeName", d.String, "the name of the scope that was checked")
+	a.Attribute("hasScope", d.Boolean, "'true' if the user has the given scope, 'false' otherwise")
+	a.Required("scopeName", "hasScope")
 })

--- a/test/graph/organization_wrapper.go
+++ b/test/graph/organization_wrapper.go
@@ -58,6 +58,8 @@ func newOrganizationWrapper(g *TestGraph, params []interface{}) interface{} {
 
 	w.identity = g.LoadIdentity(organizationIdentityID).Identity()
 	organizationResource := g.LoadResource(w.identity.IdentityResourceID.String)
+	resourceType := g.LoadResourceType(organizationResource.resource.ResourceTypeID).resourceType
+	organizationResource.resource.ResourceType = *resourceType
 	w.resource = organizationResource.Resource()
 
 	return &w
@@ -85,6 +87,6 @@ func (w *organizationWrapper) ResourceID() string {
 
 // AddAdmin assigns the admin role to a user for the org
 func (w *organizationWrapper) AddAdmin(wrapper interface{}) *organizationWrapper {
-	addRole(w.baseWrapper, w.resource, authorization.IdentityResourceTypeOrganization, w.identityIDFromWrapper(wrapper), authorization.OrganizationAdminRole)
+	addRole(w.baseWrapper, w.resource, authorization.IdentityResourceTypeOrganization, identityIDFromWrapper(w.graph.t, wrapper), authorization.OrganizationAdminRole)
 	return w
 }

--- a/test/graph/space_wrapper.go
+++ b/test/graph/space_wrapper.go
@@ -64,19 +64,19 @@ func loadSpaceWrapper(g *TestGraph, resourceID string) spaceWrapper {
 
 // AddAdmin assigns the admin role to a user for the space
 func (w *spaceWrapper) AddAdmin(wrapper interface{}) *spaceWrapper {
-	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, w.identityIDFromWrapper(wrapper), authorization.SpaceAdminRole)
+	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, identityIDFromWrapper(w.graph.t, wrapper), authorization.SpaceAdminRole)
 	return w
 }
 
 // AddContributor assigns the admin role to a user for the space
 func (w *spaceWrapper) AddContributor(wrapper interface{}) *spaceWrapper {
-	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, w.identityIDFromWrapper(wrapper), authorization.SpaceContributorRole)
+	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, identityIDFromWrapper(w.graph.t, wrapper), authorization.SpaceContributorRole)
 	return w
 }
 
 // AddViewer assigns the admin role to a user for the space
 func (w *spaceWrapper) AddViewer(wrapper interface{}) *spaceWrapper {
-	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, w.identityIDFromWrapper(wrapper), authorization.SpaceViewerRole)
+	addRole(w.baseWrapper, w.resource, authorization.ResourceTypeSpace, identityIDFromWrapper(w.graph.t, wrapper), authorization.SpaceViewerRole)
 	return w
 }
 

--- a/test/graph/team_wrapper.go
+++ b/test/graph/team_wrapper.go
@@ -104,7 +104,7 @@ func (w *teamWrapper) ResourceID() string {
 }
 
 func (w *teamWrapper) AddMember(wrapper interface{}) *teamWrapper {
-	identityID := w.identityIDFromWrapper(wrapper)
+	identityID := identityIDFromWrapper(w.graph.t, wrapper)
 
 	err := w.graph.db.Exec("INSERT INTO membership (member_id, member_of) VALUES (?, ?)", identityID, w.identity.ID).Error
 	require.NoError(w.graph.t, err)

--- a/test/graph/test_graph.go
+++ b/test/graph/test_graph.go
@@ -24,14 +24,16 @@ type baseWrapper struct {
 	graph *TestGraph
 }
 
-func (w *baseWrapper) identityIDFromWrapper(wrapper interface{}) uuid.UUID {
+func identityIDFromWrapper(t *testing.T, wrapper interface{}) uuid.UUID {
 	switch t := wrapper.(type) {
 	case *userWrapper:
 		return t.identity.ID
 	case *identityWrapper:
 		return t.identity.ID
+	case *teamWrapper:
+		return t.identity.ID
 	}
-	require.True(w.graph.t, false, "wrapper must be either user wrapper or identity wrapper")
+	require.True(t, false, "wrapper must be either 'user', 'identity' or 'team' wrapper")
 	return uuid.UUID{}
 }
 
@@ -101,9 +103,19 @@ func (g *TestGraph) CreateResourceType(params ...interface{}) *resourceTypeWrapp
 	return g.createAndRegister(newResourceTypeWrapper, params).(*resourceTypeWrapper)
 }
 
-func (g *TestGraph) ResourceTypeByID(id string) *resourceTypeWrapper {
-	require.Contains(g.t, g.references, id, "resource type with such ID is not registered")
-	return g.references[id].(*resourceTypeWrapper)
+func (g *TestGraph) ResourceTypeByID(id uuid.UUID) *resourceTypeWrapper {
+	if rt, found := g.references[id.String()]; found {
+		return rt.(*resourceTypeWrapper)
+	}
+	// if look-up in references failed, then look for the role in the DB
+	rt, err := g.app.ResourceTypeRepository().Load(g.ctx, id)
+	require.NoErrorf(g.t, err, "failed to look-up resource type with id '%s'", id)
+	rtw := &resourceTypeWrapper{
+		baseWrapper:  baseWrapper{g},
+		resourceType: rt,
+	}
+	g.references[id.String()] = rtw
+	return rtw
 }
 
 func (g *TestGraph) LoadResourceType(params ...interface{}) *resourceTypeWrapper {
@@ -269,6 +281,25 @@ func (g *TestGraph) CreateRole(params ...interface{}) *roleWrapper {
 func (g *TestGraph) RoleByID(id string) *roleWrapper {
 	require.Contains(g.t, g.references, id, "role with such ID is not registered")
 	return g.references[id].(*roleWrapper)
+}
+
+func (g *TestGraph) RoleByNameAndResourceType(name, resourceType string) *roleWrapper {
+	for _, ref := range g.references {
+		if roleWrapper, ok := ref.(*roleWrapper); ok {
+			if roleWrapper.role.Name == name && roleWrapper.role.ResourceType.Name == resourceType {
+				return roleWrapper
+			}
+		}
+	}
+	// if look-up in references failed, then look for the role in the DB
+	r, err := g.app.RoleRepository().Lookup(g.ctx, name, resourceType)
+	require.NoErrorf(g.t, err, "failed to look-up role named '%s' for resource of type '%s'", name, resourceType)
+	rw := &roleWrapper{
+		baseWrapper: baseWrapper{g},
+		role:        r,
+	}
+	g.references[r.RoleID.String()] = rw
+	return rw
 }
 
 func (g *TestGraph) CreateDefaultRoleMapping(params ...interface{}) *defaultRoleMappingWrapper {


### PR DESCRIPTION
Added endpoint as /api/resources/:resourceID/scopes/:scopeName

Also:
- refactored `controller/resource_roles_blackbox_test.go` by
  grouping in subtests

Fixes #492

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>