### PR TITLE
exclude already-banned users from deactivation

### DIFF
--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -134,16 +134,40 @@ func (s *IdentityRepositoryTestSuite) TestLoad() {
 
 func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation() {
 
+	// given
 	ctx := context.Background()
 	now := time.Now()
-	identity1 := s.Graph.CreateIdentity(now.Add(-40 * 24 * time.Hour)).Identity() // 40 days since last activity
-	identity2 := s.Graph.CreateIdentity(now.Add(-70 * 24 * time.Hour)).Identity() // 70 days since last activity
-	identity3 := s.Graph.CreateIdentity(now.Add(-70 * 24 * time.Hour)).Identity() // noise: 70 day since last activity, but already notified
 	yesterday := now.Add(-1 * 24 * time.Hour)
-	identity3.DeactivationNotification = &yesterday
-	err := s.Application.Identities().Save(ctx, identity3)
+	ago65days := now.Add(-65 * 24 * time.Hour) // 65 days since last activity and notified...
+	ago40days := now.Add(-40 * 24 * time.Hour) // 40 days since last activity and notified...
+	ago70days := now.Add(-70 * 24 * time.Hour) // 70 days since last activity and notified...
+	// user/identity1: 40 days since last activity and not notified
+	user1 := s.Graph.CreateUser().User()
+	identity1 := user1.Identities[0]
+	identity1.LastActive = &ago40days
+	err := s.Application.Identities().Save(ctx, &identity1)
 	require.NoError(s.T(), err)
-	s.Graph.CreateIdentity(now.Add(-24 * time.Hour)) // noise: 1 day since last activity
+	// user/identity2: 70 days since last activity and not notified
+	user2 := s.Graph.CreateUser().User()
+	identity2 := user2.Identities[0]
+	identity2.LastActive = &ago70days
+	err = s.Application.Identities().Save(ctx, &identity2)
+	require.NoError(s.T(), err)
+	// noise: user/identity: 1 day since last activity and not notified yet
+	user3 := s.Graph.CreateUser().User()
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))
+	identity3 := user3.Identities[0]
+	identity3.LastActive = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity3)
+	require.NoError(s.T(), err)
+	// noise: user/identity: 65 days since last activity but banned
+	user4 := s.Graph.CreateUser().User()
+	identity4 := user4.Identities[0]
+	identity4.LastActive = &ago65days
+	err = s.Application.Identities().Save(ctx, &identity4)
+	require.NoError(s.T(), err)
+	user4.Banned = true
+	err = s.Application.Users().Save(ctx, user4)
 
 	s.T().Run("no user to notify for deactivation", func(t *testing.T) {
 		// given
@@ -175,7 +199,6 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, identity2.ID, result[0].ID)
-
 	})
 
 	s.T().Run("two users to notify for deactivation with limit unreached", func(t *testing.T) {
@@ -195,6 +218,103 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
 		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, -1)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, identity2.ID, result[0].ID)
+		assert.Equal(t, identity1.ID, result[1].ID)
+	})
+
+}
+
+func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
+	// given
+	ctx := context.Background()
+	now := time.Now()
+	yesterday := now.Add(-1 * 24 * time.Hour)
+	ago65days := now.Add(-65 * 24 * time.Hour) // 65 days since last activity and notified...
+	ago40days := now.Add(-40 * 24 * time.Hour) // 40 days since last activity and notified...
+	ago70days := now.Add(-70 * 24 * time.Hour) // 70 days since last activity and notified...
+	// user/identity1: 40 days since last activity and notified
+	user1 := s.Graph.CreateUser().User()
+	identity1 := user1.Identities[0]
+	identity1.LastActive = &ago40days
+	identity1.DeactivationNotification = &yesterday
+	err := s.Application.Identities().Save(ctx, &identity1)
+	require.NoError(s.T(), err)
+	// user/identity2: 70 days since last activity and notified
+	user2 := s.Graph.CreateUser().User()
+	identity2 := user2.Identities[0]
+	identity2.LastActive = &ago70days
+	identity2.DeactivationNotification = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity2)
+	require.NoError(s.T(), err)
+	// noise: user/identity: 1 day since last activity and not notified yet
+	user3 := s.Graph.CreateUser().User()
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))
+	identity3 := user3.Identities[0]
+	identity3.LastActive = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity3)
+	require.NoError(s.T(), err)
+	// noise: user/identity: 65 days since last activity and notified, but also banned
+	user4 := s.Graph.CreateUser().User()
+	identity4 := user4.Identities[0]
+	identity4.LastActive = &ago65days
+	identity4.DeactivationNotification = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity4)
+	require.NoError(s.T(), err)
+	user4.Banned = true
+	err = s.Application.Users().Save(ctx, user4)
+
+	s.T().Run("no user to notify for deactivation", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-90 * 24 * time.Hour) // 90 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	s.T().Run("one user to notify for deactivation", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-60 * 24 * time.Hour) // 60 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID, result[0].ID)
+	})
+
+	s.T().Run("one user to notify for deactivation with limit reached", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 1)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, identity2.ID, result[0].ID)
+	})
+
+	s.T().Run("two users to notify for deactivation with limit unreached", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, 100)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, identity2.ID, result[0].ID)
+		assert.Equal(t, identity1.ID, result[1].ID)
+	})
+
+	s.T().Run("two users to notify for deactivation without limit", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToDeactivate(ctx, lastActivity, -1)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)

