### PR TITLE
List users to deactivate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only neces
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.WITService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService -o ./test/generated/application/service/ -s ".go"
 	@-mkdir -p test/generated/authentication
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
-	@-mkdir -p test/generated/authorization/token/manager
+	@-mkdir -p /test/generated/authentication/account/service
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/account/service.UserServiceConfiguration -o ./test/generated/authentication/account/service -s ".go"
 	@-mkdir -p test/generated/authorization/token/manager
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,8 @@ generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only neces
 	@-mkdir -p test/generated/authentication
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
 	@-mkdir -p test/generated/authorization/token/manager
+	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/account/service.UserServiceConfiguration -o ./test/generated/authentication/account/service -s ".go"
+	@-mkdir -p test/generated/authorization/token/manager
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"
 	@-mkdir -p test/generated/application/service
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService -o ./test/generated/application/service/ -s ".go"

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only neces
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.WITService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService -o ./test/generated/application/service/ -s ".go"
 	@-mkdir -p test/generated/authentication
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
-	@-mkdir -p /test/generated/authentication/account/service
+	@-mkdir -p test/generated/authentication/account/service
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/account/service.UserServiceConfiguration -o ./test/generated/authentication/account/service -s ".go"
 	@-mkdir -p test/generated/authorization/token/manager
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"

--- a/application/service/factory/service_factory.go
+++ b/application/service/factory/service_factory.go
@@ -223,7 +223,7 @@ func NewServiceFactory(producer servicecontext.ServiceContextProducer, config *c
 	}
 	// default function to return an instance of User Service
 	f.userServiceFunc = func() service.UserService {
-		return userservice.NewUserService(f.getContext())
+		return userservice.NewUserService(f.getContext(), f.config)
 	}
 	log.Info(nil, map[string]interface{}{}, "configuring a new service factory with %d option(s)", len(options))
 	// and options

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -155,7 +155,6 @@ type UserProfileService interface {
 }
 
 type UserService interface {
-	ListIdentitiesToDeactivate(ctx context.Context) ([]account.Identity, error)
 	ListIdentitiesToNotifyBeforeDeactivation(ctx context.Context) ([]account.Identity, error)
 	DeactivateUser(ctx context.Context, username string) (*account.Identity, error)
 	BanUser(ctx context.Context, username string) (*account.Identity, error)

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -155,6 +155,8 @@ type UserProfileService interface {
 }
 
 type UserService interface {
+	ListIdentitiesToDeactivate(ctx context.Context) ([]account.Identity, error)
+	ListIdentitiesToNotifyBeforeDeactivation(ctx context.Context) ([]account.Identity, error)
 	DeactivateUser(ctx context.Context, username string) (*account.Identity, error)
 	DeprovisionUser(ctx context.Context, username string) (*account.Identity, error)
 	UserInfo(ctx context.Context, identityID uuid.UUID) (*account.User, *account.Identity, error)

--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -19,7 +19,7 @@ import (
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -130,6 +130,7 @@ type IdentityRepository interface {
 	DeleteForResource(ctx context.Context, resourceID string) error
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Identity, error)
 	List(ctx context.Context) ([]Identity, error)
+	ListIdentitiesToDeactivate(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error)
 	IsValid(context.Context, uuid.UUID) bool
 	Search(ctx context.Context, q string, start int, limit int) ([]Identity, int, error)
 	FindIdentityMemberships(ctx context.Context, identityID uuid.UUID, resourceType *string) ([]authorization.IdentityAssociation, error)
@@ -386,6 +387,25 @@ func (m *GormIdentityRepository) List(ctx context.Context) ([]Identity, error) {
 	}, "Identity List executed successfully!")
 
 	return rows, nil
+}
+
+// ListIdentitiesToDeactivate return identities whose last activity is older than the given one. The result size is limited to the given
+// number of identities (ordered by last activity)
+// if limit is a negative value (eg: '-1'), it is ignored
+func (m *GormIdentityRepository) ListIdentitiesToDeactivate(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "listIdentitiesToDeactivate"}, time.Now())
+	var identities []Identity
+	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between
+	// queries to notify before deactivation and queries to deactivate for real.
+	err := m.db.Model(&Identity{}).Where("last_active < ?", lastActivity).Order("last_active, created_at").Limit(limit).Find(&identities).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, errs.WithStack(err)
+	}
+	log.Debug(ctx, map[string]interface{}{
+		"identities_to_deactivate": len(identities),
+	}, "Listing identities to deactivated completed")
+
+	return identities, nil
 }
 
 // IsValid returns true if the identity exists

