### PR TITLE
fix(#603): replace `s.T()` with `t` for  subtests

### DIFF
--- a/account/repository/user_blackbox_test.go
+++ b/account/repository/user_blackbox_test.go
@@ -78,7 +78,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 		// Check not existing
 		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
 		// then
-		require.IsType(s.T(), errors.NotFoundError{}, err)
+		require.IsType(t, errors.NotFoundError{}, err)
 	})
 }
 

--- a/authorization/role/repository/role_blackbox_test.go
+++ b/authorization/role/repository/role_blackbox_test.go
@@ -83,8 +83,8 @@ func (s *roleBlackBoxTest) TestExistsRole() {
 	t.Run("role exists", func(t *testing.T) {
 		//t.Parallel()
 		role, err := testsupport.CreateTestRoleWithDefaultType(s.Ctx, s.DB, uuid.NewV4().String())
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), role)
+		require.NoError(t, err)
+		require.NotNil(t, role)
 		// when
 		err = s.repo.CheckExists(s.Ctx, role.RoleID.String())
 		// then
@@ -96,7 +96,7 @@ func (s *roleBlackBoxTest) TestExistsRole() {
 		// Check not existing
 		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
 		// then
-		require.IsType(s.T(), errors.NotFoundError{}, err)
+		require.IsType(t, errors.NotFoundError{}, err)
 	})
 }
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -571,17 +571,17 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// when
 			email := user.Email
 			// by default, email is public.
-			_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
+			_, result := test.ListUsersOK(t, nil, nil, s.controller, &email, nil, nil, nil)
 			returnedUser := result.Data[0].Attributes
-			require.Equal(s.T(), email, *returnedUser.Email)
-			require.False(s.T(), *returnedUser.EmailPrivate)
+			require.Equal(t, email, *returnedUser.Email)
+			require.False(t, *returnedUser.EmailPrivate)
 
 			// check for /api/users/<ID>
 			// should show public email when not made private.
-			_, singleResult := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			_, singleResult := test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
 			returnedUser = singleResult.Data.Attributes
-			require.Equal(s.T(), email, *returnedUser.Email)
-			require.False(s.T(), *returnedUser.EmailPrivate)
+			require.Equal(t, email, *returnedUser.Email)
+			require.False(t, *returnedUser.EmailPrivate)
 
 			contextInformation := map[string]interface{}{
 				"last_visited": "yesterday",
@@ -590,32 +590,32 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 				"count":        3,
 			}
 			updateUsersPayload := newUpdateUsersPayload(WithUpdatedContextInformation(contextInformation), WithUpdatedEmailPrivate(true))
-			test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+			test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
 
 			// the /api/users/<ID> endpoint should hide out the email.
-			_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-			require.NotEqual(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
-			require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)
-			require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+			_, showUserResponse := test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			require.NotEqual(t, user.Email, *showUserResponse.Data.Attributes.Email)
+			require.Equal(t, "", *showUserResponse.Data.Attributes.Email)
+			require.True(t, *showUserResponse.Data.Attributes.EmailPrivate)
 
 			// On using the notification service account token, email would magically show up.
 			secureService, secureController = s.SecuredServiceAccountController(testsupport.TestNotificationIdentity)
-			_, showUserResponse = test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-			require.Equal(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
-			require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+			_, showUserResponse = test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			require.Equal(t, user.Email, *showUserResponse.Data.Attributes.Email)
+			require.True(t, *showUserResponse.Data.Attributes.EmailPrivate)
 
 			// On using the tenant service account token, email would magically show up too.
 			secureService, secureController = s.SecuredServiceAccountController(testsupport.TestTenantIdentity)
-			_, showUserResponse = test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-			require.Equal(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
-			require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+			_, showUserResponse = test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			require.Equal(t, user.Email, *showUserResponse.Data.Attributes.Email)
+			require.True(t, *showUserResponse.Data.Attributes.EmailPrivate)
 
 			// On using the online-registration service account token, email would NOT show up.
 			secureService, secureController = s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
-			_, showUserResponse = test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-			require.NotEqual(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
-			require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)
-			require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+			_, showUserResponse = test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			require.NotEqual(t, user.Email, *showUserResponse.Data.Attributes.Email)
+			require.Equal(t, "", *showUserResponse.Data.Attributes.Email)
+			require.True(t, *showUserResponse.Data.Attributes.EmailPrivate)
 
 		})
 
