### PR TITLE
Return deprovisioned attr in User API response

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -852,6 +852,7 @@ func ConvertToAppUser(request *goa.RequestData, user *accountrepo.User, identity
 	var userURL string
 	var email string
 	var isEmailPrivate bool
+	var isUserDeprovisioned bool
 	var createdAt time.Time
 	var updatedAt time.Time
 	var company string
@@ -880,6 +881,7 @@ func ConvertToAppUser(request *goa.RequestData, user *accountrepo.User, identity
 		createdAt = user.CreatedAt
 		updatedAt = user.UpdatedAt
 		emailVerified = user.EmailVerified
+		isUserDeprovisioned = user.Deprovisioned
 	}
 
 	converted := app.User{
@@ -905,6 +907,7 @@ func ConvertToAppUser(request *goa.RequestData, user *accountrepo.User, identity
 				EmailVerified:         &emailVerified,
 				ContextInformation:    make(map[string]interface{}),
 				RegistrationCompleted: &registrationCompleted,
+				Deprovisioned:         &isUserDeprovisioned,
 			},
 			Links: createUserLinks(request, &identity.ID),
 		},

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -119,6 +119,7 @@ func (s *UsersControllerTestSuite) TestCreateRandomUser() {
 		assert.Equal(t, identity.Username, *result.Data.Attributes.Username)
 		assert.Equal(t, user.Company, *result.Data.Attributes.Company)
 		assert.Equal(t, accountrepo.DefaultFeatureLevel, *result.Data.Attributes.FeatureLevel)
+		assert.Equal(t, false, *result.Data.Attributes.Deprovisioned)
 	})
 }
 
@@ -143,11 +144,13 @@ func (s *UsersControllerTestSuite) updateDeprovisionedAttribute(deprovisioned bo
 		// in this case, the existing state is that the user is not deprovisioned.
 		test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 		s.checkIfUserDeprovisioned(identity.ID, !deprovisioned)
+
 	} else {
 		// in this case, the existing state is that the user is deprovisioned.
 		test.UpdateUsersUnauthorized(s.T(), secureController.Context, secureService, secureController, updateUsersPayload)
 		s.checkIfUserDeprovisioned(identity.ID, !deprovisioned)
 	}
+
 }
 
 func (s *UsersControllerTestSuite) TestUpdateUser() {
@@ -854,6 +857,10 @@ func (s *UsersControllerTestSuite) checkIfUserDeprovisioned(id uuid.UUID, expect
 	identity, err := identityRepository.LoadWithUser(context.Background(), id)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), expected, identity.User.Deprovisioned)
+
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, id.String(), nil, nil)
+	require.Equal(s.T(), expected, *result.Data.Attributes.Deprovisioned)
+
 }
 
 func (s *UsersControllerTestSuite) TestSendEmailVerificationCode() {

--- a/design/user.go
+++ b/design/user.go
@@ -115,6 +115,7 @@ var userDataAttributes = a.Type("UserDataAttributes", func() {
 	a.Attribute("providerType", d.String, "The IDP provided this identity")
 	a.Attribute("cluster", d.String, "The OpenShift API URL of the cluster where the user is provisioned to")
 	a.Attribute("featureLevel", d.String, "The level of features that the user wants to use (for unreleased features)")
+	a.Attribute("deprovisioned", d.Boolean, "Whether the user has been deprovisioned")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})
 	})


### PR DESCRIPTION
This will help services verify if the user has been de-provisioned though this might mean auth service would now end up servicing a lot more HTTP GET /user requests.