### PR TITLE
create audit logs upon notification and deactivation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,6 +72,16 @@
   version = "v3.9.0"
 
 [[projects]]
+  digest = "1:dd2ecce7cadfb0c032b6ad26b1db97aeec5ceaa470b384f1f999c71af69e1d3f"
+  name = "github.com/fabric8-services/admin-console"
+  packages = [
+    "auditlog",
+    "design",
+  ]
+  pruneopts = "UT"
+  revision = "e18b57d952e4e1ebc666ecaf90bb79147a1aeb00"
+
+[[projects]]
   digest = "1:393bf58f8daf61a1ffb63c8c9fb104a18d83247f6cc42469d01bfd52b05168d8"
   name = "github.com/fabric8-services/fabric8-cluster"
   packages = ["design"]
@@ -87,10 +97,12 @@
   revision = "3af1516d1d0e6872998e0b5ae4abc25355d314de"
 
 [[projects]]
-  digest = "1:863c44b9c200bce2b6b9ba5deebccb8ddf7b4a34f7ad1f7da44c1b6b22b01fb5"
+  digest = "1:d2d643cfba058d45977b6e627beb7d4356a73d7d6b76be657e564014fab190b1"
   name = "github.com/fabric8-services/fabric8-common"
   packages = [
+    "closeable",
     "configuration",
+    "convert",
     "convert/ptr",
     "errors",
     "gocksupport",
@@ -101,7 +113,7 @@
     "test/suite",
   ]
   pruneopts = "UT"
-  revision = "4c8e64a0bf31bcc267b9c414261f267369bc5cc3"
+  revision = "2cc2344d55776abe18178fc1c2efa8abc9996565"
 
 [[projects]]
   digest = "1:05d2a6527e4b6eb09a6f91127a5c76f14062daf109c4730c879b862873444e82"
@@ -677,6 +689,8 @@
   input-imports = [
     "cirello.io/pglock",
     "github.com/dgrijalva/jwt-go",
+    "github.com/fabric8-services/admin-console/auditlog",
+    "github.com/fabric8-services/admin-console/design",
     "github.com/fabric8-services/fabric8-cluster-client/cluster",
     "github.com/fabric8-services/fabric8-cluster/design",
     "github.com/fabric8-services/fabric8-common/convert/ptr",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,6 +38,7 @@ required = [
   "github.com/goadesign/goa/goagen/gen_js",
   "github.com/goadesign/goa/goagen/utils",
   "github.com/goadesign/goa/goatest",
+  "github.com/fabric8-services/admin-console/design",
   "github.com/fabric8-services/fabric8-wit/design",
   "github.com/fabric8-services/fabric8-notification/design",
   "github.com/fabric8-services/fabric8-tenant/design",
@@ -94,12 +95,12 @@ required = [
   revision = "7e149ee841ea9fe7d439f206781b51cacde5d4d3"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/fabric8-services/fabric8-cluster-client"
+  name = "github.com/fabric8-services/admin-console"
+  revision = "e18b57d952e4e1ebc666ecaf90bb79147a1aeb00"
 
 [[constraint]]
-  name = "github.com/fabric8-services/fabric8-common"
-  revision = "4c8e64a0bf31bcc267b9c414261f267369bc5cc3"
+  branch = "master"
+  name = "github.com/fabric8-services/fabric8-cluster-client"
 
 [[constraint]]
   name = "github.com/jstemmer/go-junit-report"

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only neces
 	@echo "Generating mocks..."
 	@-rm -rf test/generated/
 	@-mkdir -p test/generated/application/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService -o ./test/generated/application/service/ -s ".go"
+	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.AdminConsoleService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService -o ./test/generated/application/service/ -s ".go"
 	@-mkdir -p test/generated/authentication
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
 	@-mkdir -p test/generated/authentication/account/service
@@ -301,6 +301,7 @@ app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-tenant/design --notool --pkg tenant -o authentication/account
 	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-notification/design --notool --pkg client -o notification
+	$(GOAGEN_BIN) client -d github.com/fabric8-services/admin-console/design --notool --pkg client -o adminconsole
 
 .PHONY: migrate-database
 ## Compiles the server and runs the database migration with it

--- a/adminconsole/service/admin_console.go
+++ b/adminconsole/service/admin_console.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/fabric8-services/fabric8-auth/adminconsole/client"
+	service "github.com/fabric8-services/fabric8-auth/application/service"
+	"github.com/fabric8-services/fabric8-auth/application/service/base"
+	servicecontext "github.com/fabric8-services/fabric8-auth/application/service/context"
+	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/goasupport"
+	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/rest"
+
+	goaclient "github.com/goadesign/goa/client"
+)
+
+// NewService creates a new service.
+func NewService(context servicecontext.ServiceContext, config Configuration) service.AdminConsoleService {
+	return &adminConsoleServiceImpl{
+		BaseService: base.NewBaseService(context),
+		config:      config,
+	}
+}
+
+// Configuration the service configuration
+type Configuration interface {
+	manager.TokenManagerConfiguration
+	GetAdminConsoleServiceURL() string
+}
+
+type adminConsoleServiceImpl struct {
+	base.BaseService
+	config Configuration
+}
+
+var _ service.AdminConsoleService = &adminConsoleServiceImpl{}
+
+// CreateAuditLog creates an audit log of the given type for the given username on the remote admin console service.
+func (s *adminConsoleServiceImpl) CreateAuditLog(ctx context.Context, username string, eventType string) error {
+	c, err := s.createSignedClient()
+	if err != nil {
+		return err
+	}
+	resp, err := c.CreateAuditLog(goasupport.ForwardContextRequestID(ctx), client.CreateAuditLogPath(username),
+		&client.CreateAuditLogPayload{
+			Data: &client.CreateAuditLogData{
+				Type: "audit_logs",
+				Attributes: &client.CreateAuditLogDataAttributes{
+					EventType: eventType,
+				},
+			},
+		})
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"username":   username,
+			"event_type": eventType,
+		}, "unable to create auditlog on admin console service")
+		return err
+	}
+	defer rest.CloseResponse(resp)
+	if resp.StatusCode >= 400 {
+		body := rest.ReadBody(resp.Body)
+		err := errors.NewInternalErrorFromString(fmt.Sprintf("failed to create audit log in admin console service: %s; response body: %s", resp.Status, body))
+		log.Error(ctx, map[string]interface{}{
+			"status":     resp.StatusCode,
+			"username":   username,
+			"event_type": eventType,
+			"err":        err,
+		}, "unexpected response code")
+		return err
+	}
+	return nil
+
+}
+
+// CreateSignedClient creates a client with a JWT signer which uses the Auth Service Account token
+func (s *adminConsoleServiceImpl) createSignedClient() (*client.Client, error) {
+	cln, err := s.createClient()
+	if err != nil {
+		return nil, err
+	}
+	m, err := manager.DefaultManager(s.config)
+	if err != nil {
+		return nil, err
+	}
+	signer := m.AuthServiceAccountSigner()
+	cln.SetJWTSigner(signer)
+	return cln, nil
+}
+
+func (s *adminConsoleServiceImpl) createClient() (*client.Client, error) {
+	u, err := url.Parse(s.config.GetAdminConsoleServiceURL())
+	if err != nil {
+		return nil, err
+	}
+	c := client.New(goaclient.HTTPClientDoer(http.DefaultClient))
+	c.Host = u.Host
+	c.Scheme = u.Scheme
+	return c, nil
+}