@@ -626,17 +626,17 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			// when
 			email := user.Email
 			// by default, email is public.
-			_, result := test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
+			_, result := test.ListUsersOK(t, nil, nil, s.controller, &email, nil, nil, nil)
 			returnedUser := result.Data[0].Attributes
-			require.Equal(s.T(), email, *returnedUser.Email)
-			require.False(s.T(), *returnedUser.EmailPrivate)
+			require.Equal(t, email, *returnedUser.Email)
+			require.False(t, *returnedUser.EmailPrivate)
 
 			// check for /api/users/<ID>
 			// should show public email when not made private.
-			_, singleResult := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			_, singleResult := test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
 			returnedUser = singleResult.Data.Attributes
-			require.Equal(s.T(), email, *returnedUser.Email)
-			require.False(s.T(), *returnedUser.EmailPrivate)
+			require.Equal(t, email, *returnedUser.Email)
+			require.False(t, *returnedUser.EmailPrivate)
 
 			contextInformation := map[string]interface{}{
 				"last_visited": "yesterday",
@@ -645,22 +645,22 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 				"count":        3,
 			}
 			updateUsersPayload := newUpdateUsersPayload(WithUpdatedContextInformation(contextInformation), WithUpdatedEmailPrivate(true))
-			_, updateResult := test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+			_, updateResult := test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
 
 			// Email will be visible to the one who it belongs to
-			require.True(s.T(), *updateResult.Data.Attributes.EmailPrivate)
-			require.Equal(s.T(), user.Email, *updateResult.Data.Attributes.Email)
+			require.True(t, *updateResult.Data.Attributes.EmailPrivate)
+			require.Equal(t, user.Email, *updateResult.Data.Attributes.Email)
 
 			// But when you try to access the same with an API which doesn't respect auth,
 			// it wouldn't be visible.
-			_, result = test.ListUsersOK(s.T(), nil, nil, s.controller, &email, nil, nil, nil)
-			require.Empty(s.T(), result.Data)
+			_, result = test.ListUsersOK(t, nil, nil, s.controller, &email, nil, nil, nil)
+			require.Empty(t, result.Data)
 
 			// the /api/users/<ID> endpoint should also hide out the email.
-			_, showUserResponse := test.ShowUsersOK(s.T(), secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
-			require.NotEqual(s.T(), user.Email, *showUserResponse.Data.Attributes.Email)
-			require.Equal(s.T(), "", *showUserResponse.Data.Attributes.Email)
-			require.True(s.T(), *showUserResponse.Data.Attributes.EmailPrivate)
+			_, showUserResponse := test.ShowUsersOK(t, secureService.Context, secureService, s.controller, identity.ID.String(), nil, nil)
+			require.NotEqual(t, user.Email, *showUserResponse.Data.Attributes.Email)
+			require.Equal(t, "", *showUserResponse.Data.Attributes.Email)
+			require.True(t, *showUserResponse.Data.Attributes.EmailPrivate)
 		})
 	})
 
@@ -815,7 +815,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			WithUpdatedContextInformation(contextInformation))
 
 		// when/then
-		test.UpdateUsersUnauthorized(s.T(), context.Background(), nil, s.controller, updateUsersPayload)
+		test.UpdateUsersUnauthorized(t, context.Background(), nil, s.controller, updateUsersPayload)
 	})
 
 	s.T().Run("deprovisioned user cannot update user", func(t *testing.T) {
@@ -840,7 +840,7 @@ func (s *UsersControllerTestSuite) TestUpdateUser() {
 			WithUpdatedContextInformation(contextInformation))
 
 		// when/then
-		test.UpdateUsersUnauthorized(s.T(), ctrl.Context, svc, ctrl, updateUsersPayload)
+		test.UpdateUsersUnauthorized(t, ctrl.Context, svc, ctrl, updateUsersPayload)
 	})
 
 }