--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -130,7 +130,7 @@ type IdentityRepository interface {
 	DeleteForResource(ctx context.Context, resourceID string) error
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Identity, error)
 	List(ctx context.Context) ([]Identity, error)
-	ListIdentitiesToDeactivate(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error)
+	ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error)
 	IsValid(context.Context, uuid.UUID) bool
 	Search(ctx context.Context, q string, start int, limit int) ([]Identity, int, error)
 	FindIdentityMemberships(ctx context.Context, identityID uuid.UUID, resourceType *string) ([]authorization.IdentityAssociation, error)
@@ -389,10 +389,10 @@ func (m *GormIdentityRepository) List(ctx context.Context) ([]Identity, error) {
 	return rows, nil
 }
 
-// ListIdentitiesToDeactivate return identities whose last activity is older than the given one. The result size is limited to the given
+// ListIdentitiesToNotifyForDeactivation return identities whose last activity is older than the given one. The result size is limited to the given
 // number of identities (ordered by last activity)
 // if limit is a negative value (eg: '-1'), it is ignored
-func (m *GormIdentityRepository) ListIdentitiesToDeactivate(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error) {
+func (m *GormIdentityRepository) ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "listIdentitiesToDeactivate"}, time.Now())
 	var identities []Identity
 	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between

--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -132,7 +132,7 @@ func (s *IdentityRepositoryTestSuite) TestLoad() {
 	})
 }
 
-func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
+func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation() {
 
 	ctx := context.Background()
 	now := time.Now()
@@ -140,32 +140,32 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
 	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                          // 1 day since last activity
 
-	s.T().Run("no user to deactivate", func(t *testing.T) {
+	s.T().Run("no user to notify for deactivation", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-90 * 24 * 60 * time.Minute) // 90 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
 		// then
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
 
-	s.T().Run("one user to deactivate", func(t *testing.T) {
+	s.T().Run("one user to notify for deactivation", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-60 * 24 * 60 * time.Minute) // 60 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, identity2.ID(), result[0].ID)
 	})
 
-	s.T().Run("one user to deactivate with limit reached", func(t *testing.T) {
+	s.T().Run("one user to notify for deactivation with limit reached", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * 60 * time.Minute) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 1)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 1)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 1)
@@ -173,11 +173,11 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 
 	})
 
-	s.T().Run("two users to deactivate with limit unreached", func(t *testing.T) {
+	s.T().Run("two users to notify for deactivation with limit unreached", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * 60 * time.Minute) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)
@@ -185,11 +185,11 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity1.ID(), result[1].ID)
 	})
 
-	s.T().Run("two users to deactivate without limit", func(t *testing.T) {
+	s.T().Run("two users to notify for deactivation without limit", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * 60 * time.Minute) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, -1)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, -1)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)

--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -138,7 +138,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 	now := time.Now()
 	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
 	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
-	s.Graph.CreateIdentity(now.Add(-24 * 60 * time.Minute))                   // 1 day since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                          // 1 day since last activity
 
 	s.T().Run("no user to deactivate", func(t *testing.T) {
 		// given

--- a/authentication/account/repository/user_blackbox_test.go
+++ b/authentication/account/repository/user_blackbox_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/jinzhu/gorm"
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -113,13 +113,13 @@ func (s *userServiceImpl) BanUser(ctx context.Context, username string) (*reposi
 }
 
 func (s *userServiceImpl) ListIdentitiesToNotifyBeforeDeactivation(ctx context.Context) ([]repository.Identity, error) {
-	since := time.Now().Add(time.Duration(s.config.GetUserDeactivationInactivityNotificationPeriod()*-1*24*60) * time.Minute) // remove 'n' days from now
+	since := time.Now().Add(time.Duration(-s.config.GetUserDeactivationInactivityNotificationPeriod() * 24) * time.Hour) // remove 'n' days from now
 	limit := s.config.GetUserDeactivationFetchLimit()
 	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, limit)
 }
 
 func (s *userServiceImpl) ListIdentitiesToDeactivate(ctx context.Context) ([]repository.Identity, error) {
-	since := time.Now().Add(time.Duration(s.config.GetUserDeactivationInactivityPeriod()*-1*24*60) * time.Minute) // remove 'n' days from now
+	since := time.Now().Add(time.Duration(-s.config.GetUserDeactivationInactivityPeriod()*-1*24) * time.Hour) // remove 'n' days from now
 	limit := s.config.GetUserDeactivationFetchLimit()
 	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, limit)
 }

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -113,15 +113,9 @@ func (s *userServiceImpl) BanUser(ctx context.Context, username string) (*reposi
 }
 
 func (s *userServiceImpl) ListIdentitiesToNotifyBeforeDeactivation(ctx context.Context) ([]repository.Identity, error) {
-	since := time.Now().Add(time.Duration(-s.config.GetUserDeactivationInactivityNotificationPeriod() * 24) * time.Hour) // remove 'n' days from now
+	since := time.Now().Add(time.Duration(-s.config.GetUserDeactivationInactivityNotificationPeriod()*24) * time.Hour) // remove 'n' days from now
 	limit := s.config.GetUserDeactivationFetchLimit()
-	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, limit)
-}
-
-func (s *userServiceImpl) ListIdentitiesToDeactivate(ctx context.Context) ([]repository.Identity, error) {
-	since := time.Now().Add(time.Duration(-s.config.GetUserDeactivationInactivityPeriod()*-1*24) * time.Hour) // remove 'n' days from now
-	limit := s.config.GetUserDeactivationFetchLimit()
-	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, limit)
+	return s.Repositories().Identities().ListIdentitiesToNotifyForDeactivation(ctx, since, limit)
 }
 
 // DeactivateUser deactivates a user, i.e., mark her as `active=false`, obfuscate the personal info and soft-delete the account

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -323,7 +323,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation()
 	now := time.Now()
 	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
 	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
