### PR TITLE
Sync call to notification service when notifying inactive users

### DIFF
--- a/application/service/services.go
+++ b/application/service/services.go
@@ -91,6 +91,7 @@ type LogoutService interface {
 type NotificationService interface {
 	SendMessageAsync(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (chan error, error)
 	SendMessagesAsync(ctx context.Context, messages []notification.Message, options ...rest.HTTPClientOption) (chan error, error)
+	SendMessage(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error
 }
 
 type OrganizationService interface {

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -205,7 +205,7 @@ func (s *userServiceImpl) ListIdentitiesToDeactivate(ctx context.Context, now fu
 
 func (s *userServiceImpl) notifyIdentityBeforeDeactivation(ctx context.Context, identity repository.Identity, expirationDate string, now func() time.Time) error {
 	msg := notification.NewUserDeactivationEmail(identity.ID.String(), identity.User.Email, expirationDate)
-	_, err := s.Services().NotificationService().SendMessageAsync(ctx, msg)
+	err := s.Services().NotificationService().SendMessage(ctx, msg)
 	if err != nil {
 		return errs.Wrap(err, "failed to send notification to user before account deactivation")
 	}

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -111,8 +111,8 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 			return 90 * 24 * time.Hour // 90 days
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
-			return nil, nil
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -120,7 +120,7 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		// then
 		require.NoError(s.T(), err)
 		assert.Empty(s.T(), result)
-		assert.Equal(s.T(), uint64(0), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(0), notificationServiceMock.SendMessageCounter)
 	})
 
 	s.Run("one user to deactivate without limit", func() {
@@ -133,9 +133,9 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		}
 		var msgToSend notification.Message
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
 			msgToSend = msg
-			return nil, nil
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -144,7 +144,7 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		require.NoError(s.T(), err)
 		require.Len(s.T(), result, 1)
 		assert.Equal(s.T(), identity2.ID, result[0].ID)
-		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageCounter)
 		// also check that the `DeactivationNotification` field was set in the DB
 		identity, err := s.Application.Identities().Load(ctx, identity2.ID)
 		require.NoError(s.T(), err)
@@ -166,8 +166,8 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 			return 30 * 24 * time.Hour // 30 days
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
-			return nil, nil
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -176,7 +176,7 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		require.NoError(s.T(), err)
 		require.Len(s.T(), result, 1)
 		assert.Equal(s.T(), identity2.ID, result[0].ID)
-		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageCounter)
 		// also check that the `DeactivationNotification` field was set in the DB
 		identity, err := s.Application.Identities().Load(ctx, identity2.ID)
 		require.NoError(s.T(), err)
@@ -194,9 +194,9 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		}
 		var msgToSend []notification.Message
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
 			msgToSend = append(msgToSend, msg)
-			return nil, nil
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -206,7 +206,7 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		require.Len(s.T(), result, 2)
 		assert.Equal(s.T(), identity2.ID, result[0].ID)
 		assert.Equal(s.T(), identity1.ID, result[1].ID)
-		assert.Equal(s.T(), uint64(2), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(2), notificationServiceMock.SendMessageCounter)
 		// also check that the `DeactivationNotification` fields were set for both identities in the DB
 		expiryDate := userservice.GetExpiryDate(config, nowf)
 		customs := []map[string]interface{}{}
@@ -246,11 +246,11 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 			return 30 * 24 * time.Hour
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
 			if msg.UserID != nil && *msg.UserID == identity2.ID.String() {
-				return nil, fmt.Errorf("mock error!")
+				return fmt.Errorf("mock error!")
 			}
-			return nil, nil
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -260,7 +260,7 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		require.Len(s.T(), result, 2)
 		assert.Equal(s.T(), identity2.ID, result[0].ID)
 		assert.Equal(s.T(), identity1.ID, result[1].ID)
-		assert.Equal(s.T(), uint64(2), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(2), notificationServiceMock.SendMessageCounter)
 		// also check that the `DeactivationNotification` fields were NOT set for identity #2 in the DB
 		identity, err := s.Application.Identities().Load(ctx, identity2.ID)
 		require.NoError(s.T(), err)
@@ -422,8 +422,8 @@ func (s *userServiceBlackboxTestSuite) TestUserDeactivationFlow() {
 	ago40days := time.Now().Add(-40 * 24 * time.Hour) // 40 days since last activity and notified...
 
 	notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-	notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
-		return nil, nil
+	notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+		return nil
 	}
 
 	userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)

--- a/authentication/account/worker/user_deactivation_notification_worker_test.go
+++ b/authentication/account/worker/user_deactivation_notification_worker_test.go
@@ -56,8 +56,8 @@ func (s *UserDeactivationNotificationWorkerTest) TestNotifyUsers() {
 	var app application.Application
 	s.SetupSubtest = func() {
 		notificationServiceMock = appservicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
-			return nil, nil
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			return nil
 		}
 		app = gormapplication.NewGormDB(s.DB, s.Configuration, s.Wrappers, factory.WithNotificationService(notificationServiceMock))
 	}
@@ -82,7 +82,7 @@ func (s *UserDeactivationNotificationWorkerTest) TestNotifyUsers() {
 		require.NoError(s.T(), err)
 		assert.NotNil(s.T(), result.DeactivationNotification)
 		// notification only sent once to the user
-		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageCounter)
 	})
 
 	s.Run("multiple workers but only one working", func() {
@@ -121,7 +121,7 @@ func (s *UserDeactivationNotificationWorkerTest) TestNotifyUsers() {
 		require.NoError(s.T(), err)
 		assert.NotNil(s.T(), result.DeactivationNotification)
 		// notification only sent once to the user
-		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageAsyncCounter)
+		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageCounter)
 		// verify that the lock was released
 		l, err := s.Application.WorkerLockRepository().AcquireLock(context.Background(), "assert", worker.UserDeactivationNotification)
 		require.NoError(s.T(), err)

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -92,8 +92,8 @@ func (s *MetricTestSuite) TestUserDeactivationNotificationCounter() {
 			return 60 * 24 * time.Hour // 60 days
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
-			return nil, nil
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when
@@ -118,9 +118,9 @@ func (s *MetricTestSuite) TestUserDeactivationNotificationCounter() {
 		}
 		var msgToSend []notification.Message
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
-		notificationServiceMock.SendMessageAsyncFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) (r chan error, r1 error) {
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
 			msgToSend = append(msgToSend, msg)
-			return nil, nil
+			return nil
 		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
 		// when

--- a/notification/service/notification.go
+++ b/notification/service/notification.go
@@ -55,6 +55,19 @@ func (s *notificationServiceImpl) SendMessageAsync(ctx context.Context, msg noti
 	return errs, nil
 }
 
+// SendMessage sends a message to fabric8-notification service
+func (s *notificationServiceImpl) SendMessage(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+	c, err := s.createClientWithContextSigner(ctx, options...)
+	if err != nil {
+		return err
+	}
+
+	if err = s.send(ctx, c, msg); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SendMessagesAsync creates a new goroutine and sends multiple messages to fabric8-notification service
 // chan error is used to send any errors received from remote notification service.
 // we might get an error while creating client which is before actual remote call to notification service, so using return type (chan error, error)


### PR DESCRIPTION
We should call notification service synchronously from deactivation notification worker. Otherwise we will mark the user as successfully notified even if we got an error from the notification service.