### PR TITLE
add worker to cleanup old OAuth State References

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,20 +153,20 @@ $(MINIMOCK_BIN):
 generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only necessary after clean or if changes occurred in interfaces.
 	@echo "Generating mocks..."
 	@-rm -rf test/generated/
-	@-mkdir -p test/generated/application/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.AdminConsoleService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService,github.com/fabric8-services/fabric8-auth/application/service.TenantService -o ./test/generated/application/service/ -s ".go"
 	@-mkdir -p test/generated/authentication
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
-	@-mkdir -p test/generated/authentication/account/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/account/service.UserServiceConfiguration -o ./test/generated/authentication/account/service -s ".go"
-	@-mkdir -p test/generated/authentication/subscription/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/subscription/service.OSOSubscriptionServiceConfiguration -o ./test/generated/authentication/subscription/service -s ".go"
-	@-mkdir -p test/generated/authorization/token/manager
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/generated/authentication/ -s ".go"
 	@-mkdir -p test/generated/application/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService -o ./test/generated/application/service/ -s ".go"
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.AdminConsoleService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService,github.com/fabric8-services/fabric8-auth/application/service.UserService,github.com/fabric8-services/fabric8-auth/application/service.TenantService -o ./test/generated/application/service/ -s ".go"
+	@-mkdir -p test/generated/authentication/account/service
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/account/service.UserServiceConfiguration -o ./test/generated/authentication/account/service -s ".go"
+	@-mkdir -p test/generated/authentication/subscription/service
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/subscription/service.OSOSubscriptionServiceConfiguration -o ./test/generated/authentication/subscription/service -s ".go"
+	@-mkdir -p test/generated/authorization/token/manager
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"
+	@-mkdir -p test/generated/application/service
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService -o ./test/generated/application/service/ -s ".go"
 	@-mkdir -p test/generated/che/service
-	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/che/service.Configuration -o ./test/generated/che/service/ -s ".go"
+	$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/che/service.Configuration -o ./test/generated/che/service/ -s ".go"
 	
 
 .PHONY: generate-client

--- a/authentication/provider/repository/state_blackbox_test.go
+++ b/authentication/provider/repository/state_blackbox_test.go
@@ -2,12 +2,14 @@ package repository_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/fabric8-services/fabric8-auth/authentication/provider/repository"
 	"github.com/fabric8-services/fabric8-auth/errors"
+	"github.com/fabric8-services/fabric8-auth/gormsupport"
 	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	uuid "github.com/satori/go.uuid"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -67,4 +69,40 @@ func (s *stateBlackBoxTest) TestCreateDeleteLoad() {
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), foundState)
 	require.True(s.T(), state2.Equal(*foundState))
+}
+
+func (s *stateBlackBoxTest) TestCleanup() {
+	// given
+	state := &repository.OauthStateReference{
+		Lifecycle: gormsupport.Lifecycle{
+			CreatedAt: time.Now().Add(-10 * 24 * 60 * time.Minute), // 10 days ago
+		},
+		State:    uuid.NewV4().String(),
+		Referrer: "domain.org",
+	}
+	_, err := s.repo.Create(s.Ctx, state)
+	require.Nil(s.T(), err, "Could not create state reference")
+	state2 := &repository.OauthStateReference{
+		State:    uuid.NewV4().String(),
+		Referrer: "anotherdomain.com",
+	}
+	_, err = s.repo.Create(s.Ctx, state2)
+	require.Nil(s.T(), err, "Could not create state reference")
+
+	// when
+	err = s.repo.Cleanup(s.Ctx)
+
+	// then
+	require.Nil(s.T(), err)
+
+	// check that state1 was deleted
+	_, err = s.repo.Load(s.Ctx, state.State)
+	require.NotNil(s.T(), err)
+	require.IsType(s.T(), errors.NotFoundError{}, err)
+
+	// check that state2 was NOT deleted
+	s2, err := s.repo.Load(s.Ctx, state2.State)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), s2)
+
 }

