### PR TITLE
feat: add api to populate identity cluster relations in cluster service

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -64,6 +64,7 @@ type ClusterService interface {
 	Status(ctx context.Context, options ...rest.HTTPClientOption) (bool, error)
 	UnlinkIdentityFromCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, options ...rest.HTTPClientOption) error
 	LinkIdentityToCluster(ctx context.Context, identityID uuid.UUID, clusterURL string, options ...rest.HTTPClientOption) error
+	LinkExistingIdentitiesToCluster(ctx context.Context, options ...rest.HTTPClientOption) error
 	Stop()
 }
 

--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/log"
 
 	"github.com/fabric8-services/fabric8-auth/authorization/token"
+	"github.com/fabric8-services/fabric8-auth/rest"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -135,6 +136,7 @@ type IdentityRepository interface {
 	AddMember(ctx context.Context, identityID uuid.UUID, memberID uuid.UUID) error
 	RemoveMember(ctx context.Context, memberOf uuid.UUID, memberID uuid.UUID) error
 	FlagPrivilegeCacheStaleForMembershipChange(ctx context.Context, memberID uuid.UUID, memberOf uuid.UUID) error
+	GetIdentitiesWithClusterURL(ctx context.Context) (map[uuid.UUID]string, error)
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name
@@ -182,6 +184,23 @@ func (m *GormIdentityRepository) LoadWithUser(ctx context.Context, id uuid.UUID)
 		return nil, errs.WithStack(errors.NewNotFoundError("user for identity", id.String()))
 	}
 	return &identities[0], nil
+}
+
+func (m *GormIdentityRepository) GetIdentitiesWithClusterURL(ctx context.Context) (map[uuid.UUID]string, error) {
+	ic := make(map[uuid.UUID]string)
+	identities, err := m.Query(IdentityFilterByProviderType(DefaultIDP), IdentityWithUser())
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "failed to load identity with default identity provider")
+		return ic, errs.WithStack(err)
+	}
+	for _, identity := range identities {
+		if identity.IsUser() && identity.User.Cluster != "" {
+			ic[identity.ID] = rest.AddTrailingSlashToURL(identity.User.Cluster)
+		}
+	}
+	return ic, nil
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error

--- a/cluster/service/cluster_whitebox_test.go
+++ b/cluster/service/cluster_whitebox_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"github.com/fabric8-services/fabric8-auth/rest"
+	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+	tokentestsupport "github.com/fabric8-services/fabric8-auth/test/token"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/h2non/gock.v1"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
+)
+
+func TestClusterService(t *testing.T) {
+	suite.Run(t, &ClusterServiceTestSuite{})
+}
+
+type ClusterServiceTestSuite struct {
+	testsuite.UnitTestSuite
+	cs      *clusterService
+	tm      manager.TokenManager
+	saToken string
+}
+
+func (s *ClusterServiceTestSuite) SetupSuite() {
+	s.UnitTestSuite.SetupSuite()
+
+	var err error
+	s.tm, err = manager.DefaultManager(s.Config)
+	require.NoError(s.T(), err)
+
+	s.saToken = s.tm.AuthServiceAccountToken()
+	s.cs = NewClusterService(nil, s.Config).(*clusterService)
+}
+
+func (s *ClusterServiceTestSuite) TestLinkAllExistingIdentityToCluster() {
+	ctx, _, reqID := tokentestsupport.ContextWithTokenAndRequestID(s.T())
+
+	s.T().Run("ok", func(t *testing.T) {
+		defer gock.OffAll()
+		identitiesWithClusterURL := make(map[uuid.UUID]string)
+		for i := 0; i < 5; i++ {
+			identityID := uuid.NewV4()
+			clusterURL := "https://cluster" + strconv.Itoa(i) + "/"
+			identitiesWithClusterURL[identityID] = clusterURL
+			gock.New("http://f8cluster").
+				Post("api/clusters/identities").
+				MatchHeader("X-Request-Id", reqID).
+				MatchHeader("Authorization", "Bearer "+s.saToken).
+				BodyString(WithPayload(identityID, clusterURL)).
+				Reply(204)
+		}
+
+		errs, e := s.cs.linkIdentitiesToCluster(ctx, identitiesWithClusterURL, rest.WithRoundTripper(http.DefaultTransport))
+		err, ok := <-errs
+
+		//then
+		assert.NoError(t, e)
+		assert.False(t, ok)
+		assert.NoError(t, err)
+	})
+
+	s.T().Run("fail", func(t *testing.T) {
+		defer gock.OffAll()
+		identitiesWithClusterURL := make(map[uuid.UUID]string)
+		for i := 0; i < 2; i++ {
+			identityID := uuid.NewV4()
+			clusterURL := "https://cluster" + strconv.Itoa(i) + "/"
+			identitiesWithClusterURL[identityID] = clusterURL
+			gock.New("http://f8cluster").
+				Post("api/clusters/identities").
+				MatchHeader("Authorization", "Bearer "+s.saToken).
+				MatchHeader("X-Request-Id", reqID).
+				BodyString(WithPayload(identityID, clusterURL)).
+				Reply(500).
+				BodyString("something went wrong")
+		}
+
+		errs, e := s.cs.linkIdentitiesToCluster(ctx, identitiesWithClusterURL, rest.WithRoundTripper(http.DefaultTransport))
+		for i := 0; i < 2; i++ {
+			err, ok := <-errs
+
+			//then
+			assert.NoError(t, e)
+			assert.True(t, ok)
+			require.Error(t, err)
+			assert.Equal(t, "failed to link identity to cluster in cluster management service. Response status: 500 Internal Server Error. Response body: something went wrong", err.Error())
+		}
+	})
+}
+
+func WithPayload(identityID uuid.UUID, clusterURL string) string {
+	return `{ "cluster-url": "` + clusterURL + `", "identity-id": "` + identityID.String() + `" }`
+}

