### PR TITLE
reset deactivation notification timestamp on user activity

### DIFF
--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -880,11 +880,12 @@ WHERE
 }
 
 // TouchLastActive is intended to be a lightweight method that updates the last active column for a specified identity
-// to the current timestamp
+// to the current timestamp. Also, it resets the `deactivation_notification` timestamp so we can send another deactivation
+// notification to the user if she is once again inactive in the future.
 func (m *GormIdentityRepository) TouchLastActive(ctx context.Context, identityID uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity", "TouchLastActive"}, time.Now())
 
-	err := m.db.Exec("UPDATE identities SET last_active = ? WHERE id = ?", time.Now(), identityID).Error
+	err := m.db.Exec("UPDATE identities SET last_active = ?, deactivation_notification = NULL WHERE id = ?", time.Now(), identityID).Error
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"id":  identityID,

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -553,7 +553,7 @@ func testMigration46(t *testing.T) {
 	defaultTime, err = time.Parse("2006-01-02:03:04:05", "2019-03-11:12:34:56")
 	require.NoError(t, err)
 	assert.Equal(t, defaultTime, lastActive)
-	// also, when a new record is inserted, its `last_activity` should not be NULL
+	// also, when a new record is inserted, its `last_active` should not be NULL
 	_, err = sqlDB.Exec("insert into identities (id) values ('00000000-0000-0000-0000-000000000003')")
 	require.NoError(t, err)
 	err = sqlDB.QueryRow("SELECT last_active FROM identities WHERE id = '00000000-0000-0000-0000-000000000003'").Scan(&lastActive)


### PR DESCRIPTION
done when "touching" the user's "last active" field

fixes #ODC217
