### PR TITLE
user real username when creating audit log

### DIFF
--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -280,12 +280,16 @@ func (s *userServiceImpl) deactivateUser(ctx context.Context, username string) (
 		return nil, err
 	}
 	// create an audit log to keep track of the user deactivation
+<<<<<<< HEAD
 	err = s.Services().AdminConsoleService().CreateAuditLog(ctx, identity.Username, auditlog.UserDeactivationEvent)
 	// just log the error
+=======
+	err = s.Services().AdminConsoleService().CreateAuditLog(ctx, username, auditlog.UserDeactivationEvent)
+>>>>>>> user real username when creating audit log
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"error":    err,
-			"username": identity.Username,
+			"username": username,
 		}, "error while creating audit log for user deactivation")
 	}
 	// do not return the error logged above.

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -280,12 +280,8 @@ func (s *userServiceImpl) deactivateUser(ctx context.Context, username string) (
 		return nil, err
 	}
 	// create an audit log to keep track of the user deactivation
-<<<<<<< HEAD
-	err = s.Services().AdminConsoleService().CreateAuditLog(ctx, identity.Username, auditlog.UserDeactivationEvent)
-	// just log the error
-=======
 	err = s.Services().AdminConsoleService().CreateAuditLog(ctx, username, auditlog.UserDeactivationEvent)
->>>>>>> user real username when creating audit log
+	// just log the error
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"error":    err,


### PR DESCRIPTION
fix to avoid submitting the request with the
obfuscated username :/

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
