### PR TITLE
Add token cleanup worker

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -140,6 +140,7 @@ type TeamService interface {
 
 type TokenService interface {
 	Audit(ctx context.Context, identity *account.Identity, tokenString string, resourceID string) (*string, error)
+	CleanupExpiredTokens(ctx context.Context) error
 	DeleteExternalToken(ctx context.Context, currentIdentity uuid.UUID, authURL string, forResource string) error
 	ExchangeRefreshToken(ctx context.Context, refreshToken string, rptToken string) (*manager.TokenSet, error)
 	RegisterToken(ctx context.Context, identityID uuid.UUID, tokenString string, tokenType string, privileges []tokenrepo.TokenPrivilege) (*tokenrepo.Token, error)

--- a/authorization/token/repository/token_blackbox_test.go
+++ b/authorization/token/repository/token_blackbox_test.go
@@ -220,36 +220,63 @@ func (s *tokenBlackBoxTest) TestCleanupExpiredTokens() {
 	yesterday := now.AddDate(0, 0, -1)
 	tomorrow := now.AddDate(0, 0, 1)
 
-	s.Graph.CreateToken(yesterday)
-	s.Graph.CreateToken(yesterday)
-	s.Graph.CreateToken(now)
-	s.Graph.CreateToken(now)
-	s.Graph.CreateToken(now)
-	s.Graph.CreateToken(tomorrow)
-	s.Graph.CreateToken(tomorrow)
+	t1 := s.Graph.CreateToken(yesterday)
+	t2 := s.Graph.CreateToken(yesterday)
+	t3 := s.Graph.CreateToken(now)
+	t4 := s.Graph.CreateToken(now)
+	t5 := s.Graph.CreateToken(now)
+	t6 := s.Graph.CreateToken(tomorrow)
+	t7 := s.Graph.CreateToken(tomorrow)
 
-	require.Equal(s.T(), s.countTokens(s.T()), 7)
+	require.Equal(s.T(), s.countTokens(), 7)
 
 	// Let's start by cleaning up all tokens that expired more than 1 hour ago
 	err := s.repo.CleanupExpiredTokens(s.Ctx, 1)
 	require.NoError(s.T(), err)
 
 	// We should be left with 5 tokens (the "yesterday" tokens should now be gone)
-	require.Equal(s.T(), s.countTokens(s.T()), 5)
+	require.Equal(s.T(), s.countTokens(), 5)
+
+	// Check the exact token IDs
+	require.False(s.T(), s.tokenExists(t1.TokenID()))
+	require.False(s.T(), s.tokenExists(t2.TokenID()))
+	require.True(s.T(), s.tokenExists(t3.TokenID()))
+	require.True(s.T(), s.tokenExists(t4.TokenID()))
+	require.True(s.T(), s.tokenExists(t5.TokenID()))
+	require.True(s.T(), s.tokenExists(t6.TokenID()))
+	require.True(s.T(), s.tokenExists(t7.TokenID()))
 
 	// Now let's clean up all the expired tokens, without any retention
 	err = s.repo.CleanupExpiredTokens(s.Ctx, 0)
 	require.NoError(s.T(), err)
 
 	// We should now be left with just 2 tokens
-	require.Equal(s.T(), s.countTokens(s.T()), 2)
+	require.Equal(s.T(), s.countTokens(), 2)
+
+	// Check the exact token IDs
+	require.False(s.T(), s.tokenExists(t1.TokenID()))
+	require.False(s.T(), s.tokenExists(t2.TokenID()))
+	require.False(s.T(), s.tokenExists(t3.TokenID()))
+	require.False(s.T(), s.tokenExists(t4.TokenID()))
+	require.False(s.T(), s.tokenExists(t5.TokenID()))
+	require.True(s.T(), s.tokenExists(t6.TokenID()))
+	require.True(s.T(), s.tokenExists(t7.TokenID()))
 }
 
-func (s *tokenBlackBoxTest) countTokens(t *testing.T) int {
+func (s *tokenBlackBoxTest) countTokens() int {
 	var result *int64
 
 	err := s.DB.Table("token").Count(&result).Error
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 
 	return int(*result)
+}
+
+func (s *tokenBlackBoxTest) tokenExists(tokenID uuid.UUID) bool {
+	exists, err := s.repo.CheckExists(s.Ctx, tokenID)
+	if err != nil {
+		require.IsType(s.T(), err, errors.NotFoundError{})
+	}
+
+	return exists
 }

--- a/authorization/token/worker/token_cleanup_worker.go
+++ b/authorization/token/worker/token_cleanup_worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/log"
 	"time"
 )
 
@@ -36,7 +37,13 @@ func (w *tokenCleanupWorker) cleanupLoop() {
 	for {
 		select {
 		case <-w.ticker.C:
-			w.app.TokenService().CleanupExpiredTokens(w.ctx)
+			err := w.app.TokenService().CleanupExpiredTokens(w.ctx)
+			if err != nil {
+				// We will just log the error and continue
+				log.Error(nil, map[string]interface{}{
+					"err": err,
+				}, "error in token cleanup worker")
+			}
 		case <-w.stopCh:
 			w.ticker.Stop()
 			return

--- a/authorization/token/worker/token_cleanup_worker.go
+++ b/authorization/token/worker/token_cleanup_worker.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"context"
+	"github.com/fabric8-services/fabric8-auth/application"
+	"time"
+)
+
+type TokenCleanupWorker interface {
+	Start(ticker *time.Ticker)
+	Stop()
+}
+
+func NewTokenCleanupWorker(ctx context.Context, app application.Application) TokenCleanupWorker {
+	return &tokenCleanupWorker{
+		ctx: ctx,
+		app: app,
+	}
+}
+
+type tokenCleanupWorker struct {
+	ctx    context.Context
+	app    application.Application
+	ticker *time.Ticker
+	stopCh chan bool
+}
+
+func (w *tokenCleanupWorker) Start(ticker *time.Ticker) {
+	w.ticker = ticker
+	w.stopCh = make(chan bool, 1)
+
+	go w.cleanupLoop()
+}
+
+func (w *tokenCleanupWorker) cleanupLoop() {
+	for {
+		select {
+		case <-w.ticker.C:
+			w.app.TokenService().CleanupExpiredTokens(w.ctx)
+		case <-w.stopCh:
+			w.ticker.Stop()
+			return
+		}
+	}
+}
+
+func (c *tokenCleanupWorker) Stop() {
+	if c.stopCh != nil {
+		c.stopCh <- true
+	}
+}

--- a/authorization/token/worker/token_cleanup_worker_blackbox_test.go
+++ b/authorization/token/worker/token_cleanup_worker_blackbox_test.go
@@ -1,0 +1,61 @@
+package worker_test
+
+import (
+	tokenRepo "github.com/fabric8-services/fabric8-auth/authorization/token/repository"
+	"github.com/fabric8-services/fabric8-auth/authorization/token/worker"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+type tokenCleanupWorkerBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+	repo tokenRepo.TokenRepository
+}
+
+func TestRunTokenCleanupWorkerBlackBoxTest(t *testing.T) {
+	suite.Run(t, &tokenCleanupWorkerBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *tokenCleanupWorkerBlackBoxTest) TestCleanupWorker() {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+	tomorrow := now.AddDate(0, 0, 1)
+
+	// Clean up all tokens
+	require.NoError(s.T(), s.deleteAllTokens(s.T()))
+
+	s.Graph.CreateToken(yesterday)
+	s.Graph.CreateToken(yesterday)
+	s.Graph.CreateToken(tomorrow)
+
+	require.Equal(s.T(), 3, s.countTokens(s.T()))
+
+	// Start the worker with a 1 second timer
+	worker := worker.NewTokenCleanupWorker(s.Ctx, s.Application)
+
+	// Activate token cleanup once every hour
+	worker.Start(time.NewTicker(time.Second))
+	defer worker.Stop()
+
+	// Wait 5 seconds
+	time.Sleep(time.Duration(5) * time.Second)
+
+	// We should now have 1 token remaining
+	require.Equal(s.T(), s.countTokens(s.T()), 1)
+}
+
+func (s *tokenCleanupWorkerBlackBoxTest) deleteAllTokens(t *testing.T) error {
+	return s.DB.Exec("DELETE FROM token").Error
+}
+
+func (s *tokenCleanupWorkerBlackBoxTest) countTokens(t *testing.T) int {
+	var result *int64
+
+	err := s.DB.Table("token").Count(&result).Error
+	require.NoError(t, err)
+
+	return int(*result)
+}

--- a/authorization/token/worker/token_cleanup_worker_blackbox_test.go
+++ b/authorization/token/worker/token_cleanup_worker_blackbox_test.go
@@ -1,7 +1,6 @@
 package worker_test
 
 import (
-	tokenRepo "github.com/fabric8-services/fabric8-auth/authorization/token/repository"
 	"github.com/fabric8-services/fabric8-auth/authorization/token/worker"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	"github.com/stretchr/testify/require"
@@ -12,7 +11,6 @@ import (
 
 type tokenCleanupWorkerBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo tokenRepo.TokenRepository
 }
 
 func TestRunTokenCleanupWorkerBlackBoxTest(t *testing.T) {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -191,6 +191,9 @@ const (
 	varEnvironment = "environment"
 	varSentryDSN   = "sentry.dsn"
 
+	// Token cleanup
+	varExpiredTokenRetentionHours = "expired.token.retention.hours"
+
 	secondsInOneDay = 24 * 60 * 60
 )
 
@@ -623,6 +626,9 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// RPT Token maximum permissions
 	c.v.SetDefault(varRPTTokenMaxPermissions, 10)
 
+	// Expired token retention time, after which tokens will be cleaned up
+	c.v.SetDefault(varExpiredTokenRetentionHours, defaultExpiredTokenRetentionHours)
+
 	// Cluster service
 	c.v.SetDefault(varShortClusterServiceURL, "http://f8cluster")
 	c.v.SetDefault(varClusterRefreshInterval, 5*time.Minute) // 5 minutes
@@ -1010,4 +1016,8 @@ func (c *ConfigurationData) GetPrivilegeCacheExpirySeconds() int64 {
 // GetRPTTokenMaxPermissions returns the maximum number of permissions that may be stored in an RPT token
 func (c *ConfigurationData) GetRPTTokenMaxPermissions() int {
 	return c.v.GetInt(varRPTTokenMaxPermissions)
+}
+
+func (c *ConfigurationData) GetExpiredTokenRetentionHours() int {
+	return c.v.GetInt(varExpiredTokenRetentionHours)
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -109,4 +109,7 @@ vwIDAQAB
 
 	prodEnvironment        = "production"
 	prodPreviewEnvironment = "prod-preview"
+
+	// The number of hours to retain expired tokens.  After this time limit has been exceeded, the token may be cleaned up (deleted)
+	defaultExpiredTokenRetentionHours = 24
 )

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/fabric8-services/fabric8-auth/authorization/token/worker"
 	"net/http"
 	"os"
 	"os/user"
@@ -286,6 +287,13 @@ func main() {
 			}
 		}(config.GetMetricsHTTPAddress())
 	}
+
+	// Start background workers
+	worker := worker.NewTokenCleanupWorker(context.Background(), appDB)
+	// Activate token cleanup once every hour
+	worker.Start(time.NewTicker(time.Hour))
+	// Stop the worker when the app shuts down
+	defer worker.Stop()
 
 	// Start http
 	if err := http.ListenAndServe(config.GetHTTPAddress(), nil); err != nil {

--- a/test/graph/token_wrapper.go
+++ b/test/graph/token_wrapper.go
@@ -4,6 +4,7 @@ import (
 	tokenRepo "github.com/fabric8-services/fabric8-auth/authorization/token/repository"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
+	"time"
 )
 
 // tokenWrapper represents an RPT Token domain object
@@ -30,9 +31,14 @@ func newTokenWrapper(g *TestGraph, params []interface{}) interface{} {
 	w.token = &tokenRepo.Token{}
 
 	var identityID *uuid.UUID
+	var expiryTime *time.Time
 
 	for i := range params {
 		switch t := params[i].(type) {
+		case *time.Time:
+			expiryTime = t
+		case time.Time:
+			expiryTime = &t
 		case *userWrapper:
 			identityID = &t.Identity().ID
 		case userWrapper:
@@ -44,6 +50,10 @@ func newTokenWrapper(g *TestGraph, params []interface{}) interface{} {
 		w.token.IdentityID = *identityID
 	} else {
 		w.token.IdentityID = w.graph.CreateUser().Identity().ID
+	}
+
+	if expiryTime != nil {
+		w.token.ExpiryTime = *expiryTime
 	}
 
 	err := g.app.TokenRepository().Create(g.ctx, w.token)


### PR DESCRIPTION
Fixes #767 

This PR introduces a token cleanup worker that runs inside a go routine.  It routinely (once per hour) invokes a token cleanup routine that removes expired tokens after a configurable retention period, set by the `AUTH_EXPIRED_TOKEN_RETENTION_HOURS` configuration parameter, which has a default of 24 hours.