--- a/controller/clusters.go
+++ b/controller/clusters.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/fabric8-services/fabric8-common/httpsupport"
 
+	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/authorization/token"
+	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/goadesign/goa"
 )
 
@@ -18,12 +21,14 @@ type clusterConfiguration interface {
 type ClustersController struct {
 	*goa.Controller
 	config clusterConfiguration
+	app    application.Application
 }
 
 // NewClustersController creates a clusters controller.
-func NewClustersController(service *goa.Service, config clusterConfiguration) *ClustersController {
+func NewClustersController(service *goa.Service, app application.Application, config clusterConfiguration) *ClustersController {
 	return &ClustersController{
 		Controller: service.NewController("ClustersController"),
+		app:        app,
 		config:     config,
 	}
 }
@@ -38,4 +43,21 @@ func (c *ClustersController) Show(ctx *app.ShowClustersContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	return nil
+}
+
+func (c *ClustersController) LinkExistingIdentitiesToCluster(ctx *app.LinkExistingIdentitiesToClusterClustersContext) error {
+	// currently using online registration as we already have it atleast for prod-preview, so we can use it directly.
+	if !token.IsSpecificServiceAccount(ctx, token.OnlineRegistration) {
+		log.Error(ctx, nil, "The account is not an authorized service account allowed to create a new user")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("account not authorized to create users."))
+	}
+
+	if err := c.app.ClusterService().LinkExistingIdentitiesToCluster(ctx); err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"error": err,
+		}, "error while linking existing identities to  it's cluster url")
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	return ctx.Accepted()
 }

--- a/controller/clusters_blackbox_test.go
+++ b/controller/clusters_blackbox_test.go
@@ -4,28 +4,64 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-auth/app/test"
+	"github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	. "github.com/fabric8-services/fabric8-auth/controller"
-	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
-
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
+	testservice "github.com/fabric8-services/fabric8-auth/test/service"
 	"github.com/goadesign/goa"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
 )
 
-type TestClustersREST struct {
-	testsuite.UnitTestSuite
+type ClustersControllerTestSuite struct {
+	gormtestsupport.DBTestSuite
+	clusterServiceMock *testservice.ClusterServiceMock
 }
 
-func TestRunClustersREST(t *testing.T) {
-	suite.Run(t, &TestClustersREST{UnitTestSuite: testsuite.NewUnitTestSuite()})
+func TestClusterController(t *testing.T) {
+	suite.Run(t, &ClustersControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
 
-func (rest *TestClustersREST) UnsecuredController() (*goa.Service, *ClustersController) {
+func (s *ClustersControllerTestSuite) UnsecuredController() (*goa.Service, *ClustersController) {
 	svc := goa.New("Cluster-Service")
-	return svc, NewClustersController(svc, rest.Config)
+	return svc, NewClustersController(svc, s.Application, s.Configuration)
 }
 
-func (rest *TestClustersREST) TestShowForServiceAccountsFails() {
+func (s *ClustersControllerTestSuite) SecuredController(identity *repository.Identity) (*goa.Service, *ClustersController) {
+	svc := testsupport.ServiceAsServiceAccountUser("Cluster-Service", *identity)
+	return svc, NewClustersController(svc, s.Application, s.Configuration)
+}
+
+func (s *ClustersControllerTestSuite) TestShowForServiceAccountsFails() {
 	// The controller should be available. It should fail because the is no cluster service available to proxy to.
-	service, controller := rest.UnsecuredController()
-	test.ShowClustersBadGateway(rest.T(), service.Context, service, controller)
+	service, controller := s.UnsecuredController()
+	test.ShowClustersBadGateway(s.T(), service.Context, service, controller)
+}
+
+func (s *ClustersControllerTestSuite) TestLinkExistingIdentitiesToCluster() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		sa := &repository.Identity{
+			Username: "online-registration",
+			ID:       uuid.NewV4(),
+		}
+		svc, ctrl := s.SecuredController(sa)
+
+		// when/then
+		test.LinkExistingIdentitiesToClusterClustersAccepted(t, svc.Context, svc, ctrl)
+	})
+
+	s.T().Run("unauthorized", func(t *testing.T) {
+		// given
+		sa := &repository.Identity{
+			Username: "unknown",
+			ID:       uuid.NewV4(),
+		}
+		svc, ctrl := s.SecuredController(sa)
+
+		// when/then
+		test.LinkExistingIdentitiesToClusterClustersUnauthorized(t, svc.Context, svc, ctrl)
+	})
 }

--- a/design/clusters.go
+++ b/design/clusters.go
@@ -38,4 +38,15 @@ var _ = a.Resource("clusters", func() {
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.BadGateway, JSONAPIErrors)
 	})
+
+	a.Action("linkExistingIdentitiesToCluster", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("/identities/link"),
+		)
+		a.Description("Link identities to clusters")
+		a.Response(d.Accepted)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
 })

--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func main() {
 	app.MountCollaboratorsController(service, collaboratorsCtrl)
 
 	// Mount "clusters" controller
-	clustersCtrl := controller.NewClustersController(service, config)
+	clustersCtrl := controller.NewClustersController(service, appDB, config)
 	app.MountClustersController(service, clustersCtrl)
 
 	// Mount "resources" controller


### PR DESCRIPTION
*Changes Proposed in this PR*
* ADD `curl -X POST clusters/identities/link -H Authorization: Bearer $SA_TOKEN` to create identity cluster relationship in cluster service for all existing users. 
