### PR TITLE
remove push client as FABRIC8_HUB_TOKEN is prompting for password

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -10,7 +10,8 @@ if [ ! -f .cico-prepare ]; then
 
     run_tests_without_coverage;
 
-    generate_client_setup fabric8-auth auth tool fabric8-services fabric8-auth-client
+    # remove this once FABRIC8_HUB_TOKEN issue is resolved. it's prompting for password
+    #generate_client_setup fabric8-auth auth tool fabric8-services fabric8-auth-client
 
     touch .cico-prepare
 fi


### PR DESCRIPTION
We are using `FABRIC8_HUB_TOKEN` to push newly generated client for `fabric8-auth-client` repository.

Currently, it's prompting for password due to which cico job is waiting and ending with failed.

Commenting this to deploy latest master on prod preview, we can uncomment this once this issue is resolved.