### PR TITLE
add whitelist to exclude user from deactivation

### DIFF
--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -134,8 +134,8 @@ type IdentityRepository interface {
 	DeleteForResource(ctx context.Context, resourceID string) error
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Identity, error)
 	List(ctx context.Context) ([]Identity, error)
-	ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error)
-	ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, exclusions []string, limit int) ([]Identity, error)
+	ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, whitelist []string, limit int) ([]Identity, error)
+	ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, whitelist []string, limit int) ([]Identity, error)
 	IsValid(context.Context, uuid.UUID) bool
 	Search(ctx context.Context, q string, start int, limit int) ([]Identity, int, error)
 	FindIdentityMemberships(ctx context.Context, identityID uuid.UUID, resourceType *string) ([]authorization.IdentityAssociation, error)
@@ -398,16 +398,19 @@ func (m *GormIdentityRepository) List(ctx context.Context) ([]Identity, error) {
 // ListIdentitiesToNotifyForDeactivation return identities whose last activity is older than the given one. The result size is limited to the given
 // number of identities (ordered by last activity)
 // if limit is a negative value (eg: '-1'), it is ignored
-func (m *GormIdentityRepository) ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error) {
+func (m *GormIdentityRepository) ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, whitelist []string, limit int) ([]Identity, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "listIdentitiesToNotifyForDeactivation"}, time.Now())
 	var identities []Identity
 	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between
 	// queries to notify before deactivation and queries to deactivate for real.
-	err := m.db.Model(&Identity{}).Preload("User").
+	query := m.db.Model(&Identity{}).Preload("User").
 		Where(`last_active < ? AND deactivation_notification IS NULL AND provider_type = ?`, lastActivity, DefaultIDP).
-		Joins("left join users on identities.user_id = users.id").Where("users.banned is false").
-		Order("last_active, created_at").
-		Limit(limit).Find(&identities).Error
+		Joins("left join users on identities.user_id = users.id").Where("users.banned is false")
+	// check for whitelist if any
+	if len(whitelist) > 0 {
+		query = query.Not("username", whitelist)
+	}
+	err := query.Order("last_active, created_at").Limit(limit).Find(&identities).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, errs.WithStack(err)
 	}

--- a/authentication/account/repository/identity.go
+++ b/authentication/account/repository/identity.go
@@ -135,7 +135,7 @@ type IdentityRepository interface {
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]Identity, error)
 	List(ctx context.Context) ([]Identity, error)
 	ListIdentitiesToNotifyForDeactivation(ctx context.Context, lastActivity time.Time, limit int) ([]Identity, error)
-	ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, limit int) ([]Identity, error)
+	ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, exclusions []string, limit int) ([]Identity, error)
 	IsValid(context.Context, uuid.UUID) bool
 	Search(ctx context.Context, q string, start int, limit int) ([]Identity, int, error)
 	FindIdentityMemberships(ctx context.Context, identityID uuid.UUID, resourceType *string) ([]authorization.IdentityAssociation, error)
@@ -422,15 +422,19 @@ func (m *GormIdentityRepository) ListIdentitiesToNotifyForDeactivation(ctx conte
 // and for whom there is a `deactivation_notification` value and who were not previously banned.
 // The result size is limited to the given number of identities (ordered by last activity)
 // if limit is a negative value (eg: '-1'), it is ignored
-func (m *GormIdentityRepository) ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, limit int) ([]Identity, error) {
+func (m *GormIdentityRepository) ListIdentitiesToDeactivate(ctx context.Context, lastActivity, notification time.Time, whitelist []string, limit int) ([]Identity, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "listIdentitiesToDeactivate"}, time.Now())
 	var identities []Identity
 	// sort identities by most inactive and then by date of creation to make sure we always get the same sublist of identities between
 	// queries to notify before deactivation and queries to deactivate for real.
-	err := m.db.Model(&Identity{}).
+	query := m.db.Model(&Identity{}).
 		Where("last_active < ? and deactivation_notification < ? and deactivation_scheduled < ? and provider_type = ?", lastActivity, notification, time.Now(), DefaultIDP).
