### PR TITLE
refactor OAuth State Reference cleanup

### DIFF
--- a/authentication/provider/worker/state_cleanup_worker.go
+++ b/authentication/provider/worker/state_cleanup_worker.go
@@ -37,7 +37,7 @@ func (w oauthStateReferenceCleanupWorker) cleanup() {
 		"owner": w.Owner,
 	}, "starting cycle of cleaning up old OAuth state references")
 	// user service has the config settings to limit the number of users to deactivate
-	if err := w.App.OauthStates().Cleanup(w.Ctx); err != nil {
+	if _, err := w.App.OauthStates().Cleanup(w.Ctx); err != nil {
 		// We will just log the error and continue
 		log.Error(nil, map[string]interface{}{
 			"err": err,

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -131,7 +131,7 @@ vwIDAQAB
 
 	defaultOAuthStateReferencesCleanupEnabled = true
 	// defaultOAuthStateReferencesCleanupWorkerIntervalSeconds the default interval between 2 cycles of the OAuth state reference cleanup
-	defaultOAuthStateReferencesCleanupWorkerIntervalSeconds = 24 * 60 // 1 hour
+	defaultOAuthStateReferencesCleanupWorkerIntervalSeconds = 10 * 60 // 10 minutes
 
 	// defaultPodName the default name of the pod (in order to avoid empty value in the logs)
 	defaultPodName = "unknown"

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -125,7 +125,6 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration41", testMigration41)
 	t.Run("TestMigration43", testMigration43)
 	t.Run("TestMigration46", testMigration46)
-	t.Run("TestMigration54", testMigration54)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName, conf); err != nil {
@@ -560,28 +559,6 @@ func testMigration46(t *testing.T) {
 	err = sqlDB.QueryRow("SELECT last_active FROM identities WHERE id = '00000000-0000-0000-0000-000000000003'").Scan(&lastActive)
 	require.NoError(t, err) // error would occur if the
 	assert.True(t, lastActive.Add(1*time.Minute).After(time.Now()))
-}
-
-func testMigration54(t *testing.T) {
-	// given
-	migrateToVersion(sqlDB, migrations[:(54)], (54))
-	_, err := sqlDB.Exec("DELETE FROM oauth_state_references")
-	require.NoError(t, err)
-	require.Nil(t, runSQLscript(sqlDB, "054-cleanup-oauth-state-references.sql"))
-	var count int64
-	err = sqlDB.QueryRow("SELECT count(*) FROM oauth_state_references").Scan(&count)
-	require.NoError(t, err)
-	require.Equal(t, int64(3), count)
-	// when
-	migrateToVersion(sqlDB, migrations[:(55)], (55))
-	// then
-	err = sqlDB.QueryRow("SELECT count(*) FROM oauth_state_references").Scan(&count)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), count) // only 1 entry left
-	err = sqlDB.QueryRow("SELECT count(*) FROM oauth_state_references where state='bar3'").Scan(&count)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), count) // only 1 entry left
-
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/054-cleanup-oauth-state-references.sql
+++ b/migration/sql-files/054-cleanup-oauth-state-references.sql
@@ -1,2 +1,3 @@
--- deletes all oauth state references older created more than 24 hours ago
-delete from oauth_state_references where created_at < current_timestamp - interval '1 day';
+-- cleanup old OAuth State References
+-- all is now performed by a worker running in a go routine 
+-- (however we need to keep this file since there was already a migration attempt on prod-preview)

--- a/migration/sql-test-files/054-cleanup-oauth-state-references.sql
+++ b/migration/sql-test-files/054-cleanup-oauth-state-references.sql
@@ -1,5 +1,0 @@
--- 2 "old" oauth state refs
-insert into oauth_state_references (created_at, referrer, state) values (now() - interval '3 days', 'foo1', 'bar1');
-insert into oauth_state_references (created_at, referrer, state) values (now() - interval '2 days', 'foo2', 'bar2');
--- 1 "new" oauth state ref
-insert into oauth_state_references (created_at, referrer, state) values (now()                    , 'foo3', 'bar3');


### PR DESCRIPTION
- abandon the migration step because there are too many
records to delete (timeout)
- rely solely on the worker, which deletes the old records
by chunk of 1000
- run the worker every 10min

Updates https://issues.redhat.com/browse/CRT-539

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
