### PR TITLE
Remove worker pool from user deactivation notification worker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,14 +364,6 @@
   revision = "5a0325d7fafaac12dda6e7fb8bd222ec1b69875e"
 
 [[projects]]
-  digest = "1:ce33c87d3c813074190a3551912c446a05048dafa436429ba9e467532bc9cdd1"
-  name = "github.com/panjf2000/ants"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "8bb0cde224fdf3a1c6915b4dbd943bc506b42257"
-  version = "v4.1"
-
-[[projects]]
   digest = "1:b2ee62e09bec113cf086d2ce0769efcc7bf79481aba8373fd8f7884e94df3462"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
@@ -722,7 +714,6 @@
     "github.com/jstemmer/go-junit-report",
     "github.com/jteeuwen/go-bindata/go-bindata",
     "github.com/lib/pq",
-    "github.com/panjf2000/ants",
     "github.com/pilu/fresh",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -118,10 +118,6 @@ required = [
   revision = "a5502dd2746ee6fc3fd58ad83d701d25e14d68d1"
 
 [[constraint]]
-  name = "github.com/panjf2000/ants"
-  version = "v4.1"
-
-[[constraint]]
   name = "cirello.io/pglock"
   source = "github.com/cirello-io/pglock"
   version = "v1.2.1"


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-754

This pull request simply removes the worker pool from the `NotifyIdentitiesBeforeDeactivation()` function and instead invokes the notification action synchronously.