-		Joins("left join users on identities.user_id = users.id").Where("users.banned is false").
-		Order("deactivation_scheduled, last_active, created_at").Limit(limit).Find(&identities).Error
+		Joins("left join users on identities.user_id = users.id").Where("users.banned is false")
+	// check for whitelist if any
+	if len(whitelist) > 0 {
+		query = query.Not("username", whitelist)
+	}
+	err := query.Order("deactivation_scheduled, last_active, created_at").Limit(limit).Find(&identities).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, errs.WithStack(err)
 	}

--- a/authentication/account/repository/identity_blackbox_test.go
+++ b/authentication/account/repository/identity_blackbox_test.go
@@ -173,7 +173,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		// given
 		lastActivity := now.Add(-90 * 24 * time.Hour) // 90 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{}, 100)
 		// then
 		require.NoError(t, err)
 		assert.Empty(t, result)
@@ -183,7 +183,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		// given
 		lastActivity := now.Add(-60 * 24 * time.Hour) // 60 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{}, 100)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 1)
@@ -196,7 +196,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 1)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{}, 1)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 1)
@@ -207,7 +207,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, 100)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{}, 100)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)
@@ -219,12 +219,33 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToNotifyForDeactivation(
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
-		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, -1)
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{}, -1)
 		// then
 		require.NoError(t, err)
 		require.Len(t, result, 2)
 		assert.Equal(t, identity2.ID, result[0].ID)
 		assert.Equal(t, identity1.ID, result[1].ID)
+	})
+
+	s.T().Run("two users to notify for deactivation but one excluded", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{identity1.Username}, -1)
+		// then
+		require.NoError(t, err)
+		require.Len(t, result, 1) // user1 is excluded
+		assert.Equal(t, identity2.ID, result[0].ID)
+	})
+
+	s.T().Run("two users to notify for deactivation but both excluded", func(t *testing.T) {
+		// given
+		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
+		// when
+		result, err := s.Application.Identities().ListIdentitiesToNotifyForDeactivation(ctx, lastActivity, []string{identity1.Username, identity2.Username}, -1)
+		// then
+		require.NoError(t, err)
+		require.Empty(t, result) // user1 and user2 are excluded
 	})
 
 }
@@ -282,7 +303,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 	err = s.Application.Identities().Save(ctx, &identity5)
 	require.NoError(s.T(), err)
 
-	s.T().Run("no user to notify for deactivation - no inactivity", func(t *testing.T) {
+	s.T().Run("no user to deactivate - no inactivity", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-90 * 24 * time.Hour) // 90 days of inactivity
 		// when
@@ -292,7 +313,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Empty(t, result)
 	})
 
-	s.T().Run("no user to notify for deactivation - late notifications", func(t *testing.T) {
+	s.T().Run("no user to deactivate - late notifications", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
@@ -302,7 +323,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Empty(t, result)
 	})
 
-	s.T().Run("one user to notify for deactivation", func(t *testing.T) {
+	s.T().Run("one user to deactivate", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-60 * 24 * time.Hour) // 60 days of inactivity
 		// when
@@ -313,7 +334,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity2.ID, result[0].ID)
 	})
 
-	s.T().Run("one user to notify for deactivation with limit reached", func(t *testing.T) {
+	s.T().Run("one user to deactivate with limit reached", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
@@ -324,7 +345,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity2.ID, result[0].ID)
 	})
 
-	s.T().Run("two users to notify for deactivation with limit unreached", func(t *testing.T) {
+	s.T().Run("two users to deactivate with limit unreached", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
@@ -336,7 +357,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity1.ID, result[1].ID)
 	})
 
-	s.T().Run("two users to notify for deactivation without limit", func(t *testing.T) {
+	s.T().Run("two users to deactivate without limit", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
@@ -348,7 +369,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity1.ID, result[1].ID)
 	})
 
