### PR TITLE
filter users to deactivate by IDP

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -87,10 +87,11 @@
   revision = "3af1516d1d0e6872998e0b5ae4abc25355d314de"
 
 [[projects]]
-  digest = "1:229c5a9afaa364250f68505356ec998ef1b2d251a0ba6f6a5e84be8a5ae9b977"
+  digest = "1:863c44b9c200bce2b6b9ba5deebccb8ddf7b4a34f7ad1f7da44c1b6b22b01fb5"
   name = "github.com/fabric8-services/fabric8-common"
   packages = [
     "configuration",
+    "convert/ptr",
     "errors",
     "gocksupport",
     "httpsupport",
@@ -678,6 +679,7 @@
     "github.com/dgrijalva/jwt-go",
     "github.com/fabric8-services/fabric8-cluster-client/cluster",
     "github.com/fabric8-services/fabric8-cluster/design",
+    "github.com/fabric8-services/fabric8-common/convert/ptr",
     "github.com/fabric8-services/fabric8-common/gocksupport",
     "github.com/fabric8-services/fabric8-common/httpsupport",
     "github.com/fabric8-services/fabric8-common/metric",

--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -404,7 +404,7 @@ func (m *GormIdentityRepository) ListIdentitiesToNotifyForDeactivation(ctx conte
 	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between
 	// queries to notify before deactivation and queries to deactivate for real.
 	err := m.db.Model(&Identity{}).Preload("User").
-		Where(`last_active < ? AND deactivation_notification IS NULL`, lastActivity).
+		Where(`last_active < ? AND deactivation_notification IS NULL AND provider_type = ?`, lastActivity, DefaultIDP).
 		Joins("left join users on identities.user_id = users.id").Where("users.banned is false").
 		Order("last_active, created_at").
 		Limit(limit).Find(&identities).Error
@@ -428,7 +428,7 @@ func (m *GormIdentityRepository) ListIdentitiesToDeactivate(ctx context.Context,
 	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between
 	// queries to notify before deactivation and queries to deactivate for real.
 	err := m.db.Model(&Identity{}).
-		Where("last_active < ? and deactivation_notification < ? and deactivation_scheduled < ?", lastActivity, notification, time.Now()).
+		Where("last_active < ? and deactivation_notification < ? and deactivation_scheduled < ? and provider_type = ?", lastActivity, notification, time.Now(), DefaultIDP).
 		Joins("left join users on identities.user_id = users.id").Where("users.banned is false").
 		Order("deactivation_scheduled, last_active, created_at").Limit(limit).Find(&identities).Error
 	if err != nil && err != gorm.ErrRecordNotFound {

--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -274,6 +274,14 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 	user4.Banned = true
 	err = s.Application.Users().Save(ctx, user4)
 	require.NoError(s.T(), err)
+	// noise: user/identity with another IDP
+	user5 := s.Graph.CreateUser().User()
+	identity5 := user5.Identities[0]
+	identity5.LastActive = &ago65days
+	identity5.DeactivationNotification = &ago11days
+	identity5.ProviderType = "foo"
+	err = s.Application.Identities().Save(ctx, &identity5)
+	require.NoError(s.T(), err)
 
 	s.T().Run("no user to notify for deactivation - no inactivity", func(t *testing.T) {
 		// given

--- a/controller/namedusers.go
+++ b/controller/namedusers.go
@@ -93,7 +93,7 @@ func (c *NamedusersController) Deactivate(ctx *app.DeactivateNamedusersContext) 
 		log.Error(ctx, map[string]interface{}{
 			"err":      err,
 			"username": ctx.Username,
-		}, "error occurred while deactivating user")
+		}, "error while deactivating user")
 		if notFound, _ := errors.IsNotFoundError(err); !notFound {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -265,6 +265,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 52
 	m = append(m, steps{ExecuteSQLFile("052-deferrable-constraints2.sql")})
 
+	// Version 53
+	m = append(m, steps{ExecuteSQLFile("053-deactivation-indexes.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/053-deactivation-indexes.sql
+++ b/migration/sql-files/053-deactivation-indexes.sql
@@ -1,0 +1,5 @@
+-- change the indexes to match the WHERE clauses in the SELECT queries to notify and deactivate users
+DROP INDEX identities_deactivation_idx;
+CREATE INDEX identities_deactivation_nootification_idx ON identities USING btree (last_active, deactivation_notification, provider_type);
+CREATE INDEX identities_deactivation_idx ON identities USING btree (last_active, deactivation_notification, deactivation_scheduled, provider_type);
+


### PR DESCRIPTION
Filter users to notify and deactivate by IDP, since this is what we also do when performing the deactivation (and banning)

Also, change a log message to match the same usual pattern: `error while ...`, which makes searching in the logs more consistent.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

