### PR TITLE
handling reg app HTTP 404 user not found

### DIFF
--- a/authentication/account/worker/user_deactivation_worker.go
+++ b/authentication/account/worker/user_deactivation_worker.go
@@ -66,13 +66,11 @@ func (w userDeactivationWorker) deactivateUsers() {
 				// deactivate user directly
 				_, err := w.App.UserService().DeactivateUser(w.Ctx, identity.Username)
 				if err != nil {
-					metric.RecordUserDeactivationTrigger(false)
 					log.Error(nil, map[string]interface{}{
 						"err":      err,
 						"username": identity.Username,
 					}, "error during deactivating user")
 				} else {
-					metric.RecordUserDeactivationTrigger(true)
 					log.Info(nil, map[string]interface{}{
 						"username": identity.Username,
 					}, "user deactivation is successful")

--- a/authentication/account/worker/user_deactivation_worker.go
+++ b/authentication/account/worker/user_deactivation_worker.go
@@ -64,7 +64,7 @@ func (w userDeactivationWorker) deactivateUsers() {
 		if err != nil {
 			if _, ok := err.(autherrors.NotFoundError); ok {
 				// deactivate user directly
-				identity, err := w.App.UserService().DeactivateUser(w.Ctx, identity.Username)
+				_, err := w.App.UserService().DeactivateUser(w.Ctx, identity.Username)
 				if err != nil {
 					metric.RecordUserDeactivationTrigger(false)
 					log.Error(nil, map[string]interface{}{

--- a/authentication/account/worker/user_deactivation_worker.go
+++ b/authentication/account/worker/user_deactivation_worker.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-auth/application"
+	autherrors "github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/metric"
 	"github.com/fabric8-services/fabric8-auth/worker"
@@ -60,14 +61,32 @@ func (w userDeactivationWorker) deactivateUsers() {
 		// deactivating the user on OSO and then call back `auth` service (on its `/namedusers/:username/deactivate` endpoint)
 		// which will handle the deactivation on the OSIO platform
 		err = w.App.OSOSubscriptionService().DeactivateUser(w.Ctx, identity.Username)
-		metric.RecordUserDeactivationTrigger(err == nil)
 		if err != nil {
-			// We will just log the error and continue
-			log.Error(nil, map[string]interface{}{
-				"err":      err,
-				"username": identity.Username,
-			}, "error while deactivating user")
+			if _, ok := err.(autherrors.NotFoundError); ok {
+				// deactivate user directly
+				identity, err := w.App.UserService().DeactivateUser(w.Ctx, identity.Username)
+				if err != nil {
+					metric.RecordUserDeactivationTrigger(false)
+					log.Error(nil, map[string]interface{}{
+						"err":      err,
+						"username": identity.Username,
+					}, "error during deactivating user")
+				} else {
+					metric.RecordUserDeactivationTrigger(true)
+					log.Info(nil, map[string]interface{}{
+						"username": identity.Username,
+					}, "user deactivation is successful")
+				}
+			} else {
+				// We will just log the error and continue
+				metric.RecordUserDeactivationTrigger(false)
+				log.Error(nil, map[string]interface{}{
+					"err":      err,
+					"username": identity.Username,
+				}, "error while triggering user deactivation")
+			}
 		} else {
+			metric.RecordUserDeactivationTrigger(true)
 			log.Info(nil, map[string]interface{}{
 				"username": identity.Username,
 			}, "user account deactivation triggered")

--- a/authentication/account/worker/user_deactivation_worker_test.go
+++ b/authentication/account/worker/user_deactivation_worker_test.go
@@ -3,10 +3,13 @@ package worker_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/fabric8-services/fabric8-auth/application/service/factory"
 
@@ -15,6 +18,7 @@ import (
 	userservice "github.com/fabric8-services/fabric8-auth/authentication/account/service"
 	"github.com/fabric8-services/fabric8-auth/authentication/account/worker"
 	ososervice "github.com/fabric8-services/fabric8-auth/authentication/subscription/service"
+	cheservice "github.com/fabric8-services/fabric8-auth/che/service"
 	"github.com/fabric8-services/fabric8-auth/configuration"
 	"github.com/fabric8-services/fabric8-auth/gormapplication"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
@@ -22,6 +26,7 @@ import (
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 	baseworker "github.com/fabric8-services/fabric8-auth/worker"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/h2non/gock.v1"
@@ -68,7 +73,7 @@ func (s *UserDeactivationWorkerTest) TestDeactivateUsers() {
 		// given
 		ctx, _, _ := testtoken.ContextWithTokenAndRequestID(s.T())
 		userToDeactivate := s.Graph.CreateUser()
-		userToDeactivate.User().Cluster = "TestCluster" // need to use the same clus
+		userToDeactivate.User().Cluster = "starter-us-east-2a"
 		err := s.Application.Users().Save(ctx, userToDeactivate.User())
 		require.NoError(s.T(), err)
 		identityToDeactivate := *userToDeactivate.Identity()
@@ -78,7 +83,7 @@ func (s *UserDeactivationWorkerTest) TestDeactivateUsers() {
 		identityToDeactivate.DeactivationScheduled = &now
 		err = s.Application.Identities().Save(ctx, &identityToDeactivate)
 		require.NoError(s.T(), err)
-		mockRemoteCalls(userToDeactivate.User(), identityToDeactivate, s.Configuration)
+		mockRemoteCalls(userToDeactivate.User(), identityToDeactivate, s.Configuration, 200)
 		// start the worker with a 50ms ticker
 		w := s.newUserDeactivationWorker(ctx, "pod-a", app)
 		freq := time.Millisecond * 50
@@ -98,7 +103,7 @@ func (s *UserDeactivationWorkerTest) TestDeactivateUsers() {
 		// given
 		ctx, _, _ := testtoken.ContextWithTokenAndRequestID(s.T())
 		userToDeactivate := s.Graph.CreateUser()
-		userToDeactivate.User().Cluster = "TestCluster" // need to use the same clus
+		userToDeactivate.User().Cluster = "starter-us-east-2a"
 		err := s.Application.Users().Save(ctx, userToDeactivate.User())
 		require.NoError(s.T(), err)
 		identityToDeactivate := *userToDeactivate.Identity()
@@ -108,7 +113,7 @@ func (s *UserDeactivationWorkerTest) TestDeactivateUsers() {
 		identityToDeactivate.DeactivationScheduled = &now
 		err = s.Application.Identities().Save(ctx, &identityToDeactivate)
 		require.NoError(s.T(), err)
-		mockRemoteCalls(userToDeactivate.User(), identityToDeactivate, s.Configuration)
+		mockRemoteCalls(userToDeactivate.User(), identityToDeactivate, s.Configuration, 200)
 		// start the workers with a 50ms ticker
 		freq := time.Millisecond * 50
 		latch := sync.WaitGroup{}
@@ -136,6 +141,41 @@ func (s *UserDeactivationWorkerTest) TestDeactivateUsers() {
 		err = l.Close()
 		require.NoError(s.T(), err)
 	})
+
+	s.Run("user not found in reg app", func() {
+		// given
+		ctx, _, _ := testtoken.ContextWithTokenAndRequestID(s.T())
+		userToDeactivate := s.Graph.CreateUser()
+		userToDeactivate.User().Cluster = "starter-us-east-2a"
+		err := s.Application.Users().Save(ctx, userToDeactivate.User())
+		require.NoError(s.T(), err)
+		identityToDeactivate := *userToDeactivate.Identity()
+		identityToDeactivate.LastActive = &ago40days
+		identityToDeactivate.DeactivationNotification = &ago30days
+		now := time.Now()
+		identityToDeactivate.DeactivationScheduled = &now
+		err = s.Application.Identities().Save(ctx, &identityToDeactivate)
+		require.NoError(s.T(), err)
+		mockRemoteCalls(userToDeactivate.User(), identityToDeactivate, s.Configuration, 404)
+		mockCheCalls(s.Configuration)
+		mockTenantCalls(s.Configuration)
+		mockClusterCalls(s.Configuration)
+		mockAdminConsoleCalls(s.Configuration)
+		// start the worker with a 50ms ticker
+		w := s.newUserDeactivationWorker(ctx, "pod-a", app)
+		freq := time.Millisecond * 50
+		w.Start(freq)
+		// wait a few cycles before checking the results
+		time.Sleep(freq * 2)
+		// now stop all workers
+		stop(w)
+		// verify that the lock was released
+		l, err := s.Application.WorkerLockRepository().AcquireLock(context.Background(), "assert", worker.UserDeactivation)
+		require.NoError(s.T(), err)
+		err = l.Close()
+		require.NoError(s.T(), err)
+		s.verifyDeactivate(userToDeactivate.User().ID)
+	})
 }
 
 func (s *UserDeactivationWorkerTest) newUserDeactivationWorker(ctx context.Context, podname string, app application.Application) baseworker.Worker {
@@ -148,7 +188,13 @@ func (s *UserDeactivationWorkerTest) newUserDeactivationWorker(ctx context.Conte
 	return worker.NewUserDeactivationWorker(ctx, app)
 }
 
-func mockRemoteCalls(userToDeactivate *account.User, identity account.Identity, config ososervice.OSOSubscriptionServiceConfiguration) {
+func (s *UserDeactivationWorkerTest) verifyDeactivate(id uuid.UUID) {
+	user, err := s.Application.Users().Load(context.Background(), id)
+	assert.Error(s.T(), err) // not found as users.delete_at is set
+	assert.Nil(s.T(), user)
+}
+
+func mockRemoteCalls(userToDeactivate *account.User, identity account.Identity, config ososervice.OSOSubscriptionServiceConfiguration, resStatus int) {
 	fmt.Printf("Preparing Gock for user '%s' / identity id '%s' username '%s' \n", userToDeactivate.ID.String(), identity.ID.String(), identity.Username)
 	// call to Cluster Service
 	gock.Observe(gock.DumpRequest)
@@ -157,5 +203,36 @@ func mockRemoteCalls(userToDeactivate *account.User, identity account.Identity, 
 		Post(fmt.Sprintf("/api/accounts/%s/deprovision_osio", identity.Username)).
 		MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
 		// not checking token here. Refer to OSO Reg App Deactivation tests
-		Reply(200)
+		Reply(resStatus)
+}
+
+func mockCheCalls(config cheservice.Configuration) {
+	gock.New(config.GetCheServiceURL()).Reply(http.StatusNoContent)
+}
+
+func mockTenantCalls(config *configuration.ConfigurationData) {
+	gock.New(config.GetTenantServiceURL()).Reply(http.StatusNoContent)
+}
+
+func mockClusterCalls(config *configuration.ConfigurationData) {
+	gock.New(config.GetClusterServiceURL()).Reply(http.StatusOK).BodyString(`{
+		"data": [
+			{
+				"api-url": "starter-us-east-2a",
+				"app-dns": "b542.starter-us-east-2a.openshiftapps.com",
+				"auth-client-default-scope": "user:full",
+				"auth-client-id": "openshift-io",
+				"auth-client-secret": "26c8c584-cbac-427d-8330-8b430b6ec620",
+				"capacity-exhausted": false,
+				"name": "starter-us-east-2a",
+				"service-account-token": "eef1c5b8-f1f4-45dd-beef-7c34be5d9f9b",
+				"service-account-username": "devtools-sre",
+				"token-provider-id": "dd0ee660-3549-4617-9cab-6e679aab41e9"
+			}
+		]
+	}`)
+}
+
+func mockAdminConsoleCalls(config *configuration.ConfigurationData) {
+	gock.New(config.GetAdminConsoleServiceURL()).Reply(http.StatusOK)
 }

--- a/authentication/subscription/service/oso_subscription_service.go
+++ b/authentication/subscription/service/oso_subscription_service.go
@@ -210,7 +210,14 @@ func (s *osoSubscriptionServiceImpl) DeactivateUser(ctx context.Context, usernam
 	defer rest.CloseResponse(res)
 	bodyString := rest.ReadBody(res.Body)
 
-	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotFound {
+	if res.StatusCode == http.StatusNotFound {
+		log.Warn(ctx, map[string]interface{}{
+			"reg_app_url":     regAppURL,
+			"response_status": res.Status,
+			"response_body":   bodyString,
+		}, "unable to deprovision user")
+		return autherrors.NewNotFoundErrorFromString(bodyString)
+	} else if res.StatusCode != http.StatusOK {
 		log.Error(ctx, map[string]interface{}{
 			"reg_app_url":     regAppURL,
 			"response_status": res.Status,

--- a/authentication/subscription/service/oso_subscription_service_blackbox_test.go
+++ b/authentication/subscription/service/oso_subscription_service_blackbox_test.go
@@ -313,7 +313,7 @@ func (s *osoSubscriptionServiceTestSuite) TestDeactivateUser() {
 		s.Run("should return an error if the client returns 500", func() {
 			username := fmt.Sprintf("user-%s", uuid.NewV4())
 			gock.New(config.GetOSORegistrationAppURL()).
-				Get(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
+				Post(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
 				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
 				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
 				Reply(500)

--- a/authentication/subscription/service/oso_subscription_service_blackbox_test.go
+++ b/authentication/subscription/service/oso_subscription_service_blackbox_test.go
@@ -307,29 +307,29 @@ func (s *osoSubscriptionServiceTestSuite) TestDeactivateUser() {
 			// then
 			require.NoError(s.T(), err)
 		})
-		s.Run("not found", func() {
-			username := fmt.Sprintf("user-%s", uuid.NewV4())
-			gock.New(config.GetOSORegistrationAppURL()).
-				Post(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
-				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
-				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
-				Reply(404)
-			// when
-			err := svc.DeactivateUser(context.Background(), username)
-			// then
-			require.NoError(s.T(), err)
-		})
 	})
 
 	s.Run("failure", func() {
-
-		s.Run("should return an error if the client returns any status but 200", func() {
+		s.Run("should return an error if the client returns 500", func() {
 			username := fmt.Sprintf("user-%s", uuid.NewV4())
 			gock.New(config.GetOSORegistrationAppURL()).
 				Get(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
 				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
 				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
 				Reply(500)
+			// when
+			err := svc.DeactivateUser(context.Background(), username)
+			// then
+			require.Error(s.T(), err)
+		})
+
+		s.Run("should return an error if the client returns 404", func() {
+			username := fmt.Sprintf("user-%s", uuid.NewV4())
+			gock.New(config.GetOSORegistrationAppURL()).
+				Post(fmt.Sprintf("api/accounts/%s/deprovision_osio", username)).
+				MatchParam("authorization_username", config.GetOSORegistrationAppAdminUsername()).
+				MatchHeader("Authorization", fmt.Sprintf("Bearer %s", config.GetOSORegistrationAppAdminToken())).
+				Reply(404)
 			// when
 			err := svc.DeactivateUser(context.Background(), username)
 			// then


### PR DESCRIPTION
- handle HTTP 404 from reg_app and call userService.DeactivateUser() directly from user_deactivation_worker.
- enhance existing user_deactivation_worker test to actually trigger user_deativation during test run.
- added new test in user_deactivation_worker for 404 case.