### PR TITLE
Use existing type as query param for listing resources a user has a role in

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -83,11 +83,13 @@ func (c *UserController) ListResources(ctx *app.ListResourcesUserContext) error 
 		}, "Bad Token")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("bad or missing token"))
 	}
-	var resourceType string
+	resourceType := ctx.Type
 	switch ctx.Type {
-	case "spaces":
-		resourceType = authorization.ResourceTypeSpace
+	case authorization.ResourceTypeSpace:
+		// ok
 	default:
+		// resource type is unknown, so let respond with an error instead of running an expensive request
+		// that will return no result.
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterErrorFromString("type", ctx.Type, "invalid or unsupported type of resource. Valid value is:'spaces'."))
 	}
 

--- a/controller/user_blackbox_test.go
+++ b/controller/user_blackbox_test.go
@@ -187,8 +187,6 @@ func (s *UserControllerTestSuite) TestShowUser() {
 
 func (s *UserControllerTestSuite) TestListUserSpaces() {
 
-	const spacesResourceType string = "spaces"
-
 	s.T().Run("ok", func(t *testing.T) {
 
 		t.Run("role on no space", func(t *testing.T) {
@@ -200,7 +198,7 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			identity := user.Identity()
 			// when
 			svc, userCtrl := s.SecuredController(*identity)
-			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, spacesResourceType)
+			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, authorization.ResourceTypeSpace)
 			// then
 			require.Len(t, spaces.Data, 0)
 		})
@@ -214,7 +212,7 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			identity := user.Identity()
 			// when
 			svc, userCtrl := s.SecuredController(*identity)
-			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, spacesResourceType)
+			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, authorization.ResourceTypeSpace)
 			// then
 			require.Len(t, spaces.Data, 1)
 			require.Equal(t, space.SpaceID(), spaces.Data[0].ID)
@@ -236,7 +234,7 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			identity := user.Identity()
 			// when
 			svc, userCtrl := s.SecuredController(*identity)
-			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, spacesResourceType)
+			_, spaces := test.ListResourcesUserOK(t, svc.Context, svc, userCtrl, authorization.ResourceTypeSpace)
 			// then
 			require.Len(t, spaces.Data, 2)
 			require.ElementsMatch(t,
@@ -270,7 +268,7 @@ func (s *UserControllerTestSuite) TestListUserSpaces() {
 			// when
 			svc, userCtrl := s.UnsecuredController()
 			// when/then
-			test.ListResourcesUserUnauthorized(t, svc.Context, svc, userCtrl, spacesResourceType)
+			test.ListResourcesUserUnauthorized(t, svc.Context, svc, userCtrl, authorization.ResourceTypeSpace)
 		})
 	})
 


### PR DESCRIPTION
Replace `spaces` with `openshift.io/resource/space` as
the resource type for spaces so there's no need for
a transation from `spaces`, but keep checking the `type`
query param for invalid values, to avoid
running an expensive query for nothing (and then return
a 400 error)

Also, `openshift.io/resource/space` is a valid query param
 as defined in https://tools.ietf.org/html/rfc3986#section-3.4,
even if it contains `/` characters

Fixes #623

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>