### PR TITLE
Disable sentry

### DIFF
--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/errors"
 	"github.com/fabric8-services/fabric8-auth/log"
-	"github.com/fabric8-services/fabric8-auth/sentry"
 
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
@@ -167,6 +166,6 @@ func JSONErrorResponse(ctx InternalServerError, err error) error {
 		}
 	}
 
-	sentry.Sentry().CaptureError(ctx, err)
+	// sentry.Sentry().CaptureError(ctx, err)
 	return errs.WithStack(ctx.InternalServerError(jsonErr))
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fabric8-services/fabric8-auth/log"
 	"github.com/fabric8-services/fabric8-auth/metric"
 	"github.com/fabric8-services/fabric8-auth/migration"
-	"github.com/fabric8-services/fabric8-auth/sentry"
 	"github.com/fabric8-services/fabric8-auth/worker"
 
 	"github.com/goadesign/goa"
@@ -90,17 +89,17 @@ func main() {
 	}
 
 	// Initialize sentry client
-	haltSentry, err := sentry.InitializeSentryClient(
-		config.GetSentryDSN(),
-		sentry.WithRelease(controller.Commit),
-		sentry.WithEnvironment(config.GetEnvironment()),
-	)
-	if err != nil {
-		log.Panic(nil, map[string]interface{}{
-			"err": err,
-		}, "failed to setup the sentry client")
-	}
-	defer haltSentry()
+	// haltSentry, err := sentry.InitializeSentryClient(
+	// 	config.GetSentryDSN(),
+	// 	sentry.WithRelease(controller.Commit),
+	// 	sentry.WithEnvironment(config.GetEnvironment()),
+	// )
+	// if err != nil {
+	// 	log.Panic(nil, map[string]interface{}{
+	// 		"err": err,
+	// 	}, "failed to setup the sentry client")
+	// }
+	// defer haltSentry()
 
 	if config.IsPostgresDeveloperModeEnabled() && log.IsDebug() {
 		db = db.Debug()


### PR DESCRIPTION
Our sentry service is moving to another location. Let's disable it for now. We might want to migrate to the new server later.