-	s.T().Run("two users to notify for deactivation but one excluded", func(t *testing.T) {
+	s.T().Run("two users to deactivate but one excluded", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when
@@ -359,7 +380,7 @@ func (s *IdentityRepositoryTestSuite) TestListIdentitiesToDeactivate() {
 		assert.Equal(t, identity2.ID, result[0].ID)
 	})
 
-	s.T().Run("two users to notify for deactivation but both excluded", func(t *testing.T) {
+	s.T().Run("two users to deactivate but both excluded", func(t *testing.T) {
 		// given
 		lastActivity := now.Add(-30 * 24 * time.Hour) // 30 days of inactivity
 		// when

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -134,7 +134,7 @@ func (s *userServiceImpl) BanUser(ctx context.Context, username string) (*reposi
 func (s *userServiceImpl) NotifyIdentitiesBeforeDeactivation(ctx context.Context, now func() time.Time) ([]repository.Identity, error) {
 	since := now().Add(-s.config.GetUserDeactivationInactivityNotificationPeriod()) // remove 'n' days from now (default: 24)
 	limit := s.config.GetUserDeactivationFetchLimit()
-	identities, err := s.Repositories().Identities().ListIdentitiesToNotifyForDeactivation(ctx, since, limit)
+	identities, err := s.Repositories().Identities().ListIdentitiesToNotifyForDeactivation(ctx, since, s.config.GetUserDeactivationWhiteList(), limit)
 	if err != nil {
 		return nil, errs.Wrap(err, "unable to send notification to users before account deactivation")
 	}

--- a/authentication/account/service/user.go
+++ b/authentication/account/service/user.go
@@ -39,6 +39,7 @@ type UserServiceConfiguration interface {
 	GetUserDeactivationInactivityNotificationPeriod() time.Duration
 	GetUserDeactivationInactivityPeriod() time.Duration
 	GetUserDeactivationRescheduleDelay() time.Duration
+	GetUserDeactivationWhiteList() []string
 }
 
 // userServiceImpl implements the UserService to manage users
@@ -184,7 +185,7 @@ func (s *userServiceImpl) ListIdentitiesToDeactivate(ctx context.Context, now fu
 	notification := now().Add(s.config.GetUserDeactivationInactivityNotificationPeriod() - s.config.GetUserDeactivationInactivityPeriod()) // make sure that the notification was sent at least `n` days earlier (default: 7)
 	limit := s.config.GetUserDeactivationFetchLimit()
 
-	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, notification, limit)
+	return s.Repositories().Identities().ListIdentitiesToDeactivate(ctx, since, notification, s.config.GetUserDeactivationWhiteList(), limit)
 }
 
 func (s *userServiceImpl) notifyIdentityBeforeDeactivation(ctx context.Context, identity repository.Identity, expirationDate string, now func() time.Time) error {

--- a/authentication/account/service/user_blackbox_test.go
+++ b/authentication/account/service/user_blackbox_test.go
@@ -101,13 +101,16 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		require.NoError(s.T(), err)
 	}
 
-	s.Run("no user to deactivate", func() {
+	s.Run("no user to notify", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 100
 		}
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 90 * 24 * time.Hour // 90 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{}
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
 		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
@@ -127,13 +130,16 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		assert.Equal(s.T(), uint64(0), adminConsoleServiceMock.CreateAuditLogCounter)
 	})
 
-	s.Run("one user to deactivate without limit", func() {
+	s.Run("one user to notify without limit", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 100
 		}
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 60 * 24 * time.Hour // 60 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{}
 		}
 		var msgToSend notification.Message
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
@@ -173,13 +179,16 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 
 	})
 
-	s.Run("one user to deactivate with limit reached", func() {
+	s.Run("one user to notify with limit reached", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 1
 		}
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 30 * 24 * time.Hour // 30 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{}
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
 		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
@@ -205,13 +214,16 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		assert.True(s.T(), time.Now().Sub(*identity.DeactivationNotification) < time.Second*2)
 	})
 
-	s.Run("two users to deactivate", func() {
+	s.Run("two users to notify", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 100
 		}
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 30 * 24 * time.Hour // 30 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{}
 		}
 		var msgToSend []notification.Message
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
@@ -269,6 +281,75 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		assert.ElementsMatch(s.T(), []string{auditlog.UserDeactivationNotificationEvent, auditlog.UserDeactivationNotificationEvent}, eventTypeToSend)
 	})
 
+	s.Run("two users to notify but one whitelisted", func() {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
+			return 30 * 24 * time.Hour // 30 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{identity1.Username}
+		}
+		var msgToSend []notification.Message
+		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			msgToSend = append(msgToSend, msg)
+			return nil
+		}
+		var usernameToSend, eventTypeToSend []string
+		adminConsoleServiceMock := servicemock.NewAdminConsoleServiceMock(s.T())
+		adminConsoleServiceMock.CreateAuditLogFunc = func(ctx context.Context, username string, eventType string) error {
+			usernameToSend = append(usernameToSend, username)
+			eventTypeToSend = append(eventTypeToSend, eventType)
+			return nil
+		}
+		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock), factory.WithAdminConsoleService(adminConsoleServiceMock)), config)
+		// when
+		result, err := userSvc.NotifyIdentitiesBeforeDeactivation(ctx, nowf)
+		// then
+		require.NoError(s.T(), err)
+		require.Len(s.T(), result, 1)
+		assert.Equal(s.T(), identity2.ID, result[0].ID)
+		assert.Equal(s.T(), uint64(1), notificationServiceMock.SendMessageCounter)
+		assert.Equal(s.T(), uint64(1), adminConsoleServiceMock.CreateAuditLogCounter)
+	})
+
+	s.Run("two users to notify but both whitelisted", func() {
+		// given
+		config.GetUserDeactivationFetchLimitFunc = func() int {
+			return 100
+		}
+		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
+			return 30 * 24 * time.Hour // 30 days
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{identity1.Username, identity2.Username}
+		}
+		var msgToSend []notification.Message
+		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
+		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
+			msgToSend = append(msgToSend, msg)
+			return nil
+		}
+		var usernameToSend, eventTypeToSend []string
+		adminConsoleServiceMock := servicemock.NewAdminConsoleServiceMock(s.T())
+		adminConsoleServiceMock.CreateAuditLogFunc = func(ctx context.Context, username string, eventType string) error {
+			usernameToSend = append(usernameToSend, username)
+			eventTypeToSend = append(eventTypeToSend, eventType)
+			return nil
+		}
+		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil, factory.WithNotificationService(notificationServiceMock), factory.WithAdminConsoleService(adminConsoleServiceMock)), config)
+		// when
+		result, err := userSvc.NotifyIdentitiesBeforeDeactivation(ctx, nowf)
+		// then
+		require.NoError(s.T(), err)
+		require.Empty(s.T(), result)
+		assert.Equal(s.T(), uint64(0), notificationServiceMock.SendMessageCounter)
+		assert.Equal(s.T(), uint64(0), adminConsoleServiceMock.CreateAuditLogCounter)
+	})
+
 	s.Run("error while sending second notification", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
@@ -276,6 +357,9 @@ func (s *userServiceBlackboxTestSuite) TestNotifyIdentitiesBeforeDeactivation() 
 		}
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 30 * 24 * time.Hour
+		}
+		config.GetUserDeactivationWhiteListFunc = func() []string {
+			return []string{}
 		}
 		notificationServiceMock := servicemock.NewNotificationServiceMock(s.T())
 		notificationServiceMock.SendMessageFunc = func(ctx context.Context, msg notification.Message, options ...rest.HTTPClientOption) error {
@@ -412,9 +496,6 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 		config.GetUserDeactivationInactivityNotificationPeriodFunc = func() time.Duration {
 			return 20 * 24 * time.Hour // 20 days
 		}
-		config.GetUserDeactivationWhiteListFunc = func() []string {
-			return []string{}
-		}
 		userSvc := userservice.NewUserService(factory.NewServiceContext(s.Application, s.Application, nil, nil), config)
 		// when
 		result, err := userSvc.ListIdentitiesToDeactivate(ctx, time.Now)
@@ -448,7 +529,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 		assert.Equal(s.T(), identity1.ID, result[1].ID) // user 1 was inactive for 40 days and notified 10 days ago
 	})
 
