### PR TITLE
Fix oauth.provider.client.id secret mounting

### DIFF
--- a/openshift/auth.app.yaml
+++ b/openshift/auth.app.yaml
@@ -49,7 +49,7 @@ objects:
               secretKeyRef:
                 name: auth
                 key: db.password
-          - name: AUTH_AUTH_PROVIDER_CLIENT_ID
+          - name: AUTH_OAUTH_PROVIDER_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: auth


### PR DESCRIPTION
Currently because of a bug in our template we do not set client ID env var correctly, so we always use the default value which is "fabric8-platform-online". But we have to fix this altogether with updating the corresponding secret when switching to RHD SSO.

**Should be merged only when we update CM/Secrets to switch to RHD!** If we merge it without updating the secrets then incorrect ID will be used.