### PR TITLE
service method to call Openshift reg app to deactivare a user

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -100,6 +100,7 @@ type OrganizationService interface {
 
 type OSOSubscriptionService interface {
 	LoadOSOSubscriptionStatus(ctx context.Context, token oauth2.Token) (string, error)
+	DeactivateUser(ctx context.Context, username string) error
 }
 
 type PermissionService interface {

--- a/authentication/subscription/service/oso_subscription_service.go
+++ b/authentication/subscription/service/oso_subscription_service.go
@@ -179,15 +179,15 @@ func (s *osoSubscriptionServiceImpl) loadSubscriptions(ctx context.Context, user
 	return &sbs, nil
 }
 
-// DeactivateUser deactivates the user on OpenShift
+// DeactivateUser deactivates the user on OpenShift Online
 func (s *osoSubscriptionServiceImpl) DeactivateUser(ctx context.Context, username string) error {
 	// Load status from OSO
 	regAppURL := fmt.Sprintf("%s/api/accounts/%s/deprovision_osio?authorization_username=%s",
 		s.config.GetOSORegistrationAppURL(), username, s.config.GetOSORegistrationAppAdminUsername())
 	log.Debug(ctx, map[string]interface{}{
-		"url": regAppURL,
-	}, "calling remote registration application to check the user status")
-	req, err := http.NewRequest("GET", regAppURL, nil)
+		"reg_app_url": regAppURL,
+	}, "calling remote registration application to deactivate user")
+	req, err := http.NewRequest("POST", regAppURL, nil)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err":         err.Error(),
@@ -207,7 +207,7 @@ func (s *osoSubscriptionServiceImpl) DeactivateUser(ctx context.Context, usernam
 	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotFound {
 		log.Error(ctx, map[string]interface{}{
 			"reg_app_url":     regAppURL,
 			"response_status": res.Status,

--- a/authentication/subscription/service/oso_subscription_service.go
+++ b/authentication/subscription/service/oso_subscription_service.go
@@ -170,10 +170,50 @@ func (s *osoSubscriptionServiceImpl) loadSubscriptions(ctx context.Context, user
 		log.Error(ctx, map[string]interface{}{
 			"err":         err,
 			"reg_app_url": regAppURL,
+			"username":    username,
 			"body":        bodyString,
 		}, "unable to unmarshal json with subscription status")
 		return nil, autherrors.NewInternalError(ctx, err)
 	}
 
 	return &sbs, nil
+}
+
+// DeactivateUser deactivates the user on OpenShift
+func (s *osoSubscriptionServiceImpl) DeactivateUser(ctx context.Context, username string) error {
+	// Load status from OSO
+	regAppURL := fmt.Sprintf("%s/api/accounts/%s/deprovision_osio?authorization_username=%s",
+		s.config.GetOSORegistrationAppURL(), username, s.config.GetOSORegistrationAppAdminUsername())
+	log.Debug(ctx, map[string]interface{}{
+		"url": regAppURL,
+	}, "calling remote registration application to check the user status")
+	req, err := http.NewRequest("GET", regAppURL, nil)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":         err.Error(),
+			"reg_app_url": regAppURL,
+		}, "unable to create http request")
+		return errs.Wrapf(err, "unable to deprovision user")
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.config.GetOSORegistrationAppAdminToken()))
+	res, err := s.httpClient.Do(req)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":         err.Error(),
+			"reg_app_url": regAppURL,
+		}, "unable to deprovision user")
+		return errs.Wrapf(err, "unable to deprovision user")
+	}
+	defer rest.CloseResponse(res)
+	bodyString := rest.ReadBody(res.Body)
+
+	if res.StatusCode != http.StatusOK {
+		log.Error(ctx, map[string]interface{}{
+			"reg_app_url":     regAppURL,
+			"response_status": res.Status,
+			"response_body":   bodyString,
+		}, "unable to deprovision user")
+		return errs.Errorf("unable to deprovision user")
+	}
+	return nil
 }

--- a/authentication/subscription/service/oso_subscription_service_blackbox_test.go
+++ b/authentication/subscription/service/oso_subscription_service_blackbox_test.go
@@ -295,22 +295,36 @@ func (s *osoSubscriptionServiceTestSuite) TestDeactivateUser() {
 	gock.Observe(gock.DumpRequest)
 
 	s.Run("success", func() {
-		username := uuid.NewV4().String()
-		gock.New(config.GetOSORegistrationAppURL()).
-			Get(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
-			MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
-			MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
-			Reply(200)
-		// when
-		err := svc.DeactivateUser(context.Background(), username)
-		// then
-		require.NoError(s.T(), err)
+		s.Run("ok", func() {
+			username := fmt.Sprintf("user-%s", uuid.NewV4())
+			gock.New(config.GetOSORegistrationAppURL()).
+				Post(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
+				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
+				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
+				Reply(200)
+			// when
+			err := svc.DeactivateUser(context.Background(), username)
+			// then
+			require.NoError(s.T(), err)
+		})
+		s.Run("not found", func() {
+			username := fmt.Sprintf("user-%s", uuid.NewV4())
+			gock.New(config.GetOSORegistrationAppURL()).
+				Post(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
+				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
+				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
+				Reply(404)
+			// when
+			err := svc.DeactivateUser(context.Background(), username)
+			// then
+			require.NoError(s.T(), err)
+		})
 	})
 
 	s.Run("failure", func() {
 
 		s.Run("should return an error if the client returns any status but 200", func() {
-			username := uuid.NewV4().String()
+			username := fmt.Sprintf("user-%s", uuid.NewV4())
 			gock.New(config.GetOSORegistrationAppURL()).
 				Get(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
 				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).


### PR DESCRIPTION
Add a method to call the deactivation (aka "deprovision") endpoint on the OpenShift registration app.

fixes #ODC483

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
