### PR TITLE
Bulk update token status values

### DIFF
--- a/authorization/token/repository/token_blackbox_test.go
+++ b/authorization/token/repository/token_blackbox_test.go
@@ -185,3 +185,30 @@ func (s *tokenBlackBoxTest) TestCreateListPrivileges() {
 	require.Len(s.T(), privs, 1)
 	require.Equal(s.T(), pc.PrivilegeCache().PrivilegeCacheID, privs[0].PrivilegeCacheID)
 }
+
+func (s *tokenBlackBoxTest) TestSetStatusFlagsForIdentity() {
+	user1 := s.Graph.CreateUser()
+	user2 := s.Graph.CreateUser()
+
+	t1 := s.Graph.CreateToken(user1)
+	t2 := s.Graph.CreateToken(user1)
+	s.Graph.CreateToken(user1)
+
+	t4 := s.Graph.CreateToken(user2)
+	s.Graph.CreateToken(user2)
+
+	require.True(s.T(), t1.Token().Valid())
+
+	s.repo.SetStatusFlagsForIdentity(s.Ctx, user1.IdentityID(), tokenPkg.TOKEN_STATUS_REVOKED)
+
+	t1Loaded := s.Graph.LoadToken(t1.TokenID())
+
+	require.False(s.T(), t1Loaded.Token().Valid())
+	require.True(s.T(), t1Loaded.Token().HasStatus(tokenPkg.TOKEN_STATUS_REVOKED))
+
+	t2Loaded := s.Graph.LoadToken(t2.TokenID())
+	require.False(s.T(), t2Loaded.Token().Valid())
+
+	t4Loaded := s.Graph.LoadToken(t4.TokenID())
+	require.True(s.T(), t4Loaded.Token().Valid())
+}

--- a/authorization/token/repository/token_blackbox_test.go
+++ b/authorization/token/repository/token_blackbox_test.go
@@ -199,7 +199,8 @@ func (s *tokenBlackBoxTest) TestSetStatusFlagsForIdentity() {
 
 	require.True(s.T(), t1.Token().Valid())
 
-	s.repo.SetStatusFlagsForIdentity(s.Ctx, user1.IdentityID(), tokenPkg.TOKEN_STATUS_REVOKED)
+	err := s.repo.SetStatusFlagsForIdentity(s.Ctx, user1.IdentityID(), tokenPkg.TOKEN_STATUS_REVOKED)
+	require.NoError(s.T(), err)
 
 	t1Loaded := s.Graph.LoadToken(t1.TokenID())
 

--- a/authorization/token/service/token_service.go
+++ b/authorization/token/service/token_service.go
@@ -708,19 +708,14 @@ func (s *tokenServiceImpl) SetStatusForAllIdentityTokens(ctx context.Context, ac
 	}
 
 	err = s.ExecuteInTransaction(func() error {
-		// For each token, set the status flag to true for the specified token status
-		for _, tkn := range tokens {
-			tkn.SetStatus(status, true)
-			err = s.Repositories().TokenRepository().Save(ctx, &tkn)
-
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"err":         err,
-					"identity_id": identity.ID,
-					"token_id":    tkn.TokenID,
-				}, "Unable to update status for token.")
-				return err
-			}
+		// Update all the token status flags
+		err = s.Repositories().TokenRepository().SetStatusFlagsForIdentity(ctx, identity.ID, status)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err":         err,
+				"identity_id": identity.ID,
+			}, "Unable to update status values for identity.")
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
Fixes #765 

This PR adds a new method to the token repository, `SetStatusFlagsForIdentity()` which allows the bulk update of token status flags for an identity.  The logout service now uses this method instead of updating token status values individually, which should hopefully result in a performance improvement.