--- a/authentication/provider/worker/state_cleanup_worker.go
+++ b/authentication/provider/worker/state_cleanup_worker.go
@@ -1,0 +1,47 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/log"
+	"github.com/fabric8-services/fabric8-auth/worker"
+)
+
+const (
+	// OAuthStateReferenceCleanup the name of the worker that cleans up old OAuth state references.
+	// Also, the name of the lock used by this worker.
+	OAuthStateReferenceCleanup = "oauth-state-reference-cleanup"
+)
+
+// NewOAuthStateReferenceCleanupWorker returns a new OAuthStateReferenceCleanupWorker
+func NewOAuthStateReferenceCleanupWorker(ctx context.Context, app application.Application) worker.Worker {
+	w := &oauthStateReferenceCleanupWorker{
+		worker.BaseWorker{
+			Ctx:   ctx,
+			App:   app,
+			Owner: worker.GetLockOwner(ctx),
+			Name:  OAuthStateReferenceCleanup,
+		},
+	}
+	w.Do = w.cleanup
+	return w
+}
+
+type oauthStateReferenceCleanupWorker struct {
+	worker.BaseWorker
+}
+
+func (w oauthStateReferenceCleanupWorker) cleanup() {
+	log.Info(w.Ctx, map[string]interface{}{
+		"owner": w.Owner,
+	}, "starting cycle of inactive users deactivation")
+	// user service has the config settings to limit the number of users to deactivate
+	if err := w.App.OauthStates().Cleanup(w.Ctx); err != nil {
+		// We will just log the error and continue
+		log.Error(nil, map[string]interface{}{
+			"err": err,
+		}, "error while cleaning up old OAuth state references")
+	}
+	log.Info(w.Ctx, map[string]interface{}{}, "ending cycle of OAuth state references cleanup")
+}

