### PR TITLE
WIP: Fix go build

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -23,7 +23,7 @@ RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && echo "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993  go1.11.1.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.11.1.linux-amd64.tar.gz \
-    && rm -f go1.11.1.linux-amd64.tar.gz \
+    && rm -f go1.11.1.linux-amd64.tar.gz; \
     fi
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,15 +2,15 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
-ARG USE_GO_VERSION_FROM_WEBSITE
+ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
 
-RUN yum install epel-release --enablerepo=extras -y
-RUN yum install --enablerepo=epel-testing -y \
+RUN yum install epel-release --enablerepo=extras -y \
+    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \
       findutils \
       git \
-      $(test -z "$USE_GO_VERSION_FROM_WEBSITE" && echo "golang") \
+      $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1 && echo "golang") \
       make \
       procps-ng \
       tar \
@@ -18,14 +18,13 @@ RUN yum install --enablerepo=epel-testing -y \
       which \
     && yum clean all
 
-RUN test -n "$USE_GO_VERSION_FROM_WEBSITE" \
-    && cd /tmp \
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget https://dl.google.com/go/go1.11.1.linux-amd64.tar.gz \
     && echo "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993  go1.11.1.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.11.1.linux-amd64.tar.gz \
     && rm -f go1.11.1.linux-amd64.tar.gz \
-    || echo 
+    fi
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Get dep for Go package management and make sure the directory has full rwz permissions for non-root users

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -22,7 +22,8 @@ RUN test -n "$USE_GO_VERSION_FROM_WEBSITE" \
     && echo "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993  go1.11.1.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.11.1.linux-amd64.tar.gz \
-    && rm -f go1.11.1.linux-amd64.tar.gz
+    && rm -f go1.11.1.linux-amd64.tar.gz \
+    || echo 
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Get dep for Go package management and make sure the directory has full rwz permissions for non-root users

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,9 @@ ENV LANG=en_US.utf8
 ARG USE_GO_VERSION_FROM_WEBSITE
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y \
+
+RUN yum install epel-release --enablerepo=extras -y
+RUN yum install --enablerepo=epel-testing -y \
       findutils \
       git \
       $(test -z "$USE_GO_VERSION_FROM_WEBSITE" && echo "golang") \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,13 +2,13 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
-ARG USE_GO_VERSION_FROM_WEBSITE=0
+ARG USE_GO_VERSION_FROM_WEBSITE
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y --quiet \
+RUN yum --enablerepo=centosplus install -y \
       findutils \
       git \
-      $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \
+      $(test -z "$USE_GO_VERSION_FROM_WEBSITE" && echo "golang") \
       make \
       procps-ng \
       tar \
@@ -16,7 +16,7 @@ RUN yum --enablerepo=centosplus install -y --quiet \
       which \
     && yum clean all
 
-RUN test -n $USE_GO_VERSION_FROM_WEBSITE \
+RUN test -n "$USE_GO_VERSION_FROM_WEBSITE" \
     && cd /tmp \
     && wget https://dl.google.com/go/go1.11.1.linux-amd64.tar.gz \
     && echo "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993  go1.11.1.linux-amd64.tar.gz" > checksum \

--- a/cico_run_coverage.sh
+++ b/cico_run_coverage.sh
@@ -2,7 +2,7 @@
 
 . cico_setup.sh
 
-export USE_GO_VERSION_FROM_WEBSITE=1
+#export USE_GO_VERSION_FROM_WEBSITE=1
 
 cico_setup_coverage;
 


### PR DESCRIPTION
This PR is addressing a few issues with build:
- Switching to golang from epel-testing since golang package was removed from centos - https://www.centos.org/forums/viewtopic.php?t=68990&p=289683
- Fixing `USE_GO_VERSION_FROM_WEBSITE` arg usage. Before that fix we actually always installed both golang from centos and from website.

TODO:
- [ ] Since go fmt has been changed in go 1.11 we need to reformat the source code.
- [ ] Tests are failing for some reason. Need to investigate.