### PR TITLE
add .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+linters:
+  fast: true
+  disable:
+    # typecheck errors due to https://github.com/goadesign/goa/issues/1850,
+    # need to update to goagen >= 1.4.0
+    - typecheck
+
+service:
+  project-path: github.com/fabric8-services/fabric8-auth
+  prepare:
+    - make deps generate


### PR DESCRIPTION
As was suggested in https://github.com/golangci/golangci/issues/18, we've supported custom build commands in `.golangci.yml`. Now this repo can be successfully analyzed by https://golangci.com