### PR TITLE
clean up OAuth State Reference created more than 1hr ago

### DIFF
--- a/authentication/provider/repository/state.go
+++ b/authentication/provider/repository/state.go
@@ -112,7 +112,7 @@ func (r *GormOauthStateReferenceRepository) Cleanup(ctx context.Context) (int64,
 	result := r.db.Exec(`delete from oauth_state_references 
 		where id in (
 			select id from oauth_state_references 
-			where created_at < current_timestamp - interval '1 day' limit 1000)`)
+			where created_at < current_timestamp - interval '1 hour' limit 1000)`)
 	if result.Error != nil {
 		log.Error(ctx, map[string]interface{}{
 			"error": result.Error.Error(),

--- a/authentication/provider/repository/state_blackbox_test.go
+++ b/authentication/provider/repository/state_blackbox_test.go
@@ -76,7 +76,7 @@ func (s *stateBlackBoxTest) TestCleanup() {
 	for i := 0; i < 1100; i++ { // 1100 occurrences
 		state := &repository.OauthStateReference{
 			Lifecycle: gormsupport.Lifecycle{
-				CreatedAt: time.Now().Add(-10 * 24 * 60 * time.Minute), // 10 days ago
+				CreatedAt: time.Now().Add(-2 * 60 * time.Minute), // 2 hrs ago
 			},
 			State:    uuid.NewV4().String(),
 			Referrer: "domain.org",
@@ -85,6 +85,9 @@ func (s *stateBlackBoxTest) TestCleanup() {
 		require.Nil(s.T(), err, "Could not create state reference")
 	}
 	recentState := &repository.OauthStateReference{
+		Lifecycle: gormsupport.Lifecycle{
+			CreatedAt: time.Now().Add(-1 * time.Minute), // 1 min ago
+		},
 		State:    uuid.NewV4().String(),
 		Referrer: "anotherdomain.com",
 	}


### PR DESCRIPTION
reduce the window from 1 day to 1hr while cleaning the OAuth State References, to avoid collision with incoming login requests, in case a state value would be reused.