--- a/authentication/provider/worker/state_cleanup_worker_test.go
+++ b/authentication/provider/worker/state_cleanup_worker_test.go
@@ -1,0 +1,158 @@
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabric8-services/fabric8-auth/application"
+	"github.com/fabric8-services/fabric8-auth/authentication/provider/repository"
+	"github.com/fabric8-services/fabric8-auth/authentication/provider/worker"
+	"github.com/fabric8-services/fabric8-auth/configuration"
+	"github.com/fabric8-services/fabric8-auth/gormapplication"
+	"github.com/fabric8-services/fabric8-auth/gormsupport"
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	baseworker "github.com/fabric8-services/fabric8-auth/worker"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type OAuthStateReferenceCleanupWorkerTest struct {
+	gormtestsupport.DBTestSuite
+}
+
+func TestOAuthStateReferenceCleanupWorker(t *testing.T) {
+	suite.Run(t, &OAuthStateReferenceCleanupWorkerTest{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+func (s *OAuthStateReferenceCleanupWorkerTest) TestCleanup() {
+	// given
+	ago40days := time.Now().Add(-40 * 24 * time.Hour) // 40 days ago
+
+	app := gormapplication.NewGormDB(s.DB, s.Configuration, s.Wrappers)
+
+	s.Run("one state reference to cleanup", func() {
+		// given 2 OAuth state references
+		state := &repository.OauthStateReference{
+			Lifecycle: gormsupport.Lifecycle{
+				CreatedAt: ago40days, // 40 days ago
+			},
+			State:    uuid.NewV4().String(),
+			Referrer: "domain.org",
+		}
+		_, err := s.Application.OauthStates().Create(s.Ctx, state)
+		require.Nil(s.T(), err, "Could not create state reference")
+		state2 := &repository.OauthStateReference{
+			State:    uuid.NewV4().String(),
+			Referrer: "anotherdomain.com",
+		}
+		_, err = s.Application.OauthStates().Create(s.Ctx, state2)
+		require.Nil(s.T(), err, "Could not create state reference")
+
+		// start the worker with a 50ms ticker
+		w := s.newOAuthStateReferenceCleanupWorker(context.Background(), "pod-a", app)
+		freq := time.Millisecond * 50
+		w.Start(freq)
+		// wait a few cycles before checking the results
+		time.Sleep(freq * 2)
+		// now stop all workers
+		stop(w)
+		// verify that the lock was released
+		l, err := s.Application.WorkerLockRepository().AcquireLock(context.Background(), "assert", worker.OAuthStateReferenceCleanup)
+		require.NoError(s.T(), err)
+		err = l.Close()
+		require.NoError(s.T(), err)
+		//
+	})
+
+	s.Run("multiple workers and only one active", func() {
+		// given 2 OAuth state references
+		state := &repository.OauthStateReference{
+			Lifecycle: gormsupport.Lifecycle{
+				CreatedAt: ago40days, // 40 days ago
+			},
+			State:    uuid.NewV4().String(),
+			Referrer: "domain.org",
+		}
+		_, err := s.Application.OauthStates().Create(s.Ctx, state)
+		require.Nil(s.T(), err, "Could not create state reference")
+		state2 := &repository.OauthStateReference{
+			State:    uuid.NewV4().String(),
+			Referrer: "anotherdomain.com",
+		}
+		_, err = s.Application.OauthStates().Create(s.Ctx, state2)
+		require.Nil(s.T(), err, "Could not create state reference")
+
+		// start the workers with a 50ms ticker
+		freq := time.Millisecond * 50
+		latch := sync.WaitGroup{}
+		latch.Add(1)
+		workers := []baseworker.Worker{}
+		for i := 1; i <= 2; i++ {
+			fmt.Printf("initializing worker %d...\n", i)
+			w := s.newOAuthStateReferenceCleanupWorker(context.Background(), fmt.Sprintf("pod-%d", i), app)
+			workers = append(workers, w)
+			go func(i int) {
+				// now, wait for latch to be released so that all workers start at the same time
+				fmt.Printf("worker %d now waiting to latch to start...\n", i)
+				latch.Wait()
+				w.Start(freq)
+			}(i)
+		}
+		latch.Done()
+		// wait a few cycles before checking the results
+		time.Sleep(freq * 5)
+		// now stop all workers
+		stop(workers...)
+		// verify that the lock was released
+		l, err := s.Application.WorkerLockRepository().AcquireLock(context.Background(), "assert", worker.OAuthStateReferenceCleanup)
+		require.NoError(s.T(), err)
+		err = l.Close()
+		require.NoError(s.T(), err)
+	})
+
+}
+
+func (s *OAuthStateReferenceCleanupWorkerTest) newOAuthStateReferenceCleanupWorker(ctx context.Context, podname string, app application.Application) baseworker.Worker {
+	err := os.Setenv("AUTH_POD_NAME", podname)
+	require.NoError(s.T(), err)
+	config, err := configuration.GetConfigurationData()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), podname, config.GetPodName())
+	ctx = context.WithValue(ctx, baseworker.LockOwner, podname)
+	return worker.NewOAuthStateReferenceCleanupWorker(ctx, app)
+}
+
+func (s *OAuthStateReferenceCleanupWorkerTest) verifyCleanup(state string) {
+	ref, err := s.Application.OauthStates().Load(context.Background(), state)
+	assert.Error(s.T(), err) // not found as state.delete_at is set
+	assert.Nil(s.T(), ref)
+}
+
+// stop stops the given workers and waits until they all actually stopped before returning.
+func stop(workers ...baseworker.Worker) {
+	freq := time.Millisecond * 50
+	// now stop all workers
+	stopWG := sync.WaitGroup{}
+	for _, w := range workers {
+		stopWG.Add(1)
+		go func(w baseworker.Worker) {
+			w.Stop()
+			for {
+				time.Sleep(freq) // give workers some time to stop for good
+				if w.IsStopped() {
+					stopWG.Done()
+					return // only exit when the worker is stopped
+				}
+			}
+		}(w)
+	}
+	stopWG.Wait()
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -204,6 +204,10 @@ const (
 	// varAdminConsoleServiceURL the URL to the Admin Console service
 	varAdminConsoleServiceURL = "admin.console.serviceurl"
 
+	varOAuthStateReferencesCleanupEnabled = "oauth.state.reference.cleanup.enabled"
+	// varOAuthStateReferencesCleanupWorkerIntervalSeconds the interval between 2 cycles of the OAuth state reference cleanup
+	varOAuthStateReferencesCleanupWorkerIntervalSeconds = "oauth.state.reference.cleanup.interval.seconds"
+
 	//------------------------------------------------------------------------------------------------------------------
 	//
 	// Other
@@ -679,6 +683,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varUserDeactivationInactivityPeriodDays, defaultUserDeactivationInactivityPeriodDays)
 	c.v.SetDefault(varUserDeactivationWorkerIntervalSeconds, defaultUserDeactivationWorkerIntervalSeconds)
 	c.v.SetDefault(varUserDeactivationNotificationWorkerIntervalSeconds, defaultUserDeactivationNotificationWorkerIntervalSeconds)
+	c.v.SetDefault(varOAuthStateReferencesCleanupWorkerIntervalSeconds, defaultOAuthStateReferencesCleanupWorkerIntervalSeconds)
+	c.v.SetDefault(varOAuthStateReferencesCleanupEnabled, defaultOAuthStateReferencesCleanupEnabled)
 	c.v.SetDefault(varPodName, defaultPodName)
 	c.v.SetDefault(varUserDeactivationWorkerRescheduleDelayHours, defaultUserDeactivationRescheduleDelayHours)
 	c.v.SetDefault(varAdminConsoleServiceURL, defaultAdminConsoleServiceURL)
@@ -1150,4 +1156,14 @@ func (c *ConfigurationData) GetUserDeactivationWhiteList() []string {
 // GetAdminConsoleServiceURL the URL to access to the Admin Console service
 func (c *ConfigurationData) GetAdminConsoleServiceURL() string {
 	return c.v.GetString(varAdminConsoleServiceURL)
+}
+
+// GetOAuthStateReferencesCleanupEnabled returns the interval between 2 cycles of the user deactivation notification worker.
+func (c *ConfigurationData) GetOAuthStateReferencesCleanupEnabled() bool {
+	return c.v.GetBool(varOAuthStateReferencesCleanupEnabled)
+}
+
+// GetOAuthStateReferencesCleanupWorkerInterval returns the interval between 2 cycles of the OAuth state referencec cleanup.
+func (c *ConfigurationData) GetOAuthStateReferencesCleanupWorkerInterval() time.Duration {
+	return time.Duration(c.v.GetInt(varOAuthStateReferencesCleanupWorkerIntervalSeconds)) * time.Second
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -129,6 +129,10 @@ vwIDAQAB
 	// defaultUserDeactivationNotificationWorkerIntervalSeconds the default interval between 2 cycles of the user deactivation notification worker
 	defaultUserDeactivationNotificationWorkerIntervalSeconds = 60 * 60 // 1 hour
 
+	defaultOAuthStateReferencesCleanupEnabled = true
+	// defaultOAuthStateReferencesCleanupWorkerIntervalSeconds the default interval between 2 cycles of the OAuth state reference cleanup
+	defaultOAuthStateReferencesCleanupWorkerIntervalSeconds = 24 * 60 // 1 hour
+
 	// defaultPodName the default name of the pod (in order to avoid empty value in the logs)
 	defaultPodName = "unknown"
 	// defaultUserDeactivationRescheduleDelayDays default of 1 day to re-attempt a failed deactivation attempt

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fabric8-services/fabric8-auth/application/transaction"
 	accountservice "github.com/fabric8-services/fabric8-auth/authentication/account/service"
 	userworker "github.com/fabric8-services/fabric8-auth/authentication/account/worker"
+	stateworker "github.com/fabric8-services/fabric8-auth/authentication/provider/worker"
 	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
 	tokenworker "github.com/fabric8-services/fabric8-auth/authorization/token/worker"
 	"github.com/fabric8-services/fabric8-auth/configuration"
@@ -326,6 +327,14 @@ func main() {
 		userDeactivationWorker := userworker.NewUserDeactivationWorker(ctx, appDB)
 		userDeactivationWorker.Start(config.GetUserDeactivationWorkerInterval())
 		workers = append(workers, userDeactivationWorker)
+	}
+	if config.GetOAuthStateReferencesCleanupEnabled() {
+		log.Info(nil, map[string]interface{}{
+			"cleanup_interval": config.GetOAuthStateReferencesCleanupWorkerInterval(),
+		}, "OAuthStateReferences cleanup worker enabled")
+		oauthStateReferenceCleanupWorker := stateworker.NewOAuthStateReferenceCleanupWorker(ctx, appDB)
+		oauthStateReferenceCleanupWorker.Start(config.GetOAuthStateReferencesCleanupWorkerInterval())
+		workers = append(workers, oauthStateReferenceCleanupWorker)
 	}
 	// graceful shutdown
 	go handleShutdown(db, workers...)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -268,6 +268,9 @@ func GetMigrations(configuration MigrationConfiguration) Migrations {
 	// Version 53
 	m = append(m, steps{ExecuteSQLFile("053-deactivation-indexes.sql")})
 
+	// Version 54
+	m = append(m, steps{ExecuteSQLFile("054-cleanup-oauth-state-references.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/054-cleanup-oauth-state-references.sql
+++ b/migration/sql-files/054-cleanup-oauth-state-references.sql
@@ -1,0 +1,2 @@
+-- deletes all oauth state references older created more than 24 hours ago
+delete from oauth_state_references where created_at < current_timestamp - interval '1 day';

--- a/migration/sql-test-files/054-cleanup-oauth-state-references.sql
+++ b/migration/sql-test-files/054-cleanup-oauth-state-references.sql
@@ -1,0 +1,5 @@
+-- 2 "old" oauth state refs
+insert into oauth_state_references (created_at, referrer, state) values (now() - interval '3 days', 'foo1', 'bar1');
+insert into oauth_state_references (created_at, referrer, state) values (now() - interval '2 days', 'foo2', 'bar2');
+-- 1 "new" oauth state ref
+insert into oauth_state_references (created_at, referrer, state) values (now()                    , 'foo3', 'bar3');


### PR DESCRIPTION
The worker is configured to run every hour (configurable)
and delete all OAuth state references older than 24hrs (hard-coded).

The worker is based on the same implementation as the other workers
(for user deactivation) and thus runs in a go routine and uses
a lock to prevent concurrent executions (although, in this case,
it's not a big deal)

Also, include a migration step to remove all OAuth state refs
older than 24hrs during startup, using a DB migration script.

Fixes https://issues.redhat.com/browse/CRT-539

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