--- a/adminconsole/service/admin_console_blackbox_test.go
+++ b/adminconsole/service/admin_console_blackbox_test.go
@@ -1,0 +1,69 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/adminconsole/service"
+	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
+	"github.com/fabric8-services/fabric8-auth/errors"
+	testsupport "github.com/fabric8-services/fabric8-auth/test"
+	testsuite "github.com/fabric8-services/fabric8-auth/test/suite"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestAdminConsoleService(t *testing.T) {
+	suite.Run(t, &TestAdminConsoleServiceSuite{})
+}
+
+type TestAdminConsoleServiceSuite struct {
+	testsuite.UnitTestSuite
+}
+
+func (s *TestAdminConsoleServiceSuite) TestCreateAuditLog() {
+	tm, err := manager.DefaultManager(s.Config)
+	require.NoError(s.T(), err)
+	saToken := tm.AuthServiceAccountToken()
+	// s.T().Logf("SA Token= %s", saToken)
+	svc := service.NewService(nil, s.Config)
+
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+	gock.New("http://admin-console").
+		Post("api/auditlogs/users/username_ok").
+		MatchHeader("Authorization", "Bearer "+saToken).
+		MatchHeader("Content-Type", "application/json").
+		BodyString(payload).
+		Reply(202)
+	gock.New("http://admin-console").
+		Post("api/auditlogs/users/username_fail").
+		MatchHeader("Authorization", "Bearer "+saToken).
+		MatchHeader("Content-Type", "application/json").
+		BodyString(payload).
+		Reply(500).BodyString("ouch")
+
+	s.Run("ok", func() {
+		// given
+		ctx := context.Background()
+		// when
+		err := svc.CreateAuditLog(ctx, "username_ok", "user_deactivation")
+		// then
+		assert.NoError(s.T(), err)
+	})
+
+	s.Run("failure", func() {
+		// given
+		ctx := context.Background()
+		// when
+		err := svc.CreateAuditLog(ctx, "username_fail", "user_deactivation")
+		// then
+		require.Error(s.T(), err)
+		testsupport.AssertError(s.T(), err, errors.InternalError{}, "failed to create audit log in admin console service: 500 Internal Server Error; response body: ouch")
+	})
+}
+
+const payload = `{"data":{"attributes":{"event_params":null,"event_type":"user_deactivation"},"type":"audit_logs"}}`