--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -168,6 +168,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 	require.NoError(s.T(), err)
 	user4.Banned = true
 	err = s.Application.Users().Save(ctx, user4)
+	require.NoError(s.T(), err)
 
 	s.T().Run("no user to notify for deactivation", func(t *testing.T) {
 		// given
@@ -265,6 +266,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 	require.NoError(s.T(), err)
 	user4.Banned = true
 	err = s.Application.Users().Save(ctx, user4)
+	require.NoError(s.T(), err)
 
 	s.T().Run("no user to notify for deactivation", func(t *testing.T) {
 		// given

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -52,19 +52,42 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation()
 		return 500 * time.Millisecond
 	}
 
-	var identity1, identity2, identity3 *repository.Identity
+	var identity1, identity2, identity3 repository.Identity
 	// configure the `SetupSubtest` and `TearDownSubtest` to setup/reset data after each subtest
 	s.SetupSubtest = func() {
 		s.CleanTest = testsuite.DeleteCreatedEntities(s.DB, s.Configuration)
 		now := time.Now()
-		identity1 = s.Graph.CreateIdentity("user1", now.Add(-40*24*time.Hour)).Identity() // 40 days since last activity
-		identity2 = s.Graph.CreateIdentity("user2", now.Add(-70*24*time.Hour)).Identity() // 70 days since last activity
-		identity3 = s.Graph.CreateIdentity("user3", now.Add(-70*24*time.Hour)).Identity() // noise: 70 day since last activity, but already notified
 		yesterday := now.Add(-1 * 24 * time.Hour)
-		identity3.DeactivationNotification = &yesterday
-		err := s.Application.Identities().Save(ctx, identity3)
+		ago65days := now.Add(-65 * 24 * time.Hour) // 65 days since last activity and notified...
+		ago40days := now.Add(-40 * 24 * time.Hour) // 40 days since last activity and notified...
+		ago70days := now.Add(-70 * 24 * time.Hour) // 70 days since last activity and notified...
+		// user/identity1: 40 days since last activity and not notified
+		user1 := s.Graph.CreateUser().User()
+		identity1 = user1.Identities[0]
+		identity1.LastActive = &ago40days
+		err := s.Application.Identities().Save(ctx, &identity1)
 		require.NoError(s.T(), err)
-		s.Graph.CreateIdentity("user4", now.Add(-24*time.Hour)) // noise: 1 day since last activity
+		// user/identity2: 70 days since last activity and not notified
+		user2 := s.Graph.CreateUser().User()
+		identity2 = user2.Identities[0]
+		identity2.LastActive = &ago70days
+		err = s.Application.Identities().Save(ctx, &identity2)
+		require.NoError(s.T(), err)
+		// noise: user/identity: 1 day since last activity and not notified yet
+		user3 := s.Graph.CreateUser().User()
+		s.Graph.CreateIdentity(now.Add(-24 * time.Hour))
+		identity3 = user3.Identities[0]
+		identity3.LastActive = &yesterday
+		err = s.Application.Identities().Save(ctx, &identity3)
+		require.NoError(s.T(), err)
+		// noise: user/identity: 65 days since last activity but banned
+		user4 := s.Graph.CreateUser().User()
+		identity4 := user4.Identities[0]
+		identity4.LastActive = &ago65days
+		err = s.Application.Identities().Save(ctx, &identity4)
+		require.NoError(s.T(), err)
+		user4.Banned = true
+		err = s.Application.Users().Save(ctx, user4)
 	}
 
 	s.TearDownSubtest = func() {
@@ -219,19 +242,41 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 		return 31 * 24 * time.Hour // 31 days
 	}
 	ctx := context.Background()
-
 	now := time.Now()
-	identity1 := s.Graph.CreateIdentity("user1", now.Add(-40*24*time.Hour)).Identity() // 40 days since last activity
 	yesterday := now.Add(-1 * 24 * time.Hour)
+	ago65days := now.Add(-65 * 24 * time.Hour) // 65 days since last activity and notified...
+	ago40days := now.Add(-40 * 24 * time.Hour) // 40 days since last activity and notified...
+	ago70days := now.Add(-70 * 24 * time.Hour) // 70 days since last activity and notified...
+	// user/identity1: 40 days since last activity and notified
+	user1 := s.Graph.CreateUser().User()
+	identity1 := user1.Identities[0]
+	identity1.LastActive = &ago40days
 	identity1.DeactivationNotification = &yesterday
-	err := s.Application.Identities().Save(ctx, identity1)
+	err := s.Application.Identities().Save(ctx, &identity1)
 	require.NoError(s.T(), err)
-	identity2 := s.Graph.CreateIdentity("user2", now.Add(-70*24*time.Hour)).Identity() // 70 days since last activity
+	// user/identity2: 70 days since last activity and notified
+	user2 := s.Graph.CreateUser().User()
+	identity2 := user2.Identities[0]
+	identity2.LastActive = &ago70days
 	identity2.DeactivationNotification = &yesterday
-	err = s.Application.Identities().Save(ctx, identity2)
+	err = s.Application.Identities().Save(ctx, &identity2)
 	require.NoError(s.T(), err)
-	s.Graph.CreateIdentity("user3", now.Add(-70*24*time.Hour)).Identity() // noise: 70 day since last activity, but not notified yet
-	s.Graph.CreateIdentity("user4", now.Add(-24*time.Hour))               // noise: 1 day since last activity
+	// noise: user/identity: 1 day since last activity and not notified yet
+	user3 := s.Graph.CreateUser().User()
+	s.Graph.CreateIdentity(now.Add(-24 * time.Hour))
+	identity3 := user3.Identities[0]
+	identity3.LastActive = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity3)
+	require.NoError(s.T(), err)
+	// noise: user/identity: 65 days since last activity and notified, but also banned
+	user4 := s.Graph.CreateUser().User()
+	identity4 := user4.Identities[0]
+	identity4.LastActive = &ago65days
+	identity4.DeactivationNotification = &yesterday
+	err = s.Application.Identities().Save(ctx, &identity4)
+	require.NoError(s.T(), err)
+	user4.Banned = true
+	err = s.Application.Users().Save(ctx, user4)
 
 	s.Run("no user to deactivate", func() {
 		// given

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -88,6 +88,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToNotifyBeforeDeactivation()
 		require.NoError(s.T(), err)
 		user4.Banned = true
 		err = s.Application.Users().Save(ctx, user4)
+		require.NoError(s.T(), err)
 	}
 
 	s.TearDownSubtest = func() {
@@ -277,6 +278,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 	require.NoError(s.T(), err)
 	user4.Banned = true
 	err = s.Application.Users().Save(ctx, user4)
+	require.NoError(s.T(), err)
 
 	s.Run("no user to deactivate", func() {
 		// given

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -253,6 +253,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 48
 	m = append(m, steps{ExecuteSQLFile("048-identity-deactivation-notification.sql")})
 
+	// Version 49
+	m = append(m, steps{ExecuteSQLFile("049-user-banned-index.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/049-user-banned-index.sql
+++ b/migration/sql-files/049-user-banned-index.sql
@@ -1,0 +1,2 @@
+-- index users on the 'banned' column to avoid fetching banned users during deactivation notification/execution
+CREATE INDEX users_banned on users using btree (banned);

--- a/test/graph/user_wrapper.go
+++ b/test/graph/user_wrapper.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"fmt"
 
+	"github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	account "github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func newUserWrapper(g *TestGraph, params []interface{}) interface{} {
 			UUID:  w.user.ID,
 			Valid: true},
 	}
-
+	w.user.Identities = []repository.Identity{*w.identity}
 	err = g.app.Identities().Create(g.ctx, w.identity)
 	require.NoError(g.t, err)
 


### PR DESCRIPTION
no need to notify and later deactivate users who
were already banned. Even more, their accounts
MUST remain intact, so we can keep a trace of their
ban and prevent them from joining again.

Fixes #ODC359

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>