### PR TITLE
Fix TestAuthenticationProviderService/TestInvalidOAuthAuthorizationCode test failure

### DIFF
--- a/authentication/provider/service/authentication_provider_service.go
+++ b/authentication/provider/service/authentication_provider_service.go
@@ -7,11 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	token2 "github.com/fabric8-services/fabric8-auth/authorization/token"
 	"net/url"
 	"regexp"
 	"strconv"
 	"time"
+
+	token2 "github.com/fabric8-services/fabric8-auth/authorization/token"
 
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application/service"
@@ -26,7 +27,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/rest"
 	errs "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -132,7 +133,7 @@ func (s *authenticationProviderServiceImpl) LoginCallback(ctx context.Context, s
 
 	providerToken, err := s.ExchangeCodeWithProvider(ctx, code, redirectURL)
 	if err != nil {
-		redirect := referrerURL.String() + "?error=" + err.Error()
+		redirect := referrerURL.String() + "?error=" + url.QueryEscape(err.Error())
 		return &redirect, err
 	}
 

--- a/authentication/provider/service/authentication_provider_service_blackbox_test.go
+++ b/authentication/provider/service/authentication_provider_service_blackbox_test.go
@@ -46,7 +46,7 @@ type authenticationProviderServiceTestSuite struct {
 	oauth provider.IdentityProvider
 }
 
-func TestAuthenticationProviderServiceBlackBox(t *testing.T) {
+func TestAuthenticationProviderService(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, &authenticationProviderServiceTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
 }
@@ -481,8 +481,10 @@ func (s *authenticationProviderServiceTestSuite) TestInvalidOAuthAuthorizationCo
 		*callbackCtx.Code, rest.AbsoluteURL(callbackCtx.RequestData, client.CallbackLoginPath(), nil))
 	require.Error(s.T(), err)
 
+	s.T().Logf("redirect URL: '%s'", *redirectUrl)
+	s.T().Logf("error: '%v'", err)
 	locationUrl, err = url.Parse(*redirectUrl)
-	require.Nil(s.T(), err)
+	require.NoError(s.T(), err)
 
 	allQueryParameters = locationUrl.Query()
 


### PR DESCRIPTION
"escape" the error message which is returned in the query param of the redirect URL

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
