### PR TITLE
Enable user deactivation

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -167,7 +167,7 @@ test-integration-with-coverage: prebuild-check clean-coverage-integration migrat
 test-integration: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	AUTH_DEVELOPER_MODE_ENABLED=1 AUTH_USER_DEACTIVATION_TESTING_MODE=FALSE AUTH_RESOURCE_DATABASE=1 AUTH_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_INTEGRATION_FLAG) -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	AUTH_DEVELOPER_MODE_ENABLED=1 AUTH_RESOURCE_DATABASE=1 AUTH_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_INTEGRATION_FLAG) -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 test-integration-benchmark: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running benchmarks: $@")

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -39,7 +38,6 @@ type UserServiceConfiguration interface {
 	GetUserDeactivationInactivityNotificationPeriodDays() time.Duration
 	GetUserDeactivationInactivityPeriodDays() time.Duration
 	GetPostDeactivationNotificationDelayMillis() time.Duration
-	GetUserDeactivationTestingMode() bool
 }
 
 // userServiceImpl implements the UserService to manage users
@@ -198,27 +196,7 @@ func (s *userServiceImpl) ListIdentitiesToDeactivate(ctx context.Context, now fu
 	notification := now().Add(s.config.GetUserDeactivationInactivityNotificationPeriodDays() - s.config.GetUserDeactivationInactivityPeriodDays()) // make sure that the notification was sent at least `n` days earlier (default: 7)
 	limit := s.config.GetUserDeactivationFetchLimit()
 
-	if s.config.GetUserDeactivationTestingMode() {
-		return s.filterUsersForTesting(s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, notification, limit))
-	}
-
 	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, notification, limit)
-}
-
-func (s *userServiceImpl) filterUsersForTesting(identities []repository.Identity, err error) ([]repository.Identity, error) {
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]repository.Identity, 0)
-
-	for _, id := range identities {
-		if strings.HasPrefix(id.User.Email, "sbryzak+preview") {
-			ids = append(ids, id)
-		}
-	}
-
-	return ids, nil
 }
 
 func (s *userServiceImpl) notifyIdentityBeforeDeactivation(ctx context.Context, identity repository.Identity, expirationDate string, now func() time.Time) error {

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -55,9 +55,6 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 	config.GetPostDeactivationNotificationDelayMillisFunc = func() time.Duration {
 		return 5 * time.Millisecond
 	}
-	config.GetUserDeactivationTestingModeFunc = func() bool {
-		return false
-	}
 	now := time.Now() // make sure we use the same 'now' everywhere in the test
 	nowf := func() time.Time {
 		return now
@@ -276,9 +273,6 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 	config.GetUserDeactivationInactivityPeriodDaysFunc = func() time.Duration {
 		return 31 * 24 * time.Hour // 31 days
 	}
-	config.GetUserDeactivationTestingModeFunc = func() bool {
-		return false
-	}
 	ctx := context.Background()
 	yesterday := time.Now().Add(-1 * 24 * time.Hour)
 	ago10days := time.Now().Add(-10 * 24 * time.Hour)
@@ -414,9 +408,6 @@ func (s *userServiceBlackboxTestSuite) TestUserDeactivationFlow() {
 	}
 	config.GetPostDeactivationNotificationDelayMillisFunc = func() time.Duration {
 		return 5 * time.Millisecond
-	}
-	config.GetUserDeactivationTestingModeFunc = func() bool {
-		return false
 	}
 	ctx := context.Background()
 	yesterday := time.Now().Add(-1 * 24 * time.Hour)

--- a/authentication/account/worker/user_deactivation_worker.go
+++ b/authentication/account/worker/user_deactivation_worker.go
@@ -43,7 +43,7 @@ type userDeactivationWorker struct {
 func (w *userDeactivationWorker) deactivateUsers() {
 	log.Debug(w.Ctx, map[string]interface{}{
 		"owner": w.Owner,
-	}, "starting cycle of inactive users deactivations")
+	}, "starting cycle of inactive users deactivation")
 	// user service has the config settings to limit the number of users to deactivate
 	identities, err := w.App.UserService().ListIdentitiesToDeactivate(w.Ctx, time.Now)
 	if err != nil {
@@ -69,5 +69,5 @@ func (w *userDeactivationWorker) deactivateUsers() {
 	log.Debug(w.Ctx, map[string]interface{}{
 		"identities": len(identities),
 		"owner":      w.Owner,
-	}, "ending cycle of inactive users deactivations")
+	}, "ending cycle of inactive users deactivation")
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1098,12 +1098,12 @@ func (c *ConfigurationData) GetUserDeactivationFetchLimit() int {
 
 // GetUserDeactivationInactivityNotificationPeriodDays returns the number of days of inactivity before notifying the user of the imminent account deactivation
 func (c *ConfigurationData) GetUserDeactivationInactivityNotificationPeriodDays() time.Duration {
-	return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityNotificationPeriodDays)) * 24 * time.Hour
+	return time.Duration(c.v.GetInt(varUserDeactivationInactivityNotificationPeriodDays)) * 24 * time.Hour
 }
 
 // GetUserDeactivationInactivityPeriodDays returns the number of days of inactivity before a user account can be deactivated
 func (c *ConfigurationData) GetUserDeactivationInactivityPeriodDays() time.Duration {
-	return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityPeriodDays)) * 24 * time.Hour
+	return time.Duration(c.v.GetInt(varUserDeactivationInactivityPeriodDays)) * 24 * time.Hour
 }
 
 // GetPostDeactivationNotificationDelayMillis returns the number of milliseconds to wait after notifying another user that her account may be deactivated

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -198,9 +198,6 @@ const (
 	// varPostDeactivationNotificationDelayMillis the delay (in milliseconds) between 2 account deactivation notifications sent to users
 	varPostDeactivationNotificationDelayMillis = "user.deactivation.post.notification.delay.millis"
 
-	// For testing user deactivation
-	varUserDeactivationTestingMode = "user.deactivation.testing.mode"
-
 	//------------------------------------------------------------------------------------------------------------------
 	//
 	// Other
@@ -675,8 +672,6 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varUserDeactivationWorkerIntervalSeconds, defaultUserDeactivationWorkerIntervalSeconds)
 	c.v.SetDefault(varUserDeactivationNotificationWorkerIntervalSeconds, defaultUserDeactivationNotificationWorkerIntervalSeconds)
 
