### PR TITLE
Add scopes endpoint for resources

### DIFF
--- a/controller/resource.go
+++ b/controller/resource.go
@@ -103,12 +103,17 @@ func (c *ResourceController) Scopes(ctx *app.ScopesResourceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
+	scopes := []*app.ResourceScopes{}
+
+	for _, scope := range pc.ScopesAsArray() {
+		scopes = append(scopes, &app.ResourceScopes{
+			ID:   scope,
+			Type: "user_resource_scope",
+		})
+	}
+
 	res := &app.ResourceScopesData{
-		Data: &app.ResourceScopes{
-			ID:     ctx.ResourceID,
-			Type:   "resource",
-			Scopes: pc.ScopesAsArray(),
-		},
+		Data: scopes,
 	}
 
 	return ctx.OK(res)

--- a/controller/resource_blackbox_test.go
+++ b/controller/resource_blackbox_test.go
@@ -221,11 +221,19 @@ func (rest *TestResourceREST) TestScopesOK() {
 
 	// Invoke the endpoint
 	_, scopes := test.ScopesResourceOK(rest.T(), svc.Context, svc, ctrl, res.ResourceID())
-	require.Equal(rest.T(), scopes.Data.ID, res.ResourceID())
-	require.Equal(rest.T(), scopes.Data.Type, "resource")
-	require.Len(rest.T(), scopes.Data.Scopes, 2)
-	require.Contains(rest.T(), scopes.Data.Scopes, "foo")
-	require.Contains(rest.T(), scopes.Data.Scopes, "bar")
+	require.Len(rest.T(), scopes.Data, 2)
+	fooFound := false
+	barFound := false
+	for _, scope := range scopes.Data {
+		require.Equal(rest.T(), "user_resource_scope", scope.Type)
+		if scope.ID == "foo" {
+			fooFound = true
+		} else if scope.ID == "bar" {
+			barFound = true
+		}
+	}
+	require.True(rest.T(), fooFound)
+	require.True(rest.T(), barFound)
 
 	// Create another user
 	user2 := rest.Graph.CreateUser()
@@ -235,9 +243,7 @@ func (rest *TestResourceREST) TestScopesOK() {
 
 	// There should be no scopes assigned for user2
 	_, scopes = test.ScopesResourceOK(rest.T(), svc.Context, svc, ctrl, res.ResourceID())
-	require.Equal(rest.T(), scopes.Data.ID, res.ResourceID())
-	require.Equal(rest.T(), scopes.Data.Type, "resource")
-	require.Len(rest.T(), scopes.Data.Scopes, 0)
+	require.Len(rest.T(), scopes.Data, 0)
 }
 
 func (rest *TestResourceREST) TestScopesInvalidResourceIDNotFound() {

--- a/design/resource.go
+++ b/design/resource.go
@@ -93,7 +93,7 @@ var ResourceMedia = a.MediaType("application/vnd.resource+json", func() {
 var ResourceScopesData = a.MediaType("application/vnd.resource_scopes_data+json", func() {
 	a.Description("Resource scopes data wrapper")
 	a.Attributes(func() {
-		a.Attribute("data", ResourceScopesMedia, "The data wrapper for the response")
+		a.Attribute("data", a.ArrayOf(ResourceScopesMedia), "The data wrapper for the response")
 		a.Required("data")
 	})
 	a.View("default", func() {
@@ -104,15 +104,13 @@ var ResourceScopesData = a.MediaType("application/vnd.resource_scopes_data+json"
 var ResourceScopesMedia = a.MediaType("application/vnd.resource_scopes+json", func() {
 	a.Description("Resource scopes payload")
 	a.Attributes(func() {
-		a.Attribute("id", d.String, "Identifier of the resource")
+		a.Attribute("id", d.String, "Name of the scope")
 		a.Attribute("type", d.String, "Type of resource")
-		a.Attribute("scopes", a.ArrayOf(d.String), "The available scopes for the resource")
-		a.Required("id", "type", "scopes")
+		a.Required("id", "type")
 	})
 	a.View("default", func() {
 		a.Attribute("id")
 		a.Attribute("type")
-		a.Attribute("scopes")
 	})
 
 })


### PR DESCRIPTION
Fixes #634 

This PR adds support for reading the current user's scopes for a resource.

Request:

`GET /api/resource/<resource_id>/scopes`

Response:

```
{
  "data": [
    {
      "id": "alpha",
      "type": "user_resource_scope"
    },
    {
      "id": "bravo",
      "type": "user_resource_scope"
    }
  ]
}

```