### PR TITLE
Fix delete users in WIT

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -527,6 +527,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4b9c3a2f4e328503a3f3f1127b02ffdacb4ef6b4f4e79f37e4739d9cfdf0907"
+  inputs-digest = "40f03e14b2a1cf852b1f9a27fc7e19eb8358cc0fead218a63084466a428cb2e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -284,7 +284,7 @@ func (s *userServiceImpl) DeactivateUser(ctx context.Context, username string) (
 
 	// call WIT and Tenant to deactivate the user there as well,
 	// using `auth` SA token here, not the request context's token
-	err := s.Services().WITService().DeleteUser(ctx, identity.ID.String())
+	err := s.Services().WITService().DeleteUser(ctx, username)
 	if err != nil {
 		// just log the error but don't suspend the deactivation
 		log.Error(ctx, map[string]interface{}{"identity_id": identity.ID, "error": err}, "error occurred during user deactivation on WIT Service")

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -592,7 +592,7 @@ func (s *userServiceBlackboxTestSuite) TestDeactivate() {
 		witCallsCounter := 0
 		gock.Observe(gock.DumpRequest)
 		gock.New("http://localhost:8080").
-			Delete(fmt.Sprintf("/api/users/username/%s", userToDeactivate.IdentityID().String())).
+			Delete(fmt.Sprintf("/api/users/username/%s", userToDeactivate.Identity().Username)).
 			MatchHeader("Authorization", "Bearer "+saToken).
 			MatchHeader("X-Request-Id", reqID).
 			SetMatcher(gocksupport.SpyOnCalls(&witCallsCounter)).

--- a/wit/service/wit_service.go
+++ b/wit/service/wit_service.go
@@ -123,14 +123,14 @@ func (s *witServiceImpl) CreateUser(ctx context.Context, identity *account.Ident
 }
 
 // DeleteUser deletes a user in WIT
-func (s *witServiceImpl) DeleteUser(ctx context.Context, identityID string) error {
-	log.Info(ctx, map[string]interface{}{"identity_id": identityID}, "deleting user on WIT service")
+func (s *witServiceImpl) DeleteUser(ctx context.Context, username string) error {
+	log.Info(ctx, map[string]interface{}{"username": username}, "deleting user on WIT service")
 	// this endpoint is restricted to the `auth` Service Account
 	remoteWITService, err := s.createClientWithContextSigner(ctx)
 	if err != nil {
 		return err
 	}
-	deleteUserAPIPath := witservice.DeleteUsersPath(identityID)
+	deleteUserAPIPath := witservice.DeleteUsersPath(username)
 	res, err := remoteWITService.DeleteUsers(goasupport.ForwardContextRequestID(ctx), deleteUserAPIPath)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func (s *witServiceImpl) DeleteUser(ctx context.Context, identityID string) erro
 	bodyString := rest.ReadBody(res.Body) // To prevent FDs leaks
 	if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{
-			"identity_id":     identityID,
+			"username":        username,
 			"response_status": res.Status,
 			"response_body":   bodyString,
 		}, "unable to delete user in WIT")

--- a/wit/service/wit_service_whitebox_test.go
+++ b/wit/service/wit_service_whitebox_test.go
@@ -182,7 +182,7 @@ func (s *TestWITSuite) TestDeleteWITUser() {
 	saToken := testtoken.TokenManager.AuthServiceAccountToken()
 
 	// test data
-	identityID := uuid.NewV4().String()
+	username := uuid.NewV4().String()
 
 	// Set up expected request
 	s.doer.Client.Error = nil
@@ -191,21 +191,21 @@ func (s *TestWITSuite) TestDeleteWITUser() {
 
 	s.doer.Client.AssertRequest = func(req *http.Request) {
 		assert.Equal(s.T(), "DELETE", req.Method)
-		assert.Equal(s.T(), fmt.Sprintf("https://wit/api/users/username/%s", identityID), req.URL.String())
+		assert.Equal(s.T(), fmt.Sprintf("https://wit/api/users/username/%s", username), req.URL.String())
 		assert.Equal(s.T(), "Bearer "+saToken, req.Header.Get("Authorization"))
 		assert.Equal(s.T(), reqID, req.Header.Get("X-Request-Id"))
 		assert.Nil(s.T(), req.Body)
 	}
 
 	s.T().Run("should accept", func(t *testing.T) {
-		err := s.ws.DeleteUser(ctx, identityID)
+		err := s.ws.DeleteUser(ctx, username)
 		require.NoError(s.T(), err)
 	})
 
 	s.T().Run("should fail to delete user if client returned an error", func(t *testing.T) {
 		s.doer.Client.Response = nil
 		s.doer.Client.Error = errors.New("failed to delete user in wit")
-		err := s.ws.DeleteUser(ctx, identityID)
+		err := s.ws.DeleteUser(ctx, username)
 		require.Error(s.T(), err)
 		assert.Equal(s.T(), "failed to delete user in wit", err.Error())
 	})
@@ -213,7 +213,7 @@ func (s *TestWITSuite) TestDeleteWITUser() {
 	s.T().Run("should fail to delete user if client returned unexpected status", func(t *testing.T) {
 		s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusInternalServerError, Status: "500"}
 		s.doer.Client.Error = nil
-		err := s.ws.DeleteUser(ctx, identityID)
+		err := s.ws.DeleteUser(ctx, username)
 		require.Error(s.T(), err)
 		testsupport.AssertError(s.T(), err, errors.New(""), "unable to delete user in WIT. Response status: 500. Response body: ")
 	})


### PR DESCRIPTION
We should use username, not ID when calling WIT.
This error is not critical. It's just logged and ignored but still worth fixing.

Also, I've changed the order of deactivation. Delete from WIT, Che, Tenant first. If Che fails then return an error. If Tenant fails then return an error. If both Che and Tenant succeed then proceed with removing the user from Auth DB.