--- a/application/service/factory/service_factory.go
+++ b/application/service/factory/service_factory.go
@@ -22,6 +22,7 @@ import (
 	tokenservice "github.com/fabric8-services/fabric8-auth/authorization/token/service"
 	cheservice "github.com/fabric8-services/fabric8-auth/che/service"
 	clusterservice "github.com/fabric8-services/fabric8-auth/cluster/service"
+	adminconsoleService "github.com/fabric8-services/fabric8-auth/adminconsole/service"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/log"
 	notificationservice "github.com/fabric8-services/fabric8-auth/notification/service"
@@ -137,6 +138,7 @@ type ServiceFactory struct {
 	config                  *configuration.ConfigurationData
 	tenantServiceFunc       func() service.TenantService       // the function to call when `TenantService()` is called on this factory
 	notificationServiceFunc func() service.NotificationService // the function to call when `NotificationService()` is called on this factory
+	adminConsoleServiceFunc func() service.AdminConsoleService // the function to call when `AdminConsoleService()` is called on this factory
 	clusterServiceFunc      func() service.ClusterService
 	authProviderServiceFunc func() service.AuthenticationProviderService
 	userServiceFunc         func() service.UserService
@@ -156,6 +158,14 @@ func WithTenantService(s service.TenantService) Option {
 func WithNotificationService(s service.NotificationService) Option {
 	return func(f *ServiceFactory) {
 		f.notificationServiceFunc = func() service.NotificationService {
+			return s
+		}
+	}
+}
+
+func WithAdminConsoleService(s service.AdminConsoleService) Option {
+	return func(f *ServiceFactory) {
+		f.adminConsoleServiceFunc = func() service.AdminConsoleService {
 			return s
 		}
 	}
@@ -199,6 +209,10 @@ func NewServiceFactory(producer servicecontext.ServiceContextProducer, config *c
 	// default function to return an instance of Notification Service
 	f.notificationServiceFunc = func() service.NotificationService {
 		return notificationservice.NewNotificationService(f.getContext(), f.config)
+	}
+	// default function to return an instance of Notification Service
+	f.adminConsoleServiceFunc = func() service.AdminConsoleService {
+		return adminconsoleService.NewService(f.getContext(), f.config)
 	}
 	// default function to return an instance of Cluster Service
 	f.clusterServiceFunc = func() service.ClusterService {
@@ -286,6 +300,10 @@ func (f *ServiceFactory) UserProfileService() service.UserProfileService {
 
 func (f *ServiceFactory) NotificationService() service.NotificationService {
 	return f.notificationServiceFunc()
+}
+
+func (f *ServiceFactory) AdminConsoleService() service.AdminConsoleService {
+	return f.adminConsoleServiceFunc()
 }
 
 func (f *ServiceFactory) TenantService() service.TenantService {

--- a/application/service/factory/service_factory.go
+++ b/application/service/factory/service_factory.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"time"
 
+	adminconsoleService "github.com/fabric8-services/fabric8-auth/adminconsole/service"
 	factorymanager "github.com/fabric8-services/fabric8-auth/application/factory/manager"
 	"github.com/fabric8-services/fabric8-auth/application/repository"
 	"github.com/fabric8-services/fabric8-auth/application/service"
@@ -22,7 +23,6 @@ import (
 	tokenservice "github.com/fabric8-services/fabric8-auth/authorization/token/service"
 	cheservice "github.com/fabric8-services/fabric8-auth/che/service"
 	clusterservice "github.com/fabric8-services/fabric8-auth/cluster/service"
-	adminconsoleService "github.com/fabric8-services/fabric8-auth/adminconsole/service"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/log"
 	notificationservice "github.com/fabric8-services/fabric8-auth/notification/service"

--- a/application/service/services.go
+++ b/application/service/services.go
@@ -94,6 +94,11 @@ type NotificationService interface {
 	SendMessage(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error
 }
 
+// AdminConsoleService the Admin Console Service interface
+type AdminConsoleService interface {
+	CreateAuditLog(ctx context.Context, username string, eventType string) error
+}
+
 type OrganizationService interface {
 	CreateOrganization(ctx context.Context, creatorIdentityID uuid.UUID, organizationName string) (*uuid.UUID, error)
 	ListOrganizations(ctx context.Context, identityID uuid.UUID) ([]authorization.IdentityAssociation, error)
@@ -192,6 +197,7 @@ type Services interface {
 	LinkService() LinkService
 	LogoutService() LogoutService
 	NotificationService() NotificationService
+	AdminConsoleService() AdminConsoleService
 	OrganizationService() OrganizationService
 	OSOSubscriptionService() OSOSubscriptionService
 	PermissionService() PermissionService

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -199,6 +199,8 @@ const (
 	varUserDeactivationInactivityPeriodDays = "user.deactivation.inactivity.period.days"
 	// varUserDeactivationWorkerRescheduleDelayHours the number of hours to wait after a failed deactivation attempt to attempt deactivation again
 	varUserDeactivationWorkerRescheduleDelayHours = "user.deactivation.reschedule.delay.hours"
+	// varAdminConsoleServiceURL the URL to the Admin Console service
+	varAdminConsoleServiceURL = "admin.console.serviceurl"
 
 	//------------------------------------------------------------------------------------------------------------------
 	//
@@ -677,6 +679,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varUserDeactivationNotificationWorkerIntervalSeconds, defaultUserDeactivationNotificationWorkerIntervalSeconds)
 	c.v.SetDefault(varPodName, defaultPodName)
 	c.v.SetDefault(varUserDeactivationWorkerRescheduleDelayHours, defaultUserDeactivationRescheduleDelayHours)
+	c.v.SetDefault(varAdminConsoleServiceURL, defaultAdminConsoleServiceURL)
 
 	// Che
 	c.v.SetDefault(varCheServiceURL, defaultCheServiceURL)
@@ -1132,6 +1135,12 @@ func (c *ConfigurationData) GetUserDeactivationNotificationWorkerInterval() time
 	return time.Duration(c.v.GetInt(varUserDeactivationNotificationWorkerIntervalSeconds)) * time.Second
 }
 
+// GetUserDeactivationRescheduleDelay the delay after which a user is automatically scheduled for another deactivation attempt
 func (c *ConfigurationData) GetUserDeactivationRescheduleDelay() time.Duration {
 	return time.Duration(c.v.GetInt(varUserDeactivationWorkerRescheduleDelayHours)) * time.Hour
+}
+
+// GetAdminConsoleServiceURL the URL to access to the Admin Console service
+func (c *ConfigurationData) GetAdminConsoleServiceURL() string {
+	return c.v.GetString(varAdminConsoleServiceURL)
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -136,4 +136,7 @@ vwIDAQAB
 
 	// defaultCheServiceURL the default URL to the Che service
 	defaultCheServiceURL = "http://rhche-host:8080"
+
+	// defaultAdminConsoleServiceURL the default URL to the Admin Console service
+	defaultAdminConsoleServiceURL = "http://admin-console"
 )

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -224,6 +224,10 @@ func (g *GormDB) NotificationService() service.NotificationService {
 	return g.serviceFactory.NotificationService()
 }
 
+func (g *GormDB) AdminConsoleService() service.AdminConsoleService {
+	return g.serviceFactory.AdminConsoleService()
+}
+
 func (g *GormDB) TenantService() service.TenantService {
 	return g.serviceFactory.TenantService()
 }

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	factorymanager "github.com/fabric8-services/fabric8-auth/application/factory/manager"
 	"github.com/fabric8-services/fabric8-auth/application/service/factory"
 	account "github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	userservice "github.com/fabric8-services/fabric8-auth/authentication/account/service"
@@ -92,7 +93,8 @@ func (s *MetricTestSuite) TestUserDeactivationNotificationCounter() {
 		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
 			return nil
 		}
-		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
+		svcCtx := factory.NewServiceContext(s.Application, s.Application, s.Configuration, factorymanager.NewFactoryWrappers(), factory.WithNotificationService(notificationServiceMock))
+		userSvc := userservice.NewUserService(svcCtx, config)
 		// when
 		result, err := userSvc.NotifyIdentitiesBeforeDeactivation(ctx, nowf)
 		// then
@@ -119,7 +121,8 @@ func (s *MetricTestSuite) TestUserDeactivationNotificationCounter() {
 			msgToSend = append(msgToSend, msg)
 			return nil
 		}
-		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock)), config)
+		svcCtx := factory.NewServiceContext(s.Application, s.Application, s.Configuration, factorymanager.NewFactoryWrappers(), factory.WithNotificationService(notificationServiceMock))
+		userSvc := userservice.NewUserService(svcCtx, config)
 		// when
 		result, err := userSvc.NotifyIdentitiesBeforeDeactivation(ctx, nowf)
 		// then


### PR DESCRIPTION
add admin console service client
include Admin Console service in service factory
use admin console client to create audit log upon notification and deactivation

fixes #ODC760

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