-	s.Graph.CreateIdentity(now.Add(-24 * 60 * time.Minute))                   // 1 day since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                   // 1 day since last activity
 
 	config := userservicemock.NewUserServiceConfigurationMock(s.T())
 	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
@@ -401,7 +401,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 	now := time.Now()
 	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
 	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
-	s.Graph.CreateIdentity(now.Add(-24 * 60 * time.Minute))                   // 1 day since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                   // 1 day since last activity
 
 	config := userservicemock.NewUserServiceConfigurationMock(s.T())
 	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/fabric8-services/fabric8-auth/application/service/factory"
+
+	userservice "github.com/fabric8-services/fabric8-auth/authentication/account/service"
 	"github.com/fabric8-services/fabric8-auth/authentication/provider"
-
 	"github.com/fabric8-services/fabric8-auth/test/graph"
 
 	"github.com/fabric8-services/fabric8-auth/authorization/token"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testsupport "github.com/fabric8-services/fabric8-auth/test"
+	userservicemock "github.com/fabric8-services/fabric8-auth/test/generated/authentication/account/service"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 	"github.com/fabric8-services/fabric8-common/gocksupport"
 
@@ -31,9 +35,6 @@ type userServiceBlackboxTestSuite struct {
 
 func TestUserService(t *testing.T) {
 	suite.Run(t, &userServiceBlackboxTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
-}
-
-func (s *userServiceBlackboxTestSuite) TestDeprovisionUnknownUserFails() {
 }
 
 func (s *userServiceBlackboxTestSuite) TestDeprovision() {
@@ -311,6 +312,179 @@ func (s *userServiceBlackboxTestSuite) TestShowUserInfoOK() {
 		// then
 		require.Error(t, err)
 		assert.IsType(t, errors.UnauthorizedError{}, errs.Cause(err))
+	})
+
+}
+
+func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation() {
+
+	now := time.Now()
+	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
+	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * 60 * time.Minute))                   // 1 day since last activity
+
+	config := userservicemock.NewUserServiceConfigurationMock(s.T())
+	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
+	ctx := context.Background()
+
+	s.T().Run("no user to deactivate", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() int {
+			return 90
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToNotifyBeforeDeactivation(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	s.T().Run("one user to deactivate", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() int {
+			return 60
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToNotifyBeforeDeactivation(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+	})
+
+	s.T().Run("one user to deactivate with limit reached", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 1
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() int {
+			return 30
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToNotifyBeforeDeactivation(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+
+	})
+
+	s.T().Run("two users to deactivate", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() int {
+			return 30
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToNotifyBeforeDeactivation(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+		assert.Equal(t, identity1.ID(), result[1].ID)
+	})
+
+}
+
+func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
+
+	now := time.Now()
+	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
+	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * 60 * time.Minute))                   // 1 day since last activity
+
+	config := userservicemock.NewUserServiceConfigurationMock(s.T())
+	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
+	ctx := context.Background()
+
+	s.T().Run("no user to deactivate", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityPeriodFunc = func() int {
+			return 90
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	s.T().Run("one user to deactivate", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityPeriodFunc = func() int {
+			return 60
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+	})
+
+	s.T().Run("one user to deactivate with limit reached", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 1
+		}
+		config.GetUserDeactivationInactivityPeriodFunc = func() int {
+			return 30
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+
+	})
+
+	s.T().Run("two users to deactivate with limit unreached", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityPeriodFunc = func() int {
+			return 30
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+		assert.Equal(t, identity1.ID(), result[1].ID)
+	})
+
+	s.T().Run("two users to deactivate without limit", func(t *testing.T) {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return -1
+		}
+		config.GetUserDeactivationInactivityPeriodFunc = func() int {
+			return 30
+		}
+		// when
+		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, identity2.ID(), result[0].ID)
+		assert.Equal(t, identity1.ID(), result[1].ID)
 	})
 
 }

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -323,7 +323,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation()
 	now := time.Now()
 	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
 	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
-	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                   // 1 day since last activity
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                          // 1 day since last activity
 
 	config := userservicemock.NewUserServiceConfigurationMock(s.T())
 	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
@@ -387,101 +387,6 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation()
 		}
 		// when
 		result, err := userSvc.ListIdentitiesToNotifyBeforeDeactivation(ctx)