@@ -857,11 +857,11 @@ func (s *UsersControllerTestSuite) TestSendEmailVerificationCode() {
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		_, identity := s.createRandomUserIdentity(t, "TestSendEmailVerificationCode-OK")
-		test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
+		test.ShowUsersOK(t, nil, nil, s.controller, identity.ID.String(), nil, nil)
 
 		// when
 		secureService, secureController := s.SecuredControllerWithDummyEmailService(identity, true)
-		test.SendEmailVerificationCodeUsersNoContent(s.T(), secureService.Context, secureService, secureController)
+		test.SendEmailVerificationCodeUsersNoContent(t, secureService.Context, secureService, secureController)
 
 	})
 
@@ -871,22 +871,22 @@ func (s *UsersControllerTestSuite) TestSendEmailVerificationCode() {
 
 		// when
 		secureService, secureController := s.SecuredControllerWithDummyEmailService(identity, true)
-		test.SendEmailVerificationCodeUsersUnauthorized(s.T(), secureService.Context, secureService, secureController)
+		test.SendEmailVerificationCodeUsersUnauthorized(t, secureService.Context, secureService, secureController)
 	})
 
 	s.T().Run("unauthorized when no identity in context", func(t *testing.T) {
 		service, controller := s.UnsecuredController()
-		test.SendEmailVerificationCodeUsersUnauthorized(s.T(), service.Context, service, controller)
+		test.SendEmailVerificationCodeUsersUnauthorized(t, service.Context, service, controller)
 	})
 
 	s.T().Run("email failure", func(t *testing.T) {
 		// given
 		_, identity := s.createRandomUserIdentity(t, "TestSendEmailVerificationCode-EmailFailure")
-		test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
+		test.ShowUsersOK(t, nil, nil, s.controller, identity.ID.String(), nil, nil)
 
 		// when
 		secureService, secureController := s.SecuredControllerWithDummyEmailService(identity, false)
-		test.SendEmailVerificationCodeUsersInternalServerError(s.T(), secureService.Context, secureService, secureController)
+		test.SendEmailVerificationCodeUsersInternalServerError(t, secureService.Context, secureService, secureController)
 	})
 }
 
@@ -895,7 +895,7 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		user, identity := s.createRandomUserIdentity(t, "TestVerifyEmailOK")
-		test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
+		test.ShowUsersOK(t, nil, nil, s.controller, identity.ID.String(), nil, nil)
 
 		// when
 		secureService, secureController := s.SecuredController(identity)
@@ -912,20 +912,20 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 				"rate":         100.00,
 				"count":        3,
 			}))
-		test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+		test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
 		// then
 		codes, err := s.Application.VerificationCodes().Query(accountrepo.VerificationCodeWithUser(), accountrepo.VerificationCodeFilterByUserID(user.ID))
-		require.NoError(s.T(), err)
-		require.Len(s.T(), codes, 1)
+		require.NoError(t, err)
+		require.Len(t, codes, 1)
 		verificationCode := codes[0].Code
 
-		rw := test.VerifyEmailUsersTemporaryRedirect(s.T(), secureService.Context, secureService, secureController, verificationCode)
+		rw := test.VerifyEmailUsersTemporaryRedirect(t, secureService.Context, secureService, secureController, verificationCode)
 		redirectLocation := rw.Header().Get("Location")
-		assert.Equal(s.T(), "https://prod-preview.openshift.io/_home?verified=true", redirectLocation)
+		assert.Equal(t, "https://prod-preview.openshift.io/_home?verified=true", redirectLocation)
 
 		codes, err = s.Application.VerificationCodes().Query(accountrepo.VerificationCodeWithUser(), accountrepo.VerificationCodeFilterByUserID(user.ID))
