### PR TITLE
Re-provision user by reg app request

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -144,6 +144,8 @@ type UserService interface {
 	LoadContextIdentityAndUser(ctx context.Context) (*account.Identity, error)
 	LoadContextIdentityIfNotDeprovisioned(ctx context.Context) (*account.Identity, error)
 	ContextIdentityIfExists(ctx context.Context) (uuid.UUID, error)
+	IdentityByUsernameAndEmail(ctx context.Context, username, email string) (*account.Identity, error)
+	ResetDeprovision(ctx context.Context, user account.User) error
 }
 
 type UserProfileService interface {

--- a/controller/users.go
+++ b/controller/users.go
@@ -133,7 +133,10 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errors.NewVersionConflictError("user with such email or username already exists"))
 		}
 		if idn.User.Deprovisioned {
-			c.app.UserService().ResetDeprovision(ctx, idn.User)
+			err := c.app.UserService().ResetDeprovision(ctx, idn.User)
+			if err != nil {
+				return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+			}
 		}
 		// User/identity already exist. Just return it.
 		return ctx.OK(ConvertToAppUser(ctx.RequestData, &idn.User, idn, true))

--- a/controller/users.go
+++ b/controller/users.go
@@ -135,6 +135,7 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 		if idn.User.Deprovisioned {
 			err := c.app.UserService().ResetDeprovision(ctx, idn.User)
 			if err != nil {
+				log.Error(ctx, map[string]interface{}{"err": err, "username": ctx.Payload.Data.Attributes.Username, "email": ctx.Payload.Data.Attributes.Email}, "unable to re-provision user")
 				return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 			}
 		}

--- a/controller/users.go
+++ b/controller/users.go
@@ -118,7 +118,25 @@ func (c *UsersController) Create(ctx *app.CreateUsersContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
 	if userExists {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewVersionConflictError("user with such email or username already exists"))
+		// This may happen for manually deprovisioned users which are reactivating their account via the registration app
+		// We should re-deprovision such user
+		idn, err := c.app.UserService().IdentityByUsernameAndEmail(ctx, ctx.Payload.Data.Attributes.Username, ctx.Payload.Data.Attributes.Email)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err":      err,
+				"username": ctx.Payload.Data.Attributes.Username,
+				"email":    ctx.Payload.Data.Attributes.Email,
+			}, "unable to lookup identity by username and email")
+			return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+		}
+		if idn == nil {
+			return jsonapi.JSONErrorResponse(ctx, errors.NewVersionConflictError("user with such email or username already exists"))
+		}
+		if idn.User.Deprovisioned {
+			c.app.UserService().ResetDeprovision(ctx, idn.User)
+		}
+		// User/identity already exist. Just return it.
+		return ctx.OK(ConvertToAppUser(ctx.RequestData, &idn.User, idn, true))
 	}
 
 	// If it's a new user, Auth service generates an Identity ID for the user.


### PR DESCRIPTION
If some user was manually deprovisioned in the OSO registration app but was not blocked (due to inactivity for example) then the user can reactivate the account by using signup again. In this case the reg app will call Auth to create a new user. Currently Auth will return 409 for such users. This PR re-provision such users and returns 200 to the reg app.