### PR TITLE
fix: unable to recreate identity/role/resource relationship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ account/tenant
 test/service
 test/token/oauth
 test/login
+test/generated
+authentication/account

--- a/authorization/role/repository/identity_role_blackbox_test.go
+++ b/authorization/role/repository/identity_role_blackbox_test.go
@@ -487,6 +487,28 @@ func (s *identityRoleBlackBoxTest) TestCreateIdentityExistingAssignmentFails() {
 	require.IsType(s.T(), errors.DataConflictError{}, errs.Cause(err))
 }
 
+func (s *identityRoleBlackBoxTest) TestRecreateIdentityExistingAssignmentOK() {
+	// given an identity/role that was created then deleted
+	existingUser := s.Graph.CreateUser()
+	knownRoleID := getKnownRoleIDForSpace(s)
+	newSpace := s.Graph.CreateSpace()
+	ir := role.IdentityRole{
+		IdentityRoleID: uuid.NewV4(),
+		IdentityID:     existingUser.Identity().ID,
+		ResourceID:     newSpace.SpaceID(),
+		RoleID:         knownRoleID,
+	}
+	err := s.repo.Create(context.Background(), &ir)
+	require.NoError(s.T(), err)
+	err = s.repo.Delete(context.Background(), ir.IdentityRoleID)
+	require.NoError(s.T(), err)
+	// when creating it again
+	ir.IdentityRoleID = uuid.NewV4()
+	err = s.repo.Create(context.Background(), &ir)
+	// then it be allowd
+	require.NoError(s.T(), err)
+}
+
 func getKnownRoleIDForSpace(s *identityRoleBlackBoxTest) uuid.UUID {
 	roles, err := s.roleRepo.FindRolesByResourceType(context.Background(), authorization.ResourceTypeSpace)
 	require.Nil(s.T(), err)

--- a/controller/resource_roles_blackbox_test.go
+++ b/controller/resource_roles_blackbox_test.go
@@ -148,29 +148,60 @@ func (s *ResourceRolesControllerTestSuite) TestAssignRole() {
 	})
 
 	s.T().Run("conflict", func(t *testing.T) {
-		// given
-		g := s.NewTestGraph(t)
-		res := g.CreateSpace()
 
-		testUser := g.CreateUser()
-		res.AddViewer(testUser)
+		t.Run("role already assigned", func(t *testing.T) {
+			// given
+			g := s.NewTestGraph(t)
+			res := g.CreateSpace()
+			// Create a user who has the privileges to assign roles
+			adminUser := g.CreateUser("adminuser")
+			res.AddAdmin(adminUser)
+			// create a test user with viewer role, first
+			testUser := g.CreateUser()
+			res.AddViewer(testUser)
 
-		// Create a user who has the privileges to assign roles
-		adminUser := g.CreateUser("adminuser")
-		res.AddAdmin(adminUser)
-
-		svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
-		payload := &app.AssignRoleResourceRolesPayload{
-			Data: []*app.AssignRoleData{
-				{
-					Role: authorization.SpaceContributorRole,
-					Ids:  []string{testUser.Identity().ID.String()},
+			svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: []*app.AssignRoleData{
+					{
+						Role: authorization.SpaceContributorRole,
+						Ids:  []string{testUser.Identity().ID.String()},
+					},
 				},
-			},
-		}
+			}
+			// assign contributor role once: ok
+			test.AssignRoleResourceRolesNoContent(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+			// assign contributor role twice: fails
+			test.AssignRoleResourceRolesConflict(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		})
 
-		test.AssignRoleResourceRolesNoContent(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
-		test.AssignRoleResourceRolesConflict(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+		t.Run("assign lower role", func(t *testing.T) {
+			// given
+			g := s.NewTestGraph(t)
+			res := g.CreateSpace()
+			// Create a user who has the privileges to assign roles
+			adminUser := g.CreateUser("adminuser")
+			res.AddAdmin(adminUser)
+			// create a test user with admin role as well
+			testUser := g.CreateUser()
+			res.AddAdmin(testUser)
+
+			svc, ctrl := s.SecuredControllerWithIdentity(*adminUser.Identity())
+			payload := &app.AssignRoleResourceRolesPayload{
+				Data: []*app.AssignRoleData{
+					{
+						Role: authorization.SpaceContributorRole,
+						Ids:  []string{testUser.Identity().ID.String()},
+					},
+				},
+			}
+			// when assign contributor role to user
+			test.AssignRoleResourceRolesNoContent(t, svc.Context, svc, ctrl, res.SpaceID(), payload)
+			// then
+			_, returnedIdentityRoles := test.ListAssignedResourceRolesOK(t, svc.Context, svc, ctrl, res.SpaceID())
+			require.Len(t, returnedIdentityRoles.Data, 2)
+			s.checkExists(t, []uuid.UUID{adminUser.IdentityID(), testUser.IdentityID()}, []string{"admin", "contributor"}, returnedIdentityRoles)
+		})
 	})
 
 	s.T().Run("unauthorized", func(t *testing.T) {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -218,11 +218,17 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 36
 	m = append(m, steps{ExecuteSQLFile("036-token-privileges.sql")})
 
+	// Version 37
 	m = append(m, steps{ExecuteSQLFile("037-invitation-redirect-url.sql")})
 
+	// Version 38
 	m = append(m, steps{ExecuteSQLFile("038-admin-console-resource.sql")})
 
+	// Version 39
 	m = append(m, steps{ExecuteSQLFile("039-resource-type-alter.sql")})
+
+	// Version 40
+	m = append(m, steps{ExecuteSQLFile("040-identity-role-index.sql")})
 
 	// Version N
 	//

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -121,7 +121,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration36", testMigration36)
 	t.Run("TestMigration38", testMigration38)
 	t.Run("TestMigration39", testMigration39)
-	t.Run("TestMigration39", testMigration40)
+	t.Run("TestMigration40", testMigration40)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName, conf); err != nil {

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -121,6 +121,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration36", testMigration36)
 	t.Run("TestMigration38", testMigration38)
 	t.Run("TestMigration39", testMigration39)
+	t.Run("TestMigration39", testMigration40)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName, conf); err != nil {
@@ -514,7 +515,11 @@ func testMigration39(t *testing.T) {
 	// Not ok to insert with invalid default_role_id - has foreign key constraint
 	_, err = sqlDB.Exec("INSERT INTO resource_type (resource_type_id,NAME,created_at,default_role_id) VALUES (uuid_generate_v4(),'wont-work',Now(),uuid_generate_v4())")
 	require.Error(t, err)
+}
 
+func testMigration40(t *testing.T) {
+	migrateToVersion(sqlDB, migrations[:(41)], (41))
+	require.Nil(t, runSQLscript(sqlDB, "040-identity-role-index.sql"))
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/040-identity-role-index.sql
+++ b/migration/sql-files/040-identity-role-index.sql
@@ -1,0 +1,2 @@
+DROP INDEX uq_identity_role_identity_role_resource;
+CREATE UNIQUE INDEX uq_identity_role_identity_role_resource ON identity_role (identity_id, resource_id, role_id) where deleted_at is null;

--- a/migration/sql-test-files/040-identity-role-index.sql
+++ b/migration/sql-test-files/040-identity-role-index.sql
@@ -1,0 +1,21 @@
+-- prepare data
+insert into resource_type (resource_type_id, name) values ('c3605c89-d2ae-4d3f-b4b6-dc0078531c9e', 'resource/migration-test');
+insert into resource (resource_id, resource_type_id, name) values('9c17b0a3-a56e-4e44-ad93-756ec85e94ac', 'c3605c89-d2ae-4d3f-b4b6-dc0078531c9e', 'migration-test-resource');
+insert into role (role_id, resource_type_id, name) values ('11b3a386-70ef-4ef5-bc5e-e897cb2ca859', 'c3605c89-d2ae-4d3f-b4b6-dc0078531c9e', 'migration-test-role');
+insert into identities (id, username, registration_completed) values ('7bb8876f-7d93-46ad-bbd3-733b77b76c55', 'migration-test-user', true);
+
+-- create identity/role
+insert into identity_role (identity_role_id, resource_id, identity_id, role_id) values ('977182c3-71b9-4954-bd58-000000000001', '9c17b0a3-a56e-4e44-ad93-756ec85e94ac', '7bb8876f-7d93-46ad-bbd3-733b77b76c55', '11b3a386-70ef-4ef5-bc5e-e897cb2ca859');
+-- mark as deleted
+update identity_role set deleted_at = now() where identity_role_id = '977182c3-71b9-4954-bd58-000000000001';
+-- create a new one with the same resource/identity/role IDs
+insert into identity_role (identity_role_id, resource_id, identity_id, role_id) values ('977182c3-71b9-4954-bd58-000000000002', '9c17b0a3-a56e-4e44-ad93-756ec85e94ac', '7bb8876f-7d93-46ad-bbd3-733b77b76c55', '11b3a386-70ef-4ef5-bc5e-e897cb2ca859');
+
+
+-- remove test data
+delete from identity_role where identity_role_id = '977182c3-71b9-4954-bd58-000000000001';
+delete from identity_role where identity_role_id = '977182c3-71b9-4954-bd58-000000000002';
+delete from identities where id = '7bb8876f-7d93-46ad-bbd3-733b77b76c55';
+delete from role where role_id = '11b3a386-70ef-4ef5-bc5e-e897cb2ca859';
+delete from resource where resource_id = '9c17b0a3-a56e-4e44-ad93-756ec85e94ac';
+delete from resource_type where resource_type_id = 'c3605c89-d2ae-4d3f-b4b6-dc0078531c9e';


### PR DESCRIPTION
when an identity/role/resource relationship was deleted, it was
impossible to re-create the same due to a unique index that would
not ignore the `soft deleted` records.

fixes #718

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>