-		// then
-		require.NoError(t, err)
-		require.Len(t, result, 2)
-		assert.Equal(t, identity2.ID(), result[0].ID)
-		assert.Equal(t, identity1.ID(), result[1].ID)
-	})
-
-}
-
-func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
-
-	now := time.Now()
-	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * 60 * time.Minute)) // 40 days since last activity
-	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * 60 * time.Minute)) // 70 days since last activity
-	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))                   // 1 day since last activity
-
-	config := userservicemock.NewUserServiceConfigurationMock(s.T())
-	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
-	ctx := context.Background()
-
-	s.T().Run("no user to deactivate", func(t *testing.T) {
-		// given
-		config.GetUserDeactivationFetchLimitFunc = func() int {
-			return 100
-		}
-		config.GetUserDeactivationInactivityPeriodFunc = func() int {
-			return 90
-		}
-		// when
-		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
-		// then
-		require.NoError(t, err)
-		assert.Empty(t, result)
-	})
-
-	s.T().Run("one user to deactivate", func(t *testing.T) {
-		// given
-		config.GetUserDeactivationFetchLimitFunc = func() int {
-			return 100
-		}
-		config.GetUserDeactivationInactivityPeriodFunc = func() int {
-			return 60
-		}
-		// when
-		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
-		// then
-		require.NoError(t, err)
-		require.Len(t, result, 1)
-		assert.Equal(t, identity2.ID(), result[0].ID)
-	})
-
-	s.T().Run("one user to deactivate with limit reached", func(t *testing.T) {
-		// given
-		config.GetUserDeactivationFetchLimitFunc = func() int {
-			return 1
-		}
-		config.GetUserDeactivationInactivityPeriodFunc = func() int {
-			return 30
-		}
-		// when
-		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
-		// then
-		require.NoError(t, err)
-		require.Len(t, result, 1)
-		assert.Equal(t, identity2.ID(), result[0].ID)
-
-	})
-
-	s.T().Run("two users to deactivate with limit unreached", func(t *testing.T) {
-		// given
-		config.GetUserDeactivationFetchLimitFunc = func() int {
-			return 100
-		}
-		config.GetUserDeactivationInactivityPeriodFunc = func() int {
-			return 30
-		}
-		// when
-		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
-		// then
-		require.NoError(t, err)
-		require.Len(t, result, 2)
-		assert.Equal(t, identity2.ID(), result[0].ID)
-		assert.Equal(t, identity1.ID(), result[1].ID)
-	})
-
-	s.T().Run("two users to deactivate without limit", func(t *testing.T) {
-		// given
-		config.GetUserDeactivationFetchLimitFunc = func() int {
-			return -1
-		}
-		config.GetUserDeactivationInactivityPeriodFunc = func() int {
-			return 30
-		}
-		// when
-		result, err := userSvc.ListIdentitiesToDeactivate(ctx)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -178,6 +178,18 @@ const (
 
 	//------------------------------------------------------------------------------------------------------------------
 	//
+	// User deactivation
+	//
+	//------------------------------------------------------------------------------------------------------------------
+	// varUserDeactivationFetchLimit the maximum number of identities to warn before deactivation and deactivate
+	varUserDeactivationFetchLimit = "user.deactivation.fetch.limit"
+	// varUserDeactivationInactivityPeriodNotification the number of days of inactivity before notifying the user of account deactivation
+	varUserDeactivationInactivityNotificationPeriod = "user.deactivation.inactivity.notification.period"
+	// varUserDeactivationInactivityPeriod the number of days of inactivity before deactivating the user account
+	varUserDeactivationInactivityPeriod = "user.deactivation.inactivity.period"
+
+	//------------------------------------------------------------------------------------------------------------------
+	//
 	// Other
 	//
 	//------------------------------------------------------------------------------------------------------------------
@@ -635,6 +647,12 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Cluster service
 	c.v.SetDefault(varShortClusterServiceURL, "http://f8cluster")
 	c.v.SetDefault(varClusterRefreshInterval, 5*time.Minute) // 5 minutes
+
+	// User deactivation
+	c.v.SetDefault(varUserDeactivationFetchLimit, defaultUserDeactivationFetchLimit)
+	c.v.SetDefault(varUserDeactivationInactivityNotificationPeriod, defaultUserDeactivationInactivityNotificationPeriod)
+	c.v.SetDefault(varUserDeactivationInactivityPeriod, defaultUserDeactivationInactivityPeriod)
+
 }
 
 // GetEmailVerifiedRedirectURL returns the url where the user would be redirected to after clicking on email
@@ -1031,4 +1049,19 @@ func (c *ConfigurationData) GetRPTTokenMaxPermissions() int {
 
 func (c *ConfigurationData) GetExpiredTokenRetentionHours() int {
 	return c.v.GetInt(varExpiredTokenRetentionHours)
+}
+
+// GetUserDeactivationFetchLimit returns the max/limit number of user accounts to deactivate during a worker call
+func (c *ConfigurationData) GetUserDeactivationFetchLimit() int {
+	return c.v.GetInt(varUserDeactivationFetchLimit)
+}
+
+// GetUserDeactivationInactivityNotificationPeriod returns the number of days of inactivity before notifying the user of the imminent account deactivation
+func (c *ConfigurationData) GetUserDeactivationInactivityNotificationPeriod() int {
+	return c.v.GetInt(varUserDeactivationInactivityNotificationPeriod)
+}
+
+// GetUserDeactivationInactivityPeriod returns the number of days of inactivity before a user account can be deactivated
+func (c *ConfigurationData) GetUserDeactivationInactivityPeriod() int {
+	return c.v.GetInt(varUserDeactivationInactivityPeriod)
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -117,7 +117,7 @@ vwIDAQAB
 	// defaultUserDeactivationFetchLimit the default number of accounts to return when fetching the users to deactivate (and deactivate at once)
 	defaultUserDeactivationFetchLimit = 10
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
-	defaultUserDeactivationInactivityNotificationPeriod = 30 // 30 days
+	defaultUserDeactivationInactivityNotificationPeriod = 24 // 24 days
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
-	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 7 // 37 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
+	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 7 // 31 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
 )

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -119,5 +119,5 @@ vwIDAQAB
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
 	defaultUserDeactivationInactivityNotificationPeriod = 30 // 30 days
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
-	defaultUserDeactivationInactivityPeriod = 37 // 30 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
+	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 7 // 37 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
 )

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -113,4 +113,11 @@ vwIDAQAB
 
 	// The number of hours to retain expired tokens.  After this time limit has been exceeded, the token may be cleaned up (deleted)
 	defaultExpiredTokenRetentionHours = 24
+
+	// defaultUserDeactivationFetchLimit the default number of accounts to return when fetching the users to deactivate (and deactivate at once)
+	defaultUserDeactivationFetchLimit = 10
+	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
+	defaultUserDeactivationInactivityNotificationPeriod = 30 // 30 days
+	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
+	defaultUserDeactivationInactivityPeriod = 37 // 30 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
 )

--- a/test/graph/identity_wrapper.go
+++ b/test/graph/identity_wrapper.go
@@ -1,8 +1,10 @@
 package graph
 
 import (
+	"time"
+
 	account "github.com/fabric8-services/fabric8-auth/authentication/account/repository"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,10 +28,17 @@ func loadIdentityWrapper(g *TestGraph, identityID uuid.UUID) identityWrapper {
 
 func newIdentityWrapper(g *TestGraph, params []interface{}) interface{} {
 	w := identityWrapper{baseWrapper: baseWrapper{g}}
-
+	var lastActive *time.Time
+	for _, p := range params {
+		switch p := p.(type) {
+		case time.Time:
+			lastActive = &p
+		}
+	}
 	w.identity = &account.Identity{
 		Username:     "TestUserIdentity-" + uuid.NewV4().String(),
 		ProviderType: account.DefaultIDP,
+		LastActive:   lastActive,
 	}
 
 	err := g.app.Identities().Create(g.ctx, w.identity)


### PR DESCRIPTION
user service exposes 2 new methods to:
- list the users to notify before deactivation
- list the users accounts to deactivate for good

the inativity period before notifying and deactiving
are expressed in days and configurable
also, the number of number of identities to retrieve
can be limited (or use '-1' to remove any limit)

Fixes #ODC180