### PR TITLE
Add token validation check to goa middleware

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -146,6 +146,7 @@ type TokenService interface {
 	RegisterToken(ctx context.Context, identityID uuid.UUID, tokenString string, tokenType string, privileges []tokenrepo.TokenPrivilege) (*tokenrepo.Token, error)
 	RetrieveExternalToken(ctx context.Context, forResource string, req *goa.RequestData, forcePull *bool) (*app.ExternalToken, *string, error)
 	SetStatusForAllIdentityTokens(ctx context.Context, accessToken *jwt.Token, status int) error
+	ValidateToken(ctx context.Context, tkn *jwt.Token) error
 }
 
 type UserProfileService interface {

--- a/authentication/provider/service/authentication_provider_service_blackbox_test.go
+++ b/authentication/provider/service/authentication_provider_service_blackbox_test.go
@@ -662,7 +662,11 @@ func (s *authenticationProviderServiceTestSuite) TestExchangeRefreshTokenValidNo
 	claims["sub"] = user.IdentityID().String()
 	claims["iat"] = time.Now().Unix() - 60*60 // Issued 1h ago
 	claims["exp"] = time.Now().Unix() + 60*60 // Expires in 1h
+
 	refreshToken, err := testtoken.GenerateRefreshTokenWithClaims(claims)
+	_, err = s.Application.TokenService().RegisterToken(s.Ctx, user.IdentityID(), refreshToken, token2.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	require.NoError(s.T(), err)
 	// when
 	ctx := manager.ContextWithTokenManager(testtoken.ContextWithRequest(nil), tm)
@@ -691,10 +695,17 @@ func (s *authenticationProviderServiceTestSuite) TestExchangeRefreshTokenWithAcc
 	claims["sub"] = user.IdentityID().String()
 	claims["iat"] = time.Now().Unix() - 60*60 // Issued 1h ago
 	claims["exp"] = time.Now().Unix() + 60*60 // Expires in 1h
+
 	refreshToken, err := testtoken.GenerateRefreshTokenWithClaims(claims)
 	require.NoError(s.T(), err)
+	_, err = s.Application.TokenService().RegisterToken(s.Ctx, user.IdentityID(), refreshToken, token2.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	accessToken, err := testtoken.GenerateAccessTokenWithClaims(claims)
 	require.NoError(s.T(), err)
+	_, err = s.Application.TokenService().RegisterToken(s.Ctx, user.IdentityID(), accessToken, token2.TOKEN_TYPE_ACCESS, nil)
+	require.NoError(s.T(), err)
+
 	// when
 	result, err := s.Application.TokenService().ExchangeRefreshToken(ctx, refreshToken, accessToken)
 	// then
@@ -721,10 +732,17 @@ func (s *authenticationProviderServiceTestSuite) TestExchangeRefreshTokenWithRPT
 	claims["sub"] = user.IdentityID().String()
 	claims["iat"] = time.Now().Unix() - 60*60 // Issued 1h ago
 	claims["exp"] = time.Now().Unix() + 60*60 // Expires in 1h
+
 	refreshToken, err := testtoken.GenerateRefreshTokenWithClaims(claims)
 	require.NoError(s.T(), err)
+	_, err = s.Application.TokenService().RegisterToken(s.Ctx, user.IdentityID(), refreshToken, token2.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	accessToken, err := testtoken.GenerateAccessTokenWithClaims(claims)
 	require.NoError(s.T(), err)
+	_, err = s.Application.TokenService().RegisterToken(s.Ctx, user.IdentityID(), accessToken, token2.TOKEN_TYPE_ACCESS, nil)
+	require.NoError(s.T(), err)
+
 	// obtain an RPT token using the access token
 	space := s.Graph.CreateSpace().AddAdmin(user)
 	rpt, err := s.Application.TokenService().Audit(ctx, user.Identity(), accessToken, space.SpaceID())

--- a/authorization/token/repository/token_blackbox_test.go
+++ b/authorization/token/repository/token_blackbox_test.go
@@ -216,6 +216,9 @@ func (s *tokenBlackBoxTest) TestSetStatusFlagsForIdentity() {
 }
 
 func (s *tokenBlackBoxTest) TestCleanupExpiredTokens() {
+	// Start by deleting all tokens
+	s.DB.Exec("DELETE FROM TOKEN")
+
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1)
 	tomorrow := now.AddDate(0, 0, 1)
@@ -228,7 +231,7 @@ func (s *tokenBlackBoxTest) TestCleanupExpiredTokens() {
 	t6 := s.Graph.CreateToken(tomorrow)
 	t7 := s.Graph.CreateToken(tomorrow)
 
-	require.Equal(s.T(), s.countTokens(), 7)
+	require.Equal(s.T(), 7, s.countTokens())
 
 	// Let's start by cleaning up all tokens that expired more than 1 hour ago
 	err := s.repo.CleanupExpiredTokens(s.Ctx, 1)
@@ -251,7 +254,7 @@ func (s *tokenBlackBoxTest) TestCleanupExpiredTokens() {
 	require.NoError(s.T(), err)
 
 	// We should now be left with just 2 tokens
-	require.Equal(s.T(), s.countTokens(), 2)
+	require.Equal(s.T(), 2, s.countTokens())
 
 	// Check the exact token IDs
 	require.False(s.T(), s.tokenExists(t1.TokenID()))

--- a/authorization/token/service/token_service.go
+++ b/authorization/token/service/token_service.go
@@ -324,7 +324,27 @@ func (s *tokenServiceImpl) Audit(ctx context.Context, identity *accountrepo.Iden
 // ExchangeRefreshToken exchanges refreshToken for a new user token
 func (s *tokenServiceImpl) ExchangeRefreshToken(ctx context.Context, refreshToken string, rptToken string) (*manager.TokenSet, error) {
 
-	identity, err := s.loadIdentityFromSubClaim(ctx, refreshToken)
+	tkn, err := s.tokenManager.Parse(ctx, refreshToken)
+	if err != nil {
+		return nil, errors.NewUnauthorizedError(err.Error())
+	}
+
+	err = s.ValidateToken(ctx, tkn)
+	if err != nil {
+		return nil, errors.NewUnauthorizedError(err.Error())
+	}
+
+	claims := tkn.Claims.(jwt.MapClaims)
+	sub := claims["sub"]
+	if sub == nil {
+		return nil, errors.NewUnauthorizedError("missing 'sub' claim in the refresh token")
+	}
+	identityID, err := uuid.FromString(fmt.Sprintf("%s", sub))
+	if err != nil {
+		return nil, errors.NewUnauthorizedError(err.Error())
+	}
+
+	identity, err := s.Repositories().Identities().LoadWithUser(ctx, identityID)
 
 	if err != nil {
 		if unauth, _ := errors.IsUnauthorizedError(err); unauth {
@@ -813,27 +833,6 @@ func (s *tokenServiceImpl) retrieveClusterToken(ctx context.Context, forResource
 		"cluster": provider.OSOCluster().Name,
 	}, "Returning a cluster wide token")
 	return &clusterToken, nil, nil
-}
-
-// loadIdentityFromSubClaim Parses the specified token string and extracts the sub claim from the resulting token, then
-// uses that value to load the Identity (and corresponding User) record.  If there is no sub claim, a nil identity will
-// be returned along with an unauthorized error
-func (s *tokenServiceImpl) loadIdentityFromSubClaim(ctx context.Context, token string) (*accountrepo.Identity, error) {
-	// Parse the token and extract its claims
-	claims, err := s.tokenManager.ParseTokenWithMapClaims(ctx, token)
-	if err != nil {
-		return nil, errors.NewUnauthorizedError(err.Error())
-	}
-	sub := claims["sub"]
-	if sub == nil {
-		return nil, errors.NewUnauthorizedError("missing 'sub' claim in the refresh token")
-	}
-	identityID, err := uuid.FromString(fmt.Sprintf("%s", sub))
-	if err != nil {
-		return nil, errors.NewUnauthorizedError(err.Error())
-	}
-
-	return s.Repositories().Identities().LoadWithUser(ctx, identityID)
 }
 
 func (s *tokenServiceImpl) scopesEquivalent(value1 []string, value2 []string) bool {

--- a/authorization/token/service/token_service_blackbox_test.go
+++ b/authorization/token/service/token_service_blackbox_test.go
@@ -1043,6 +1043,7 @@ func (s *tokenServiceBlackboxTest) TestRegisterInvalidToken() {
 	require.NoError(s.T(), err)
 
 	claims, err := testtoken.TokenManager.ParseToken(s.Ctx, userToken.AccessToken)
+	require.NoError(s.T(), err)
 
 	tkn, err := testtoken.TokenManager.GenerateUnsignedRPTTokenForIdentity(s.Ctx, claims, *identity, nil)
 	require.NoError(s.T(), err)

--- a/authorization/token/service/token_service_blackbox_test.go
+++ b/authorization/token/service/token_service_blackbox_test.go
@@ -833,6 +833,10 @@ func (s *tokenServiceBlackboxTest) TestExchangeRefreshTokenWithNoRPTTokenHasNoPe
 	at, err := tm.GenerateUserTokenForIdentity(ctx, *user.Identity(), false)
 	require.NoError(s.T(), err)
 
+	// Register the refresh token
+	_, err = s.Application.TokenService().RegisterToken(ctx, user.IdentityID(), at.RefreshToken, token.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	ctx = manager.ContextWithTokenManager(ctx, tm)
 	refreshToken, err := tm.Parse(ctx, at.RefreshToken)
 	require.NoError(s.T(), err)
@@ -856,6 +860,11 @@ func (s *tokenServiceBlackboxTest) TestExchangeRefreshTokenWithRPTToken() {
 	// Create an initial access token for the user
 	at, err := tm.GenerateUserTokenForIdentity(ctx, *user.Identity(), false)
 	require.NoError(s.T(), err)
+
+	// Register the refresh token
+	_, err = s.Application.TokenService().RegisterToken(ctx, user.IdentityID(), at.RefreshToken, token.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	atClaims, err := tm.ParseToken(ctx, at.AccessToken)
 	require.NoError(s.T(), err)
 	// create space
@@ -890,6 +899,11 @@ func (s *tokenServiceBlackboxTest) TestExchangeRefreshTokenWithRPTTokenAndStaleR
 	// Create an initial access token for the user
 	at, err := tm.GenerateUserTokenForIdentity(ctx, *user.Identity(), false)
 	require.NoError(s.T(), err)
+
+	// Register the refresh token
+	_, err = s.Application.TokenService().RegisterToken(ctx, user.IdentityID(), at.RefreshToken, token.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	// create space
 	space := s.Graph.CreateSpace().AddAdmin(user)
 	// create RPT for the 2nd space
@@ -921,6 +935,11 @@ func (s *tokenServiceBlackboxTest) TestExchangeRefreshTokenWithRPTTokenMultiReso
 	// Create an initial access token for the user
 	at, err := tm.GenerateUserTokenForIdentity(ctx, *user.Identity(), false)
 	require.NoError(s.T(), err)
+
+	// Register the refresh token
+	_, err = s.Application.TokenService().RegisterToken(ctx, user.IdentityID(), at.RefreshToken, token.TOKEN_TYPE_REFRESH, nil)
+	require.NoError(s.T(), err)
+
 	// create space 1
 	space1 := s.Graph.CreateSpace().AddAdmin(user)
 	// create RPT for the 1st space

--- a/authorization/token/token.go
+++ b/authorization/token/token.go
@@ -54,6 +54,13 @@ type JSONKeys struct {
 	Keys []interface{} `json:"keys"`
 }
 
+// IsValidTokenType returns true if the specified token type is one of the known token types, otherwise returns false
+func IsValidTokenType(tokenType string) bool {
+	return tokenType == TOKEN_TYPE_RPT ||
+		tokenType == TOKEN_TYPE_ACCESS ||
+		tokenType == TOKEN_TYPE_REFRESH
+}
+
 // IsSpecificServiceAccount checks if the request is done by a service account listed in the names param
 // based on the JWT Token provided in context
 func IsSpecificServiceAccount(ctx context.Context, names ...string) bool {

--- a/authorization/token/token_blackbox_test.go
+++ b/authorization/token/token_blackbox_test.go
@@ -1,0 +1,24 @@
+package token_test
+
+import (
+	"github.com/fabric8-services/fabric8-auth/authorization/token"
+	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type tokenBlackboxTest struct {
+	testsuite.UnitTestSuite
+}
+
+func TestTokenBlackbox(t *testing.T) {
+	suite.Run(t, &tokenBlackboxTest{})
+}
+
+func (s *tokenBlackboxTest) TestIsValidTokenType() {
+	require.True(s.T(), token.IsValidTokenType("ACC"))
+	require.True(s.T(), token.IsValidTokenType("REF"))
+	require.True(s.T(), token.IsValidTokenType("RPT"))
+	require.False(s.T(), token.IsValidTokenType("foo"))
+}

--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -49,7 +49,7 @@ func handler(app application.Application, tokenManager manager.TokenManager, sch
 			// If the token is *not* a service account token, then check if it is valid
 			accountName := token.Claims.(jwtgo.MapClaims)["service_accountname"]
 			if accountName == nil {
-				err = app.TokenService().ValidateToken(context.Background(), token)
+				err = app.TokenService().ValidateToken(ctx, token)
 				if err != nil {
 					log.Error(ctx, map[string]interface{}{"error": err}, "failed to validate JSON Web Token in TokenContext middleware")
 					tokenManager.AddLoginRequiredHeader(rw)

--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -3,6 +3,8 @@ package goamiddleware
 import (
 	"context"
 	"fmt"
+	jwtgo "github.com/dgrijalva/jwt-go"
+	"github.com/fabric8-services/fabric8-auth/application"
 	"net/http"
 	"strings"
 
@@ -17,14 +19,14 @@ import (
 // Authorization header when possible. If the Authorization header is missing in the request,
 // no error is returned. However, if the Authorization header contains a
 // token, it will be stored it in the context.
-func TokenContext(tokenManager manager.TokenManager, scheme *goa.JWTSecurity) goa.Middleware {
+func TokenContext(app application.Application, tokenManager manager.TokenManager, scheme *goa.JWTSecurity) goa.Middleware {
 	errUnauthorized := goa.NewErrorClass("token_validation_failed", 401)
 	return func(nextHandler goa.Handler) goa.Handler {
-		return handler(tokenManager, scheme, nextHandler, errUnauthorized)
+		return handler(app, tokenManager, scheme, nextHandler, errUnauthorized)
 	}
 }
 
-func handler(tokenManager manager.TokenManager, scheme *goa.JWTSecurity, nextHandler goa.Handler, errUnauthorized goa.ErrorClass) goa.Handler {
+func handler(app application.Application, tokenManager manager.TokenManager, scheme *goa.JWTSecurity, nextHandler goa.Handler, errUnauthorized goa.ErrorClass) goa.Handler {
 	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		// TODO: implement the QUERY string handler too
 		if scheme.In != goa.LocHeader {
@@ -43,6 +45,18 @@ func handler(tokenManager manager.TokenManager, scheme *goa.JWTSecurity, nextHan
 				tokenManager.AddLoginRequiredHeader(rw)
 				return errUnauthorized("token is invalid")
 			}
+
+			// If the token is *not* a service account token, then check if it is valid
+			accountName := token.Claims.(jwtgo.MapClaims)["service_accountname"]
+			if accountName == nil {
+				err = app.TokenService().ValidateToken(context.Background(), token)
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{"error": err}, "failed to validate JSON Web Token in TokenContext middleware")
+					tokenManager.AddLoginRequiredHeader(rw)
+					return errUnauthorized("token is invalid")
+				}
+			}
+
 			ctx = jwt.WithJWT(ctx, token)
 		}
 

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -95,8 +95,8 @@ func (s *testJWTokenContextSuite) TestHandler() {
 	require.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "401 token_validation_failed: token is invalid", err.Error())
 	header = textproto.MIMEHeader(rw.Header())
-	require.NotEmpty(s.T(), header.Get("WWW-Authenticate"))
-	require.NotEmpty(s.T(), header.Get("Access-Control-Expose-Headers"))
+	require.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", header.Get("WWW-Authenticate"))
+	assert.Contains(s.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
 }
 
 func dummyHandler(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -70,6 +70,10 @@ func (s *testJWTokenContextSuite) TestHandler() {
 	header := textproto.MIMEHeader(rw.Header())
 	assert.NotContains(s.T(), header, "WWW-Authenticate")
 	assert.NotContains(s.T(), header, "Access-Control-Expose-Headers")
+
+	// Test with a user token
+	rw = httptest.NewRecorder()
+	s.Graph.CreateToken()
 }
 
 func dummyHandler(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -73,7 +73,14 @@ func (s *testJWTokenContextSuite) TestHandler() {
 
 	// Test with a user token
 	rw = httptest.NewRecorder()
-	s.Graph.CreateToken()
+	tkn := s.Graph.CreateToken()
+	rq.Header.Set("Authorization", "Bearer "+tkn.TokenString())
+	err = h(context.Background(), rw, rq)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "next-handler-error", err.Error())
+	header = textproto.MIMEHeader(rw.Header())
+	assert.NotContains(s.T(), header, "WWW-Authenticate")
+	assert.NotContains(s.T(), header, "Access-Control-Expose-Headers")
 }
 
 func dummyHandler(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -3,36 +3,36 @@ package goamiddleware
 import (
 	"context"
 	"errors"
+	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
 	"testing"
 
-	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
-func TestJWTokenContext(t *testing.T) {
-	suite.Run(t, &TestJWTokenContextSuite{})
+type testJWTokenContextSuite struct {
+	gormtestsupport.DBTestSuite
 }
 
-type TestJWTokenContextSuite struct {
-	testsuite.UnitTestSuite
+func TestJWTTokenContextSuite(t *testing.T) {
+	suite.Run(t, &testJWTokenContextSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
 
-func (s *TestJWTokenContextSuite) TestHandler() {
+func (s *testJWTokenContextSuite) TestHandler() {
 	schema := &goa.JWTSecurity{}
 	errUnauthorized := goa.NewErrorClass("token_validation_failed", 401)
 
 	rw := httptest.NewRecorder()
 	rq := &http.Request{Header: make(map[string][]string)}
-	h := handler(testtoken.TokenManager, schema, dummyHandler, errUnauthorized)
+	h := handler(s.Application, testtoken.TokenManager, schema, dummyHandler, errUnauthorized)
 
 	err := h(context.Background(), rw, rq)
 	require.Error(s.T(), err)

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 		}, "failed to create token manager")
 	}
 	// Middleware that extracts and stores the token in the context
-	jwtMiddlewareTokenContext := goamiddleware.TokenContext(tokenManager, app.NewJWTSecurity())
+	jwtMiddlewareTokenContext := goamiddleware.TokenContext(appDB, tokenManager, app.NewJWTSecurity())
 	service.Use(jwtMiddlewareTokenContext)
 
 	service.Use(manager.InjectTokenManager(tokenManager))


### PR DESCRIPTION
This PR adds a validation check to the goa middleware to ensure that user access tokens are currently valid.