### PR TITLE
Don't fail deactivation if user not found

### DIFF
--- a/authentication/account/service/tenant.go
+++ b/authentication/account/service/tenant.go
@@ -75,6 +75,11 @@ func (t *tenantServiceImpl) Delete(ctx context.Context, identityID uuid.UUID) er
 			"response_status": response.Status,
 			"response_body":   respBody,
 		}, "unable to delete tenants")
+		if response.StatusCode == http.StatusNotFound {
+			// May happen if the user has been already deleted from Tenant
+			// Log the error but don't return it
+			return nil
+		}
 		return errors.New("unable to delete tenant")
 	}
 

--- a/authentication/account/service/tenant.go
+++ b/authentication/account/service/tenant.go
@@ -69,21 +69,27 @@ func (t *tenantServiceImpl) Delete(ctx context.Context, identityID uuid.UUID) er
 	defer rest.CloseResponse(response)
 	respBody := rest.ReadBody(response.Body)
 
-	if response.StatusCode != http.StatusNoContent {
-		log.Error(ctx, map[string]interface{}{
+	switch response.StatusCode {
+	case http.StatusNoContent:
+		// OK
+		return nil
+	case http.StatusNotFound:
+		// May happen if the user has been already deleted from Tenant
+		// Log the error but return OK
+		log.Warn(ctx, map[string]interface{}{
 			"identity_id":     identityID.String(),
 			"response_status": response.Status,
 			"response_body":   respBody,
-		}, "unable to delete tenants")
-		if response.StatusCode == http.StatusNotFound {
-			// May happen if the user has been already deleted from Tenant
-			// Log the error but don't return it
-			return nil
-		}
-		return errors.New("unable to delete tenant")
+		}, "unable to delete tenant which is OK if tenant already deleted")
+		return nil
 	}
 
-	return nil
+	log.Error(ctx, map[string]interface{}{
+		"identity_id":     identityID.String(),
+		"response_status": response.Status,
+		"response_body":   respBody,
+	}, "unable to delete tenants")
+	return errors.New("unable to delete tenant")
 }
 
 // createClientWithContextSigner creates with a signer based on current context

--- a/authentication/account/service/tenant_whitebox_test.go
+++ b/authentication/account/service/tenant_whitebox_test.go
@@ -108,8 +108,13 @@ func (s *TestTenantServiceSuite) TestDelete() {
 	err := s.ts.Delete(ctx, identityID)
 	require.NoError(s.T(), err)
 
-	// Fail if returned anything but No Contented
+	// OK if returned Not Found
 	s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusNotFound}
+	err = s.ts.Delete(ctx, identityID)
+	require.NoError(s.T(), err)
+
+	// Fail if returned another error
+	s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusInternalServerError}
 	err = s.ts.Delete(ctx, identityID)
 	require.Error(s.T(), err)
 	assert.Equal(s.T(), "unable to delete tenant", err.Error())