-	c.v.SetDefault(varUserDeactivationTestingMode, defaultUserDeactivationTestingMode)
-
 	// Che
 	c.v.SetDefault(varCheServiceURL, defaultCheServiceURL)
 
@@ -1103,14 +1098,12 @@ func (c *ConfigurationData) GetUserDeactivationFetchLimit() int {
 
 // GetUserDeactivationInactivityNotificationPeriodDays returns the number of days of inactivity before notifying the user of the imminent account deactivation
 func (c *ConfigurationData) GetUserDeactivationInactivityNotificationPeriodDays() time.Duration {
-	//return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityNotificationPeriodDays)) * 24 * time.Hour
-	return time.Minute * 30
+	return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityNotificationPeriodDays)) * 24 * time.Hour
 }
 
 // GetUserDeactivationInactivityPeriodDays returns the number of days of inactivity before a user account can be deactivated
 func (c *ConfigurationData) GetUserDeactivationInactivityPeriodDays() time.Duration {
-	//return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityPeriodDays)) * 24 * time.Hour
-	return time.Minute * 60
+	return time.Duration(c.v.GetFloat64(varUserDeactivationInactivityPeriodDays)) * 24 * time.Hour
 }
 
 // GetPostDeactivationNotificationDelayMillis returns the number of milliseconds to wait after notifying another user that her account may be deactivated
