### PR TITLE
contract-tests: Add CICO script for provider side of contract testing.

### DIFF
--- a/cico_run_contract_tests_provider.sh
+++ b/cico_run_contract_tests_provider.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "This is the provider side of the contract testing."
+echo "The script will be filled when https://github.com/fabric8-services/fabric8-auth/pull/711 is merged."


### PR DESCRIPTION
This PR adds an 'empty' `cico_run_contract_tests_provider.sh` CICO script that is executed by the https://ci.centos.org/job/devtools-contract-test-provider-fabric8-wit-fabric8-auth/ Jenkins job.

The script is empty now to prevent the Jenkins job from failing and will be filled once the proper contract test are merged (https://github.com/fabric8-services/fabric8-auth/pull/711).