--- a/che/service/che_service_blackbox_test.go
+++ b/che/service/che_service_blackbox_test.go
@@ -28,27 +28,28 @@ func (s *TestCheSuite) TestDeleteUser() {
 	defer gock.OffAll()
 	gock.Observe(gock.DumpRequest)
 
+	identity := s.Graph.CreateIdentity().Identity()
+	tokenManager, err := manager.DefaultManager(s.Configuration)
+	require.NoError(s.T(), err)
+	tokenMatcher := gock.NewBasicMatcher()
+	tokenMatcher.Add(func(req *http.Request, ereq *gock.Request) (bool, error) {
+		h := req.Header.Get("Authorization")
+		if strings.HasPrefix(h, "Bearer ") {
+			token := h[len("Bearer "):]
+			// parse the token and check the 'sub' claim
+			tk, err := tokenManager.Parse(context.Background(), token)
+			if err != nil {
+				return false, err
+			}
+			if claims, ok := tk.Claims.(jwt.MapClaims); ok {
+				return claims["sub"] == identity.ID.String(), nil
+			}
+		}
+		return false, nil
+	})
+
 	s.Run("ok", func() {
 		// given
-		identity := s.Graph.CreateIdentity().Identity()
-		tokenManager, err := manager.DefaultManager(s.Configuration)
-		require.NoError(s.T(), err)
-		tokenMatcher := gock.NewBasicMatcher()
-		tokenMatcher.Add(func(req *http.Request, ereq *gock.Request) (bool, error) {
-			h := req.Header.Get("Authorization")
-			if strings.HasPrefix(h, "Bearer ") {
-				token := h[len("Bearer "):]
-				// parse the token and check the 'sub' claim
-				tk, err := tokenManager.Parse(context.Background(), token)
-				if err != nil {
-					return false, err
-				}
-				if claims, ok := tk.Claims.(jwt.MapClaims); ok {
-					return claims["sub"] == identity.ID.String(), nil
-				}
-			}
-			return false, nil
-		})
 		gock.New("http://localhost:8091").
 			Delete(fmt.Sprintf("api/user/%s", identity.ID)).
 			SetMatcher(tokenMatcher).
@@ -59,4 +60,29 @@ func (s *TestCheSuite) TestDeleteUser() {
 		require.NoError(s.T(), err)
 	})
 
+	s.Run("404 ok", func() {
+		// given
+		gock.New("http://localhost:8091").
+			Delete(fmt.Sprintf("api/user/%s", identity.ID)).
+			SetMatcher(tokenMatcher).
+			Reply(404) // expect a `No Content` response
+		// when
+		err = s.Application.CheService().DeleteUser(s.Ctx, *identity)
+		// then
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("another error not ok", func() {
+		// given
+		gock.New("http://localhost:8091").
+			Delete(fmt.Sprintf("api/user/%s", identity.ID)).
+			SetMatcher(tokenMatcher).
+			Reply(500) // expect a `No Content` response
+		// when
+		fmt.Println("!!!!!! test")
+		err = s.Application.CheService().DeleteUser(s.Ctx, *identity)
+		// then
+		require.Error(s.T(), err)
+		fmt.Println("!!!!!! test done")
+	})
 }

--- a/che/service/che_service_blackbox_test.go
+++ b/che/service/che_service_blackbox_test.go
@@ -79,10 +79,8 @@ func (s *TestCheSuite) TestDeleteUser() {
 			SetMatcher(tokenMatcher).
 			Reply(500) // expect a `No Content` response
 		// when
-		fmt.Println("!!!!!! test")
 		err = s.Application.CheService().DeleteUser(s.Ctx, *identity)
 		// then
 		require.Error(s.T(), err)
-		fmt.Println("!!!!!! test done")
 	})
 }

--- a/controller/namedusers.go
+++ b/controller/namedusers.go
@@ -4,12 +4,12 @@ import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application"
 	appservice "github.com/fabric8-services/fabric8-auth/application/service"
+	"github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	"github.com/fabric8-services/fabric8-auth/authorization/token"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/jsonapi"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/sentry"
-
 	"github.com/goadesign/goa"
 )
 
@@ -94,11 +94,17 @@ func (c *NamedusersController) Deactivate(ctx *app.DeactivateNamedusersContext) 
 			"err":      err,
 			"username": ctx.Username,
 		}, "error occurred while deactivating user")
-		return jsonapi.JSONErrorResponse(ctx, err)
+		if notFound, _ := errors.IsNotFoundError(err); !notFound {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+		// Ignore notFound error. If user has not found then we don't want the reg-app keep trying to deactivate it in auth.
+		// We can add some dummy Identity in response here
+		identity = &repository.Identity{}
+	} else {
+		log.Info(ctx, map[string]interface{}{
+			"username": ctx.Username,
+		}, "user deactivated")
 	}
-	log.Info(ctx, map[string]interface{}{
-		"username": ctx.Username,
-	}, "user deactivated")
 
 	return ctx.OK(ConvertToAppUser(ctx.RequestData, &identity.User, identity, true))
 }

--- a/controller/namedusers_blackbox_test.go
+++ b/controller/namedusers_blackbox_test.go
@@ -158,7 +158,7 @@ func (s *NamedUsersControllerTestSuite) TestBan() {
 
 			})
 
-			t.Run("missing tokem", func(t *testing.T) {
+			t.Run("missing token", func(t *testing.T) {
 				// If no token present in the context then fails too
 				_, ctrl := s.SecuredServiceAccountController(testsupport.TestOnlineRegistrationAppIdentity)
 				test.BanNamedusersForbidden(s.T(), nil, nil, ctrl, userToBan.Identity().Username)
@@ -257,7 +257,7 @@ func (s *NamedUsersControllerTestSuite) TestDeactivateUser() {
 				return nil, errors.NewNotFoundErrorFromString("user not found")
 			}
 			// when
-			test.DeactivateNamedusersNotFound(t, svc.Context, svc, ctrl, "unknown-user")
+			test.DeactivateNamedusersOK(t, svc.Context, svc, ctrl, "unknown-user")
 			// then
 			// verify that the `UserService.DeactivateUser` func was called once...
 			assert.Equal(t, 1, int(userServiceMock.DeactivateUserCounter))


### PR DESCRIPTION
Follow up on https://github.com/fabric8-services/fabric8-auth/pull/834#discussion_r280301696

User could be deactivated/deleted partially. For example in Che we succeed but failed in Tenant. In this case reg app will reschedule deactivation. So, we want to ignore not found errors in the flow (just log them) otherwise re-deactivation won't ever succeed.