### PR TITLE
Remove _total from counter metric names to avoid conversion to Hz

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -730,6 +730,7 @@
     "github.com/wadey/gocovmerge",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/net/context",
+    "golang.org/x/net/websocket",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/github",
     "gopkg.in/h2non/gock.v1",

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	UserDeactivationNotificationCounterName string = "user_deactivation_notification_total"
-	UserDeactivationCounterName             string = "user_deactivation_total"
+	UserDeactivationNotificationCounterName string = "user_deactivation_notification" // PCP automatically rate-converts *_total counters to Hz. So, we don't use _total in the name to avoid that conversion
+	UserDeactivationCounterName             string = "user_deactivation"
 )
 
 var (


### PR DESCRIPTION
Counter type metrics (as inferred from names like _total) are automatically rate-converted to Hz by pcp.

If we rename the counter metrics away from *_total then the row counter should be available in pcp.