### PR TITLE
chore: add config file to skip validation for minishift folder

### DIFF
--- a/.ike-prow/test-keeper.yaml
+++ b/.ike-prow/test-keeper.yaml
@@ -1,0 +1,2 @@
+skip_validation_for:
+  - 'minishift/'


### PR DESCRIPTION
**Changes Proposed in this PR**
In Ike-Prow we have a feature where we can add our customized location to skip test check. http://arquillian.org/ike-prow-plugins/#test-keeper-config

Currently, ike is crying each time if we change something in `minishift/` folder. so reviewer has to comment `ok-without-test`.

After this ike won't check for tests with change in all paths mentioned in config file.(in our case `minishift` so no more `ok-without-tests` if any change in `minishift/`).

  
