### PR TITLE
Update gplock to v1.2.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,9 @@
 [[projects]]
   name = "cirello.io/pglock"
   packages = ["."]
-  revision = "0759a5f88d75b7629df0a9714e7fa34f6efb4d07"
-  source = "github.com/alexeykazakov/pglock"
+  revision = "3c6e8e654aa6046016854efb1f3dcec6a2fafb58"
+  source = "github.com/cirello-io/pglock"
+  version = "v1.2.1"
 
 [[projects]]
   name = "github.com/ajg/form"
@@ -527,6 +528,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "40f03e14b2a1cf852b1f9a27fc7e19eb8358cc0fead218a63084466a428cb2e6"
+  inputs-digest = "efa6016961794d17a4894c2b1aa174616dbdbddd2cbb32ed2f9de4e2503a162a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -123,8 +123,8 @@ required = [
 
 [[constraint]]
   name = "cirello.io/pglock"
-  source = "github.com/alexeykazakov/pglock"
-  revision = "0759a5f88d75b7629df0a9714e7fa34f6efb4d07"
+  source = "github.com/cirello-io/pglock"
+  version = "v1.2.1"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
https://github.com/cirello-io/pglock/pull/1 has been fixed and released in v.1.2.1
So, we can switch to the upstream release now.