-	s.Run("one user excluded from deactivation", func() {
+	s.Run("one user excluded from deactivation (even if scheduled)", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 100
@@ -471,7 +552,7 @@ func (s *userServiceBlackboxTestSuite) TestListUsersToDeactivate() {
 		assert.Equal(s.T(), identity2.ID, result[0].ID) // user 2 was inactive for 70 days and notified 10 days ago
 	})
 
-	s.Run("two users excluded from deactivation", func() {
+	s.Run("two users excluded from deactivation (even if scheduled)", func() {
 		// given
 		config.GetUserDeactivationFetchLimitFunc = func() int {
 			return 100

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -199,6 +199,8 @@ const (
 	varUserDeactivationInactivityPeriodDays = "user.deactivation.inactivity.period.days"
 	// varUserDeactivationWorkerRescheduleDelayHours the number of hours to wait after a failed deactivation attempt to attempt deactivation again
 	varUserDeactivationWorkerRescheduleDelayHours = "user.deactivation.reschedule.delay.hours"
+	// varUserExcludeList the list of *space-separated* usernames to exclude from user deactivation
+	varUserDeactivationWhiteList = "user.deactivation.whitelist"
 	// varAdminConsoleServiceURL the URL to the Admin Console service
 	varAdminConsoleServiceURL = "admin.console.serviceurl"
 
@@ -1138,6 +1140,11 @@ func (c *ConfigurationData) GetUserDeactivationNotificationWorkerInterval() time
 // GetUserDeactivationRescheduleDelay the delay after which a user is automatically scheduled for another deactivation attempt
 func (c *ConfigurationData) GetUserDeactivationRescheduleDelay() time.Duration {
 	return time.Duration(c.v.GetInt(varUserDeactivationWorkerRescheduleDelayHours)) * time.Hour
+}
+
+// GetUserDeactivationWhiteList the list of usernames to exclude users from deactivation
+func (c *ConfigurationData) GetUserDeactivationWhiteList() []string {
+	return c.v.GetStringSlice(varUserDeactivationWhiteList)
 }
 
 // GetAdminConsoleServiceURL the URL to access to the Admin Console service

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -47,6 +47,9 @@ func (s *MetricTestSuite) TestUserDeactivationNotificationCounter() {
 	config.GetUserDeactivationInactivityPeriodFunc = func() time.Duration {
 		return 97 * 24 * time.Hour
 	}
+	config.GetUserDeactivationWhiteListFunc = func() []string {
+		return []string{}
+	}
 	now := time.Now() // make sure we use the same 'now' everywhere in the test
 	nowf := func() time.Time {
 		return now

--- a/openshift/auth.app.yaml
+++ b/openshift/auth.app.yaml
@@ -218,6 +218,11 @@ objects:
               configMapKeyRef:
                 name: auth
                 key: user.deactivation.interval.seconds
+          - name: AUTH_USER_DEACTIVATION_WHITELIST
+            valueFrom:
+              configMapKeyRef:
+                name: auth
+                key: user.deactivation.whitelist
           imagePullPolicy: Always
           name: auth
           ports:

--- a/openshift/auth.config.yaml
+++ b/openshift/auth.config.yaml
@@ -58,4 +58,5 @@ objects:
     ignore.email.prod: ".+\\+preview.*\\@redhat\\.com"
     user.deactivation.notification.enabled: false
     user.deactivation.enabled: false
+    user.deactivation.whitelist: "username1 username2"
   


### PR DESCRIPTION
Use a configuration-based list of usernames to exclude from the user deacvation. 
It's enough if those users are not notified: they won't have a scheduled deactivation either.

Fixes #ODC1007

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
