### PR TITLE
Add username to authentication error message

### DIFF
--- a/authentication/provider/service/authentication_provider_service.go
+++ b/authentication/provider/service/authentication_provider_service.go
@@ -365,8 +365,8 @@ func (s *authenticationProviderServiceImpl) UpdateIdentityUsingUserInfoEndPoint(
 
 	// Set the user profile's username in the context
 	profileCtx := ctx.Value(provider.UserProfileContextKey)
-	if profileCtx != nil {
-		profileCtx.(*provider.UserProfileContext).Username = &userProfile.Username
+	if pCtx, ok := profileCtx.(*provider.UserProfileContext); ok {
+		pCtx.Username = &userProfile.Username
 	}
 
 	identity := &account.Identity{}

--- a/authentication/provider/service/authentication_provider_service.go
+++ b/authentication/provider/service/authentication_provider_service.go
@@ -363,6 +363,12 @@ func (s *authenticationProviderServiceImpl) UpdateIdentityUsingUserInfoEndPoint(
 		return nil, errors.New("unable to get user profile " + err.Error())
 	}
 
+	// Set the user profile's username in the context
+	profileCtx := ctx.Value(provider.UserProfileContextKey)
+	if profileCtx != nil {
+		profileCtx.(*provider.UserProfileContext).Username = &userProfile.Username
+	}
+
 	identity := &account.Identity{}
 
 	identities, err := s.Repositories().Identities().Query(account.IdentityFilterByUsername(userProfile.Username), account.IdentityWithUser())

--- a/authentication/provider/user_profile.go
+++ b/authentication/provider/user_profile.go
@@ -8,7 +8,13 @@ const (
 	ApprovedAttributeName = "approved"
 	ClusterAttribute      = "cluster"
 	RHDUsernameAttribute  = "rhd_username"
+	UserProfileContextKey = "user_profile_context"
 )
+
+// UserProfileUsernameContext
+type UserProfileContext struct {
+	Username *string
+}
 
 // OAuthUserProfile represents standard OAuth User profile api request payload
 type OAuthUserProfile struct {

--- a/authentication/provider/user_profile.go
+++ b/authentication/provider/user_profile.go
@@ -8,10 +8,12 @@ const (
 	ApprovedAttributeName = "approved"
 	ClusterAttribute      = "cluster"
 	RHDUsernameAttribute  = "rhd_username"
+
+	// UserProfileContextKey is the context value key used to carry a UserProfileContext value
 	UserProfileContextKey = "user_profile_context"
 )
 
-// UserProfileUsernameContext
+// UserProfileUsernameContext is used to pass certain informational state between layers via the context
 type UserProfileContext struct {
 	Username *string
 }

--- a/controller/token.go
+++ b/controller/token.go
@@ -218,8 +218,8 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 
 	if notApprovedRedirect != nil && token == nil {
 		// the code enters this block only if the user is not provisioned on OSO.
-		userProfileContext := profileCtx.Value(provider.UserProfileContextKey).(*provider.UserProfileContext)
-		if userProfileContext != nil {
+		userProfileContext, ok := profileCtx.Value(provider.UserProfileContextKey).(*provider.UserProfileContext)
+		if ok {
 			return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError(
 				fmt.Sprintf("user is not authorized to access OpenShift: %s", *userProfileContext.Username)))
 		}

--- a/controller/token.go
+++ b/controller/token.go
@@ -1,7 +1,8 @@
 package controller
 
 import (
-	"github.com/fabric8-services/fabric8-auth/configuration"
+	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/authorization/token"
 	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
 	"github.com/fabric8-services/fabric8-auth/client"
+	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
@@ -177,6 +179,8 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 	var token *app.OauthToken
 	var notApprovedRedirect *string
 
+	profileCtx := context.WithValue(ctx, provider.UserProfileContextKey, &provider.UserProfileContext{})
+
 	switch payload.GrantType {
 	case "client_credentials":
 		token, err = c.exchangeWithGrantTypeClientCredentials(ctx)
@@ -193,7 +197,9 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 			}, "failed to parse referrer")
 			return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 		}
-		notApprovedRedirect, token, err = c.app.AuthenticationProviderService().ExchangeAuthorizationCodeForUserToken(ctx, *payload.Code, payload.ClientID, redirectURL)
+
+		notApprovedRedirect, token, err = c.app.AuthenticationProviderService().ExchangeAuthorizationCodeForUserToken(
+			profileCtx, *payload.Code, payload.ClientID, redirectURL)
 		ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
 
 		if err != nil {
@@ -212,6 +218,11 @@ func (c *TokenController) Exchange(ctx *app.ExchangeTokenContext) error {
 
 	if notApprovedRedirect != nil && token == nil {
 		// the code enters this block only if the user is not provisioned on OSO.
+		userProfileContext := profileCtx.Value(provider.UserProfileContextKey).(*provider.UserProfileContext)
+		if userProfileContext != nil {
+			return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError(
+				fmt.Sprintf("user is not authorized to access OpenShift: %s", *userProfileContext.Username)))
+		}
 		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("user is not authorized to access OpenShift"))
 	}
 

--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -658,7 +658,7 @@ func (s *TokenControllerTestSuite) TestExchangeWithCorrectCodeButNotApprovedUser
 
 	code := "XYZ"
 	_, errResp := test.ExchangeTokenForbidden(s.T(), svc.Context, svc, ctrl, &app.TokenExchange{GrantType: "authorization_code", ClientID: s.Configuration.GetPublicOAuthClientID(), Code: &code})
-	require.Equal(s.T(), "user is not authorized to access OpenShift", errResp.Errors[0].Detail)
+	require.True(s.T(), strings.HasPrefix(errResp.Errors[0].Detail, "user is not authorized to access OpenShift"))
 
 	provider, _ = s.getDummyOAuthIDPProvider(true)
 	testsupport.ActivateDummyIdentityProviderFactory(s, provider)


### PR DESCRIPTION
This PR uses the context to propagate username information up the stack from the user profile call (in the authentication service provider) to the token controller, where it is then used to generate the error message returned to the client.

Fixes #683 