### PR TITLE
remove usage of request in generate token methods

### DIFF
--- a/authorization/token/manager/token_manager.go
+++ b/authorization/token/manager/token_manager.go
@@ -433,13 +433,8 @@ func (m *tokenManager) GenerateUnsignedUserAccessTokenFromClaims(ctx context.Con
 		claims["email"] = tokenClaims.Email
 	}
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -477,12 +472,8 @@ func (m *tokenManager) GenerateUnsignedUserAccessTokenForIdentity(ctx context.Co
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["kid"] = m.userAccountPrivateKey.KeyID
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -546,13 +537,8 @@ func (m *tokenManager) GenerateUnsignedUserRefreshTokenForIdentity(ctx context.C
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["kid"] = m.userAccountPrivateKey.KeyID
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -590,13 +576,8 @@ func (m *tokenManager) GenerateUnsignedUserRefreshToken(ctx context.Context, ref
 		return nil, errors.WithStack(err)
 	}
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -642,13 +623,8 @@ func (m *tokenManager) GenerateUnsignedUserAccessTokenFromRefreshToken(ctx conte
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["kid"] = m.userAccountPrivateKey.KeyID
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -833,13 +809,8 @@ func (m *tokenManager) GenerateUnsignedUserAccessTokenFromClaimsForAPIClient(ctx
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["kid"] = m.userAccountPrivateKey.KeyID
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -903,13 +874,8 @@ func (m *tokenManager) GenerateUnsignedUserRefreshTokenForAPIClient(ctx context.
 		return nil, errors.WithStack(err)
 	}
 
-	req := goa.ContextRequest(ctx)
-	if req == nil {
-		return nil, errors.New("missing request in context")
-	}
-
-	authOpenshiftIO := rest.AbsoluteURL(req, "", m.config)
-	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURL(req, "", "", m.config)
+	authOpenshiftIO := m.config.GetAuthServiceURL()
+	openshiftIO, err := rest.ReplaceDomainPrefixInAbsoluteURLStr(authOpenshiftIO, "", "")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/authorization/token/manager/token_manager_test.go
+++ b/authorization/token/manager/token_manager_test.go
@@ -42,7 +42,7 @@ func (s *TestTokenSuite) TestGenerateUserTokenForIdentity() {
 
 func (s *TestTokenSuite) TestGenerateTransientUserAccessTokenForIdentity() {
 	// given
-	ctx := testtoken.ContextWithRequest(nil)
+	ctx := context.Background()
 	user := repository.User{
 		ID:       uuid.NewV4(),
 		Email:    uuid.NewV4().String(),
@@ -98,7 +98,7 @@ func (s *TestTokenSuite) TestRefreshedUserTokenForIdentity() {
 
 func (s *TestTokenSuite) TestGenerateUserTokenAndRefreshFlowForAPIClient() {
 	// given
-	ctx := testtoken.ContextWithRequest(nil)
+	ctx := context.Background()
 	identityID := uuid.NewV4()
 	username := uuid.NewV4().String()
 	email := uuid.NewV4().String()
@@ -458,7 +458,7 @@ func (s *TestTokenSuite) checkConvertToken(offlineToken bool) {
 }
 
 func (s *TestTokenSuite) generateToken(offlineToken bool) (*oauth2.Token, repository.Identity, context.Context) {
-	ctx := testtoken.ContextWithRequest(nil)
+	ctx := context.Background()
 	user := repository.User{
 		ID:       uuid.NewV4(),
 		Email:    uuid.NewV4().String(),

--- a/authorization/token/manager/token_manager_test.go
+++ b/authorization/token/manager/token_manager_test.go
@@ -68,8 +68,8 @@ func (s *TestTokenSuite) TestGenerateTransientUserAccessTokenForIdentity() {
 	expiresIn := time.Duration(s.Config.GetTransientTokenExpiresIn()) * time.Second
 	s.assertExpiresIn(claims["exp"], expiresIn, 10*time.Second) // 60 seconds days +/- 10 seconds
 	s.assertIntClaim(claims, "nbf", 0)
-	s.assertClaim(claims, "iss", "https://auth.openshift.io")
-	s.assertClaim(claims, "aud", "https://openshift.io")
+	s.assertClaim(claims, "iss", "http://auth.localhost")
+	s.assertClaim(claims, "aud", "http://localhost")
 	s.assertClaim(claims, "typ", "Bearer")
 	s.assertClaim(claims, "auth_time", iat)
 	s.assertClaim(claims, "approved", !identity.User.Banned)
@@ -84,8 +84,8 @@ func (s *TestTokenSuite) TestGenerateTransientUserAccessTokenForIdentity() {
 	s.assertClaim(claims, "family_name", lastName)
 
 	s.assertClaim(claims, "allowed-origins", []interface{}{
-		"https://auth.openshift.io",
-		"https://openshift.io",
+		"http://auth.localhost",
+		"http://localhost",
 	})
 	// and verify that the claim is transient
 	s.assertClaim(claims, "transient", "true")
@@ -225,8 +225,8 @@ func (s *TestTokenSuite) checkGenerateRPTTokenForIdentity() {
 	iat := s.assertIat(rptClaims)
 	s.assertExpiresIn(rptClaims["exp"], 30*24*time.Hour, time.Minute) // 30 days +/- 1 min
 	s.assertIntClaim(rptClaims, "nbf", 0)
-	s.assertClaim(rptClaims, "iss", "https://auth.openshift.io")
-	s.assertClaim(rptClaims, "aud", "https://openshift.io")
+	s.assertClaim(rptClaims, "iss", "http://auth.localhost")
+	s.assertClaim(rptClaims, "aud", "http://localhost")
 	s.assertClaim(rptClaims, "typ", "Bearer")
 	s.assertClaim(rptClaims, "auth_time", iat)
 	s.assertClaim(rptClaims, "approved", !identity.User.Banned)
@@ -240,8 +240,8 @@ func (s *TestTokenSuite) checkGenerateRPTTokenForIdentity() {
 	s.assertClaim(rptClaims, "family_name", lastName)
 
 	s.assertClaim(rptClaims, "allowed-origins", []interface{}{
-		"https://auth.openshift.io",
-		"https://openshift.io",
+		"http://auth.localhost",
+		"http://localhost",
 	})
 }
 
@@ -269,8 +269,8 @@ func (s *TestTokenSuite) assertGeneratedToken(generatedToken *oauth2.Token, iden
 	iat := s.assertIat(accessToken)
 	s.assertExpiresIn(accessToken["exp"], 30*24*time.Hour, time.Minute) // 30 days +/- 1 min
 	s.assertIntClaim(accessToken, "nbf", 0)
-	s.assertClaim(accessToken, "iss", "https://auth.openshift.io")
-	s.assertClaim(accessToken, "aud", "https://openshift.io")
+	s.assertClaim(accessToken, "iss", "http://auth.localhost")
+	s.assertClaim(accessToken, "aud", "http://localhost")
 	s.assertClaim(accessToken, "typ", "Bearer")
 	s.assertClaim(accessToken, "auth_time", iat)
 	s.assertClaim(accessToken, "approved", !identity.User.Banned)
@@ -285,8 +285,8 @@ func (s *TestTokenSuite) assertGeneratedToken(generatedToken *oauth2.Token, iden
 	s.assertClaim(accessToken, "family_name", lastName)
 
 	s.assertClaim(accessToken, "allowed-origins", []interface{}{
-		"https://auth.openshift.io",
-		"https://openshift.io",
+		"http://auth.localhost",
+		"http://localhost",
 	})
 
 	// Refresh token
@@ -302,8 +302,8 @@ func (s *TestTokenSuite) assertGeneratedToken(generatedToken *oauth2.Token, iden
 	s.assertJti(refreshToken)
 	s.assertIat(refreshToken)
 	s.assertIntClaim(refreshToken, "nbf", 0)
-	s.assertClaim(refreshToken, "iss", "https://auth.openshift.io")
-	s.assertClaim(refreshToken, "aud", "https://openshift.io")
+	s.assertClaim(refreshToken, "iss", "http://auth.localhost")
+	s.assertClaim(refreshToken, "aud", "http://localhost")
 	if offlineToken {
 		s.assertIntClaim(refreshToken, "exp", 0)
 		s.assertClaim(refreshToken, "typ", "Offline")
@@ -362,7 +362,7 @@ func (s *TestTokenSuite) TestAddLoginRequiredHeaderToUnauthorizedError() {
 }
 
 func (s *TestTokenSuite) checkLoginRequiredHeader(rw http.ResponseWriter) {
-	assert.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
+	assert.Equal(s.T(), "LOGIN url=http://auth.localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
 	header := textproto.MIMEHeader(rw.Header())
 	assert.Contains(s.T(), header["Access-Control-Expose-Headers"], "WWW-Authenticate")
 }

--- a/authorization/token/manager/token_manager_whitebox_test.go
+++ b/authorization/token/manager/token_manager_whitebox_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"github.com/fabric8-services/fabric8-auth/authorization/token"
 	"os"
 	"sync"
 	"testing"
+
+	"github.com/fabric8-services/fabric8-auth/authorization/token"
+	uuid "github.com/satori/go.uuid"
 
 	config "github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/resource"
@@ -16,7 +18,6 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -274,7 +275,7 @@ func (s *TestWhiteboxTokenSuite) TestAuthServiceAccount() {
 	_, err = uuid.FromString(jti)
 	require.Nil(s.T(), err)
 	require.NotEmpty(s.T(), claims["iat"])
-	require.Equal(s.T(), "http://localhost", claims["iss"])
+	require.Equal(s.T(), "http://auth.localhost", claims["iss"])
 }
 
 const (

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -499,7 +499,7 @@ func (c *ConfigurationData) GetAuthServiceURL() string {
 	case prodPreviewEnvironment:
 		return "https://auth.prod-preview.openshift.io"
 	default:
-		return "http://localhost"
+		return "http://auth.localhost"
 	}
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -338,7 +338,7 @@ func NewConfigurationData(mainConfigFile string, serviceAccountConfigFile string
 		c.appendDefaultConfigErrorMessage("OSO Reg App admin token is empty")
 	}
 	c.validateURL(c.GetAuthServiceURL(), "Auth service")
-	if c.GetAuthServiceURL() == "http://localhost" {
+	if c.GetAuthServiceURL() == "http://auth.localhost" {
 		c.appendDefaultConfigErrorMessage("environment is expected to be set to 'production' or 'prod-preview'")
 	}
 	if c.GetSentryDSN() == "" {

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -109,14 +109,14 @@ func TestGetEnvironmentOK(t *testing.T) {
 	// Environment not set
 	saConfig, err := configuration.GetConfigurationData()
 	require.NoError(t, err)
-	assert.Equal(t, "http://localhost", saConfig.GetAuthServiceURL())
+	assert.Equal(t, "http://auth.localhost", saConfig.GetAuthServiceURL())
 	assert.Contains(t, saConfig.DefaultConfigurationError().Error(), "environment is expected to be set to 'production' or 'prod-preview'")
 
 	// Environment set to some unknown value
 	os.Setenv(constAuthEnvironment, "somethingelse")
 	saConfig, err = configuration.GetConfigurationData()
 	require.NoError(t, err)
-	assert.Equal(t, "http://localhost", saConfig.GetAuthServiceURL())
+	assert.Equal(t, "http://auth.localhost", saConfig.GetAuthServiceURL())
 	assert.Contains(t, saConfig.DefaultConfigurationError().Error(), "environment is expected to be set to 'production' or 'prod-preview'")
 
 	// Environment set to prod-preview

--- a/controller/token_blackbox_test.go
+++ b/controller/token_blackbox_test.go
@@ -29,10 +29,10 @@ import (
 	testservice "github.com/fabric8-services/fabric8-auth/test/generated/application/service"
 	testjwt "github.com/fabric8-services/fabric8-auth/test/jwt"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -108,7 +108,7 @@ func checkJWK(t *testing.T, testDir string, keys *app.PublicKeys) {
 }
 
 func (s *TokenControllerTestSuite) checkLoginRequiredHeader(rw http.ResponseWriter) {
-	assert.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
+	assert.Equal(s.T(), "LOGIN url=http://auth.localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
 	assert.Contains(s.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
 }
 

--- a/goamiddleware/jwt_token_context_whitebox_test.go
+++ b/goamiddleware/jwt_token_context_whitebox_test.go
@@ -3,19 +3,20 @@ package goamiddleware
 import (
 	"context"
 	"errors"
-	"github.com/fabric8-services/fabric8-auth/authorization/token"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
 	"testing"
 	"time"
 
+	"github.com/fabric8-services/fabric8-auth/authorization/token"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +59,7 @@ func (s *testJWTokenContextSuite) TestHandler() {
 	err = h(context.Background(), rw, rq)
 	require.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "401 token_validation_failed: token is invalid", err.Error())
-	assert.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
+	assert.Equal(s.T(), "LOGIN url=http://auth.localhost/api/login, description=\"re-login is required\"", rw.Header().Get("WWW-Authenticate"))
 	assert.Contains(s.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
 
 	// OK if token is valid
@@ -100,7 +101,7 @@ func (s *testJWTokenContextSuite) TestHandler() {
 	require.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "401 token_validation_failed: token is invalid", err.Error())
 	header = textproto.MIMEHeader(rw.Header())
-	require.Equal(s.T(), "LOGIN url=http://localhost/api/login, description=\"re-login is required\"", header.Get("WWW-Authenticate"))
+	require.Equal(s.T(), "LOGIN url=http://auth.localhost/api/login, description=\"re-login is required\"", header.Get("WWW-Authenticate"))
 	assert.Contains(s.T(), rw.Header().Get("Access-Control-Expose-Headers"), "WWW-Authenticate")
 }
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -81,6 +81,22 @@ func ReplaceDomainPrefixInAbsoluteURL(req *goa.RequestData, replaceBy, relative 
 	return absoluteURLForHost(req, newHost, relative), nil
 }
 
+// ReplaceDomainPrefixInAbsoluteURLStr check ReplaceDomainPrefixInAbsoluteURL.  This works on url string.
+func ReplaceDomainPrefixInAbsoluteURLStr(urlStr string, replaceBy, relative string) (string, error) {
+	if urlStr == "" { // this happens for tests. See https://github.com/goadesign/goa/issues/1861
+		return "", nil
+	}
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return "", err
+	}
+	newHost, err := ReplaceDomainPrefix(url.Host, replaceBy)
+	if err != nil {
+		return "", err
+	}
+	return toAbsoluteURL(url.Scheme, newHost, relative), nil
+}
+
 func absoluteURLForHost(req *goa.RequestData, host, relative string) string {
 	scheme := "http"
 	if req.URL != nil && req.URL.Scheme == "https" { // isHTTPS
@@ -89,6 +105,13 @@ func absoluteURLForHost(req *goa.RequestData, host, relative string) string {
 	xForwardProto := req.Header.Get("X-Forwarded-Proto")
 	if xForwardProto != "" {
 		scheme = xForwardProto
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, host, relative)
+}
+
+func toAbsoluteURL(scheme, host, relative string) string {
+	if scheme == "" {
+		scheme = "http"
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, host, relative)
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -82,7 +82,7 @@ func ReplaceDomainPrefixInAbsoluteURL(req *goa.RequestData, replaceBy, relative 
 }
 
 // ReplaceDomainPrefixInAbsoluteURLStr check ReplaceDomainPrefixInAbsoluteURL.  This works on url string.
-func ReplaceDomainPrefixInAbsoluteURLStr(urlStr string, replaceBy, relative string) (string, error) {
+func ReplaceDomainPrefixInAbsoluteURLStr(urlStr, replaceBy, relative string) (string, error) {
 	if urlStr == "" { // this happens for tests. See https://github.com/goadesign/goa/issues/1861
 		return "", nil
 	}

--- a/rest/rest_blackbox_test.go
+++ b/rest/rest_blackbox_test.go
@@ -108,6 +108,57 @@ func TestReplaceDomainPrefixInAbsoluteURLOK(t *testing.T) {
 	assert.Equal(t, "https://core.openshift.io/testpath6", urlStr)
 }
 
+func TestReplaceDomainPrefixInAbsoluteURLStr(t *testing.T) {
+	tables := []struct {
+		urlStr    string
+		replaceBy string
+		relative  string
+		want      string
+		wantErr   bool
+	}{
+		{
+			urlStr:    "http://auth.localhost",
+			replaceBy: "",
+			relative:  "",
+			want:      "http://localhost",
+		},
+		{
+			urlStr:    "http://auth.localhost",
+			replaceBy: "cluster",
+			relative:  "",
+			want:      "http://cluster.localhost",
+		},
+		{
+			urlStr:    "http://auth.localhost",
+			replaceBy: "",
+			relative:  "/testpath1",
+			want:      "http://localhost/testpath1",
+		},
+		{
+			urlStr:    "http://auth.localhost",
+			replaceBy: "cluster",
+			relative:  "/testpath2",
+			want:      "http://cluster.localhost/testpath2",
+		},
+		{
+			urlStr:    "http://localhost",
+			replaceBy: "",
+			relative:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, table := range tables {
+		got, err := ReplaceDomainPrefixInAbsoluteURLStr(table.urlStr, table.replaceBy, table.relative)
+		if table.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, table.want, got)
+		}
+	}
+}
+
 func TestHostOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()


### PR DESCRIPTION
- **remove usage of http request** in method `GenerateUnsignedUserAccessTokenForIdentity()`.  Such method ideally no need to have request in given context.  Out of http request only AuthServiceURL is extracted which is now taken from `config.GetAuthServiceURL()`

- introduce new method `ReplaceDomainPrefixInAbsoluteURLStr()` in rest package, which works upon URL string input and does similar to what ReplaceDomainPrefixInAbsoluteURL() doing.

- config.GetAuthServiceURL() return `http://auth.localhost` instead of `http://localhost` for default case when it called from localhost while running test.  We need to add `auth` sub-domain so that  GenerateUnsignedUserAccessTokenForIdentity() test run smoothly.  Also, auth_service_url will be always having sub-domain (in prod and prod-preview) and this change will make things consistent.