-		require.NoError(s.T(), err)
-		require.Len(s.T(), codes, 0)
+		require.NoError(t, err)
+		require.Len(t, codes, 0)
 	})
 
 	s.T().Run("fail", func(t *testing.T) {
@@ -933,9 +933,9 @@ func (s *UsersControllerTestSuite) TestVerifyEmail() {
 		_, identity := s.createRandomUserIdentity(t, "TestVerifyEmailFail")
 		// when
 		secureService, secureController := s.SecuredController(identity)
-		rw := test.VerifyEmailUsersTemporaryRedirect(s.T(), secureService.Context, secureService, secureController, "ABCD")
+		rw := test.VerifyEmailUsersTemporaryRedirect(t, secureService.Context, secureService, secureController, "ABCD")
 		redirectLocation := rw.Header().Get("Location")
-		testsupport.EqualURLs(s.T(), "https://prod-preview.openshift.io/_home?verified=false&error=code+with+id+%27ABCD%27+not+found", redirectLocation)
+		testsupport.EqualURLs(t, "https://prod-preview.openshift.io/_home?verified=false&error=code+with+id+%27ABCD%27+not+found", redirectLocation)
 	})
 }
 

--- a/wit/service/wit_service_whitebox_test.go
+++ b/wit/service/wit_service_whitebox_test.go
@@ -161,15 +161,15 @@ func (s *TestWITSuite) TestUpdateWITUser() {
 
 	s.T().Run("should update user if client ok", func(t *testing.T) {
 		err := s.ws.UpdateUser(ctx, &updateUsersPayload, identityId)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 	})
 
 	s.T().Run("should fail to update user if client returned an error", func(t *testing.T) {
 		s.doer.Client.Response = nil
 		s.doer.Client.Error = errors.New("failed to update user in wit")
 		err := s.ws.UpdateUser(ctx, &updateUsersPayload, identityId)
-		require.Error(s.T(), err)
-		assert.Equal(s.T(), "failed to update user in wit", err.Error())
+		require.Error(t, err)
+		assert.Equal(t, "failed to update user in wit", err.Error())
 
 	})
 
@@ -177,8 +177,8 @@ func (s *TestWITSuite) TestUpdateWITUser() {
 		s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusInternalServerError, Status: "500"}
 		s.doer.Client.Error = nil
 		err := s.ws.UpdateUser(ctx, &updateUsersPayload, identityId)
-		require.Error(s.T(), err)
-		testsupport.AssertError(s.T(), err, errors.New(""), "unable to update user in WIT. Response status: 500. Response body: ")
+		require.Error(t, err)
+		testsupport.AssertError(t, err, errors.New(""), "unable to update user in WIT. Response status: 500. Response body: ")
 
 	})
 }
@@ -206,23 +206,23 @@ func (s *TestWITSuite) TestGetSpace() {
 
 	s.T().Run("should return space if client ok", func(t *testing.T) {
 		space, err := s.ws.GetSpace(ctx, spaceId)
-		require.NoError(s.T(), err)
-		require.Equal(s.T(), space, testSpace)
+		require.NoError(t, err)
+		require.Equal(t, space, testSpace)
 	})
 
 	s.T().Run("should fail to get space if client returned an error", func(t *testing.T) {
 		s.doer.Client.Response = nil
 		s.doer.Client.Error = errors.New("failed to get space from wit")
 		_, err := s.ws.GetSpace(ctx, spaceId)
-		require.Error(s.T(), err)
-		assert.Equal(s.T(), "failed to get space from wit", err.Error())
+		require.Error(t, err)
+		assert.Equal(t, "failed to get space from wit", err.Error())
 	})
 
 	s.T().Run("should fail to get space if client returned unexpected status", func(t *testing.T) {
 		s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusInternalServerError, Status: "500"}
 		s.doer.Client.Error = nil
 		_, err := s.ws.GetSpace(ctx, spaceId)
-		require.Error(s.T(), err)
+		require.Error(t, err)
 		testsupport.AssertError(s.T(), err, errors.New(""), "unable to get space from WIT. Response status: 500. Response body: ")
 	})
 }


### PR DESCRIPTION

Fixes: #603 