@@ -1128,8 +1121,4 @@ func (c *ConfigurationData) GetUserDeactivationWorkerIntervalSeconds() time.Dura
 // GetUserDeactivationNotificationWorkerIntervalSeconds returns the interval between 2 cycles of the user deactivation notification worker.
 func (c *ConfigurationData) GetUserDeactivationNotificationWorkerIntervalSeconds() time.Duration {
 	return time.Duration(c.v.GetInt(varUserDeactivationNotificationWorkerIntervalSeconds)) * time.Second
-}
-
-func (c *ConfigurationData) GetUserDeactivationTestingMode() bool {
-	return c.v.GetBool(varUserDeactivationTestingMode)
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -129,6 +129,4 @@ vwIDAQAB
 	defaultUserDeactivationWorkerIntervalSeconds = 240
 	// defaultUserDeactivationNotificationWorkerIntervalSeconds the default interval between 2 cycles of the user deactivation worker
 	defaultUserDeactivationNotificationWorkerIntervalSeconds = 240
-
-	defaultUserDeactivationTestingMode = true
 )

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -120,13 +120,14 @@ vwIDAQAB
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
 	defaultUserDeactivationInactivityNotificationPeriod = 24 // 24 days
 	// defaultUserDeactivationInactivityPeriod the default number of days of inactivity before a user account can be deactivated
-	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 7 // 31 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
+	//	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 7 // 31 days (7 days after defaultUserDeactivationInactivityNotificationPeriod)
+	defaultUserDeactivationInactivityPeriod = defaultUserDeactivationInactivityNotificationPeriod + 1 // 31 days (1 day after defaultUserDeactivationInactivityNotificationPeriod)
 	// defaultPostDeactivationNotificationDelay the default number of milliseconds between to user account deactivation notifications by the same go routine
 	defaultPostDeactivationNotificationDelay = 500
 	// defaultCheServiceURL the default URL to the Che service
 	defaultCheServiceURL = "http://rhche-host:8080"
 	// defaultPostDeactivationNotificationDelay the default interval between 2 cycles of the user deactivation worker
-	defaultUserDeactivationWorkerIntervalSeconds = 240
-	// defaultUserDeactivationNotificationWorkerIntervalSeconds the default interval between 2 cycles of the user deactivation worker
-	defaultUserDeactivationNotificationWorkerIntervalSeconds = 240
+	defaultUserDeactivationWorkerIntervalSeconds = 60 * 60 // 1 hour
+	// defaultUserDeactivationNotificationWorkerIntervalSeconds the default interval between 2 cycles of the user deactivation notification worker
+	defaultUserDeactivationNotificationWorkerIntervalSeconds = 60 * 60 // 1 hour
 )

--- a/main.go
+++ b/main.go
@@ -296,8 +296,7 @@ func main() {
 	// token cleanup, running once every hour
 	tokenCleanupWorker := tokenworker.NewTokenCleanupWorker(context.Background(), appDB)
 	tokenCleanupWorker.Start(time.Hour)
-	// // user deactivation and notification workers, running once per day
-	// DISABLED FOR NOW
+	// User deactivation and notification workers
 	ctx := manager.ContextWithTokenManager(context.Background(), tokenManager)
 	ctx = context.WithValue(ctx, worker.LockOwner, config.GetPodName())
 	userDeactivationWorker := userworker.NewUserDeactivationWorker(ctx, appDB)
@@ -305,8 +304,8 @@ func main() {
 	userDeactivationNotificationWorker := userworker.NewUserDeactivationNotificationWorker(ctx, appDB)
 	userDeactivationNotificationWorker.Start(config.GetUserDeactivationNotificationWorkerIntervalSeconds())
 
-	// gracefull shutdown
-	go handleShutdown(db, tokenCleanupWorker) //, userDeactivationNotificationWorker, userDeactivationWorker)
+	// graceful shutdown
+	go handleShutdown(db, tokenCleanupWorker, userDeactivationNotificationWorker, userDeactivationWorker)
 
 	// Start http
 	if err := http.ListenAndServe(config.GetHTTPAddress(), nil); err != nil {


### PR DESCRIPTION
1. Reverts the test mode introduced by https://github.com/fabric8-services/fabric8-auth/pull/818 (with some fixes)
2. Enables notifications & deactivation workers
3. Sets worker cycles to one hour instead of 4 minutes.