### PR TITLE
Handle case where a user has multiple roles on resources

### DIFF
--- a/controller/user_blackbox_test.go
+++ b/controller/user_blackbox_test.go
@@ -205,7 +205,7 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			require.Len(t, spaces.Data, 0)
 		})
 
-		t.Run("role on 1 space", func(t *testing.T) {
+		t.Run("1 role on 1 space", func(t *testing.T) {
 			// given
 			g := s.NewTestGraph(t)
 			user := g.CreateUser()
@@ -217,16 +217,47 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, spacesResourceType)
 			// then
 			require.Len(t, spaces.Data, 1)
-			require.Equal(t, space.SpaceID(), spaces.Data[0].ID)
-			assert.Equal(t, authorization.SpaceAdminRole, spaces.Data[0].Attributes.Role)
-			assert.Equal(t, authorization.SpaceAdminRole, spaces.Data[0].Attributes.Role)
-			assert.ElementsMatch(t, spaces.Data[0].Attributes.Scopes, []string{
+			assert.Equal(t, space.SpaceID(), spaces.Data[0].ID)
+			require.Len(t, spaces.Data[0].Attributes.Roles, 1)
+			assert.Equal(t, authorization.SpaceAdminRole, spaces.Data[0].Attributes.Roles[0].Name)
+			assert.ElementsMatch(t, spaces.Data[0].Attributes.Roles[0].Scopes, []string{
 				authorization.ManageSpaceScope,
 				authorization.ContributeSpaceScope,
 				authorization.ViewSpaceScope})
 		})
 
-		t.Run("role on 2 spaces", func(t *testing.T) {
+		t.Run("2 roles on 1 space", func(t *testing.T) {
+			// given
+			g := s.NewTestGraph(t)
+			user := g.CreateUser()
+			space := g.CreateSpace().AddAdmin(user).AddContributor(user)
+			require.NotNil(t, user.Identity())
+			identity := user.Identity()
+			// when
+			svc, userCtrl := s.SecuredController(*identity)
+			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, spacesResourceType)
+			// then
+			require.Len(t, spaces.Data, 1)
+			assert.Equal(t, space.SpaceID(), spaces.Data[0].ID)
+			require.Len(t, spaces.Data[0].Attributes.Roles, 2)
+			require.ElementsMatch(t, []string{authorization.SpaceAdminRole, authorization.SpaceContributorRole},
+				[]string{spaces.Data[0].Attributes.Roles[0].Name, spaces.Data[0].Attributes.Roles[1].Name})
+			for i, role := range spaces.Data[0].Attributes.Roles {
+				switch role.Name {
+				case authorization.SpaceAdminRole:
+					assert.ElementsMatch(t, spaces.Data[0].Attributes.Roles[i].Scopes, []string{
+						authorization.ManageSpaceScope,
+						authorization.ContributeSpaceScope,
+						authorization.ViewSpaceScope})
+				case authorization.SpaceContributorRole:
+					assert.ElementsMatch(t, spaces.Data[0].Attributes.Roles[i].Scopes, []string{
+						authorization.ContributeSpaceScope,
+						authorization.ViewSpaceScope})
+				}
+			}
+		})
+
+		t.Run("1 role on 2 spaces", func(t *testing.T) {
 			// given
 			g := s.NewTestGraph(t)
 			user := g.CreateUser()
@@ -245,14 +276,16 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			for _, spaceData := range spaces.Data {
 				switch spaceData.ID {
 				case space1.SpaceID():
-					assert.Equal(t, authorization.SpaceAdminRole, spaceData.Attributes.Role)
-					assert.ElementsMatch(t, spaceData.Attributes.Scopes, []string{
+					require.Len(t, spaceData.Attributes.Roles, 1)
+					assert.Equal(t, authorization.SpaceAdminRole, spaceData.Attributes.Roles[0].Name)
+					assert.ElementsMatch(t, spaceData.Attributes.Roles[0].Scopes, []string{
 						authorization.ManageSpaceScope,
 						authorization.ContributeSpaceScope,
 						authorization.ViewSpaceScope})
 				case space2.SpaceID():
-					assert.Equal(t, authorization.SpaceContributorRole, spaceData.Attributes.Role)
-					assert.ElementsMatch(t, spaceData.Attributes.Scopes, []string{
+					require.Len(t, spaceData.Attributes.Roles, 1)
+					assert.Equal(t, authorization.SpaceContributorRole, spaceData.Attributes.Roles[0].Name)
+					assert.ElementsMatch(t, spaceData.Attributes.Roles[0].Scopes, []string{
 						authorization.ContributeSpaceScope,
 						authorization.ViewSpaceScope})
 				}

--- a/design/user.go
+++ b/design/user.go
@@ -136,9 +136,15 @@ var userResourceData = a.Type("UserResourceData", func() {
 	a.Required("id", "type", "attributes")
 })
 
-// userResourceDataAttributes contains info about the role and scopes that the user has in the resource
+// userResourceDataAttributes contains info about the roles that the user has in the resource
 var userResourceDataAttributes = a.Type("UserResourceDataAttributes", func() {
-	a.Attribute("role", d.String, "The role of the user in the corresponding resource")
-	a.Attribute("scopes", a.ArrayOf(d.String), "The scopes associated with the role of the user in the corresponding resource")
-	a.Required("role", "scopes")
+	a.Attribute("roles", a.ArrayOf(userResourceRoles), "The role of the user in the corresponding resource")
+	a.Required("roles")
+})
+
+// userResourceRoles contains info about each role and its scopes that the user has in the resource
+var userResourceRoles = a.Type("UserResourceRoles", func() {
+	a.Attribute("name", d.String, "The name of the role of the user in the corresponding resource")
+	a.Attribute("scopes", a.ArrayOf(d.String), "The name of the scopes of the user in the corresponding resource")
+	a.Required("name", "scopes")
 })


### PR DESCRIPTION
return an array of roles with its name and associated scopes
for each resource in which the user has a role in.

Eg:
````
{
    "data": [{
        "attributes": {
            "roles": [{
                "name": "contributor",
                "scopes": ["contribute", "view"]
            }, {
                "name": "admin",
                "scopes": ["contribute", "manage", "view"]
            }]
        },
        "id": "a41e48b7-369d-4316-a0a0-ba52c1e5ef55",
        "type": "spaces"
    }]
}
````

Fixes #622

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>