### PR TITLE
Add support for last active timestamp for identities

### DIFF
--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -2,6 +2,7 @@ package repository_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/fabric8-services/fabric8-auth/authorization"
 	"github.com/fabric8-services/fabric8-auth/errors"
@@ -379,4 +380,20 @@ func (s *IdentityRepositoryTestSuite) TestRemoveMember() {
 	memberships, err = s.Application.Identities().FindIdentityMemberships(s.Ctx, user.IdentityID(), nil)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), memberships, 0)
+}
+
+func (s *IdentityRepositoryTestSuite) TestTouchLastUpdated() {
+	identity := s.Graph.CreateIdentity()
+
+	require.Nil(s.T(), identity.Identity().LastActive)
+
+	now := time.Now()
+
+	err := s.Application.Identities().TouchLastActive(s.Ctx, identity.ID())
+	require.NoError(s.T(), err)
+
+	// Reload the identity
+	identity = s.Graph.LoadIdentity(identity.ID())
+
+	require.True(s.T(), now.Before(*identity.Identity().LastActive))
 }

--- a/authentication/provider/service/authentication_provider_service.go
+++ b/authentication/provider/service/authentication_provider_service.go
@@ -328,6 +328,13 @@ func (s *authenticationProviderServiceImpl) CreateOrUpdateIdentityAndUser(ctx co
 		"user_name":   identity.Username,
 	}, "local user created/updated")
 
+	// Update the identity's last active timestamp
+	err = s.Repositories().Identities().TouchLastActive(ctx, identity.ID)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{"err": err, "identity_id": identity.ID.String()}, "failed to update last_active timestamp for identity")
+		return nil, nil, err
+	}
+
 	// Generate a new user token instead of using the original oauth provider token
 	userToken, err := tokenManager.GenerateUserTokenForIdentity(ctx, *identity, false)
 	if err != nil {

--- a/authentication/provider/service/authentication_provider_service_blackbox_test.go
+++ b/authentication/provider/service/authentication_provider_service_blackbox_test.go
@@ -1065,6 +1065,8 @@ func (s *authenticationProviderServiceTestSuite) TestCreateOrUpdateIdentityAndUs
 		}, nil
 	}
 
+	now := time.Now()
+
 	// when
 	tm := testtoken.TokenManager
 	ctx := manager.ContextWithTokenManager(context.Background(), tm)
@@ -1083,6 +1085,10 @@ func (s *authenticationProviderServiceTestSuite) TestCreateOrUpdateIdentityAndUs
 	require.NoError(s.T(), err)
 	assert.NotEmpty(s.T(), resultAccessTokenClaims.SessionState)
 	s.T().Logf("token claim `session_state`: %v", resultAccessTokenClaims.SessionState)
+
+	// Confirm that the identity's last active field was updated
+	identity := s.Graph.LoadIdentity(user.IdentityID())
+	require.True(s.T(), now.Before(*identity.Identity().LastActive))
 
 	// Confirm that both an access token and refresh token were created for the user's identity
 	tokens, err := s.Application.TokenRepository().ListForIdentity(s.Ctx, user.IdentityID())

--- a/authorization/token/service/token_service.go
+++ b/authorization/token/service/token_service.go
@@ -497,6 +497,9 @@ func (s *tokenServiceImpl) ExchangeRefreshToken(ctx context.Context, refreshToke
 			return errors.NewInternalError(ctx, err)
 		}
 
+		// Update the identity's last active timestamp
+		s.Repositories().Identities().TouchLastActive(ctx, identity.ID)
+
 		return nil
 	})
 

--- a/authorization/token/service/token_service.go
+++ b/authorization/token/service/token_service.go
@@ -498,7 +498,11 @@ func (s *tokenServiceImpl) ExchangeRefreshToken(ctx context.Context, refreshToke
 		}
 
 		// Update the identity's last active timestamp
-		s.Repositories().Identities().TouchLastActive(ctx, identity.ID)
+		err = s.Repositories().Identities().TouchLastActive(ctx, identity.ID)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{"error": err}, "could not update last active timestamp")
+			return errors.NewInternalError(ctx, err)
+		}
 
 		return nil
 	})

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -242,6 +242,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 44
 	m = append(m, steps{ExecuteSQLFile("044-user-active.sql")})
 
+	// Version 45
+	m = append(m, steps{ExecuteSQLFile("045-identity-last-active.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/045-identity-last-active.sql
+++ b/migration/sql-files/045-identity-last-active.sql
@@ -1,0 +1,1 @@
+ALTER TABLE identities ADD COLUMN last_active timestamp with time zone;


### PR DESCRIPTION
This pull request adds a new timestamp column to the `identities` table:

`ALTER TABLE identities ADD COLUMN last_active timestamp with time zone;`

Upon any of the following the events, this timestamp will be updated to the current time:

- During the authentication process (`authentication_provider_service.go`, in the `CreateOrUpdateIdentityAndUser()` function)
- During refresh token exchange, when a refresh token is exchanged for a renewed access token (in `TokenService.ExchangeRefreshToken()`)
- Upon user logout (in `LogoutService.Logout()`)

Fixes #796