### PR TITLE
feat(775): obfuscate and deactive user at service layer

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/rest"
 	"github.com/fabric8-services/fabric8-auth/wit"
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/oauth2"
 	"net/url"
 )
@@ -153,6 +153,7 @@ type UserProfileService interface {
 }
 
 type UserService interface {
+	DeactivateUser(ctx context.Context, username string) (*account.Identity, error)
 	DeprovisionUser(ctx context.Context, username string) (*account.Identity, error)
 	UserInfo(ctx context.Context, identityID uuid.UUID) (*account.User, *account.Identity, error)
 	LoadContextIdentityAndUser(ctx context.Context) (*account.Identity, error)

--- a/authentication/account/repository/user.go
+++ b/authentication/account/repository/user.go
@@ -11,11 +11,11 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/log"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 )
 
 // In future, we could add support for FieldDefinitions the way we have for workitems.
@@ -38,6 +38,7 @@ type User struct {
 	Cluster       string // The OpenShift cluster allocated to the user.
 	// Whether the user has been deprovisioned
 	Deprovisioned      bool                       `gorm:"column:deprovisioned"`
+	Active             bool                       `gorm:"column:active"`
 	Identities         []Identity                 // has many Identities from different IDPs
 	ContextInformation account.ContextInformation `sql:"type:jsonb"` // context information of the user activity
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -238,6 +238,10 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 
 	// Version 43
 	m = append(m, steps{ExecuteSQLFile("043-add-admin-console-resource.sql")})
+
+	// Version 44
+	m = append(m, steps{ExecuteSQLFile("044-user-active.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/044-user-active.sql
+++ b/migration/sql-files/044-user-active.sql
@@ -1,0 +1,2 @@
+-- add an 'active' column (default true) in the 'user' table
+ALTER TABLE users ADD COLUMN active boolean DEFAULT true;

--- a/test/account.go
+++ b/test/account.go
@@ -14,7 +14,7 @@ import (
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 
 	"github.com/jinzhu/gorm"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -311,4 +311,35 @@ func AssertIdentityEqual(t require.TestingT, expected, actual *account.Identity)
 	assert.Equal(t, expected.User.FullName, actual.User.FullName)
 	assert.Equal(t, expected.User.ImageURL, actual.User.ImageURL)
 	assert.Equal(t, expected.User.URL, actual.User.URL)
+}
+
+// AssertIdentityObfuscated verifies that the `actual` identity was obfuscated, ie,
+// all the personal data were replaced with UUID values, except a few fields
+func AssertIdentityObfuscated(t require.TestingT, expected, actual *account.Identity) {
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	require.NotEmpty(t, actual.User)
+	assert.Equal(t, expected.ID, actual.ID)
+	// verify that all those fields have a UUID for value (ie, data was obfuscated)
+	for _, field := range []string{
+		actual.Username,
+		*actual.ProfileURL,
+		actual.User.Bio,
+		actual.User.Company,
+		actual.User.Email,
+		actual.User.FullName,
+		actual.User.ImageURL,
+		actual.User.URL,
+		actual.User.Cluster,
+		actual.User.FeatureLevel,
+	} {
+		_, err := uuid.FromString(field)
+		require.NoError(t, err)
+	}
+	// verify other fields
+	assert.Equal(t, expected.UserID, actual.UserID)
+	assert.Equal(t, expected.ProviderType, actual.ProviderType)
+	assert.False(t, actual.User.Active)
+	assert.False(t, actual.User.Deprovisioned)
+	assert.Empty(t, actual.User.ContextInformation)
 }

--- a/test/graph/user_wrapper.go
+++ b/test/graph/user_wrapper.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	account "github.com/fabric8-services/fabric8-auth/authentication/account/repository"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +43,7 @@ func newUserWrapper(g *TestGraph, params []interface{}) interface{} {
 	}
 	w.user = &account.User{
 		ID:           id,
+		Active:       true,
 		Email:        fmt.Sprintf("TestUser-%s@test.com", id),
 		EmailPrivate: emailPrivate,
 		FullName:     fullname,


### PR DESCRIPTION
Added a new `Active` field on the User type (with an
associated column in the DB with default value 'true')

Obfuscate all personal data in the user and identity records,
and mark the user as `active=false`.

Fixes #775